### PR TITLE
Add connector lines with LeaderLine

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 # Proyecto-barack
+
+This project displays a hierarchical product table. It requires the [LeaderLine](https://anseki.github.io/leader-line/) library for drawing connector lines between related rows. The library is loaded from a CDN in `index.html`.

--- a/index.html
+++ b/index.html
@@ -12,6 +12,8 @@
   <script src="https://cdn.jsdelivr.net/npm/papaparse@5.3.2/papaparse.min.js"></script>
   <!-- SheetJS (xlsx) para exportar a Excel -->
   <script src="https://cdn.jsdelivr.net/npm/xlsx@0.18.5/dist/xlsx.full.min.js"></script>
+  <!-- LeaderLine para dibujar conectores -->
+  <script src="https://cdn.jsdelivr.net/npm/leader-line@1.0.7/leader-line.min.js"></script>
 </head>
 <body>
   <h1>Sinóptico de Producto Barack</h1>
@@ -97,6 +99,7 @@
 
   <script>
     document.addEventListener('DOMContentLoaded', () => {
+      const linesMap = {};
       /* ==================================================
          1) Mostrar/Ocultar Columnas
       ================================================== */
@@ -233,12 +236,16 @@
         const hijos = document.querySelectorAll(`#sinoptico tbody tr[data-parent="${parentId}"]`);
         hijos.forEach(hijo => {
           hijo.style.display = '';
+          const line = linesMap[hijo.getAttribute('data-id')];
+          if (line) line.show();
         });
       }
       function hideSubtree(parentId) {
         const hijos = document.querySelectorAll(`#sinoptico tbody tr[data-parent="${parentId}"]`);
         hijos.forEach(hijo => {
           hijo.style.display = 'none';
+          const line = linesMap[hijo.getAttribute('data-id')];
+          if (line) line.hide();
           const btn = hijo.querySelector('.toggle-btn');
           if (btn) {
             btn.textContent = '+';
@@ -268,6 +275,7 @@
             tr.style.display = 'none';
           }
         });
+        Object.values(linesMap).forEach(line => line.hide());
         document.querySelectorAll('.toggle-btn').forEach(btn => {
           if (!btn.classList.contains('hidden')) {
             btn.textContent = '+';
@@ -279,6 +287,7 @@
         document.querySelectorAll('#sinoptico tbody tr').forEach(tr => {
           tr.style.display = '';
         });
+        Object.values(linesMap).forEach(line => line.show());
         document.querySelectorAll('.toggle-btn').forEach(btn => {
           if (!btn.classList.contains('hidden')) {
             btn.textContent = '–';
@@ -331,6 +340,9 @@
         const expandedIds = Array.from(
           document.querySelectorAll('#sinoptico tbody .toggle-btn[data-expanded="true"]')
         ).map(btn => btn.closest('tr').getAttribute('data-id'));
+
+        Object.values(linesMap).forEach(line => line.remove());
+        Object.keys(linesMap).forEach(key => delete linesMap[key]);
 
         Papa.parse('sinoptico.csv', {
           download: true,
@@ -539,6 +551,15 @@
             });
 
             document.querySelector('#sinoptico tbody').appendChild(tr);
+            const parentRow = document.querySelector(`tr[data-id="${fila.ParentID}"]`);
+            if (parentRow) {
+              const line = new LeaderLine(
+                parentRow.querySelector('.item-text'),
+                tr.querySelector('.item-text'),
+                { color: '#0d1b3d', path: 'straight' }
+              );
+              linesMap[fila.ID] = line;
+            }
             dibujarNodos(fila.ID.toString().trim(), nivel + 1);
           });
         }


### PR DESCRIPTION
## Summary
- include LeaderLine from CDN
- draw lines between parent and child rows when building table
- hide or show lines with expand/collapse actions
- remove lines during reloads
- document LeaderLine dependency

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6843a8a63ec48329ac146aa756925aa5