### PR TITLE
Add semicolon delimiter to Papa.parse

### DIFF
--- a/index.html
+++ b/index.html
@@ -348,6 +348,7 @@
           download: true,
           header: true,
           skipEmptyLines: true,
+          delimiter: ';',
           complete(results) {
             if (results.errors.length) {
               console.error('Errores al parsear CSV:', results.errors);


### PR DESCRIPTION
## Summary
- set `delimiter` option when parsing CSV

## Testing
- `node -e "const fs=require('fs');const Papa=require('papaparse');fs.readFile('sinoptico.csv','utf8',(e,d)=>{if(e)throw e;const r=Papa.parse(d,{delimiter:';',header:true,skipEmptyLines:true});console.log('rows',r.data.length);});"`

------
https://chatgpt.com/codex/tasks/task_e_6843ab22ea488329b15de0d8992c2f04