### PR TITLE
Enable wrapping for item text

### DIFF
--- a/index.html
+++ b/index.html
@@ -446,9 +446,10 @@
 
             // Celda “Item” con botón +/–, flecha y texto
             const tdItem = document.createElement('td');
-            tdItem.style.whiteSpace = 'nowrap';
-            tdItem.style.overflow = 'hidden';
-            tdItem.style.textOverflow = 'ellipsis';
+            // Permitir que el texto se muestre completo
+            tdItem.style.whiteSpace = 'normal';
+            tdItem.style.overflow = 'visible';
+            tdItem.style.textOverflow = 'unset';
 
             // ¿Tiene hijos este nodo?
             const tieneHijos =

--- a/styles.css
+++ b/styles.css
@@ -285,6 +285,9 @@ table#sinoptico tbody td {
 #sinoptico th:nth-child(1),
 #sinoptico td:nth-child(1) {
   width: 40%;
+  white-space: normal;
+  overflow: visible;
+  text-overflow: unset;
 }
 #sinoptico th:nth-child(2),
 #sinoptico td:nth-child(2) {


### PR DESCRIPTION
## Summary
- allow item text column to use normal whitespace
- show full text in first column instead of ellipsis

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_6843a464d3988329b8ad342407f72d99