### PR TITLE
Fix intro header color and add placeholder page

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Because some browsers block local file reads, it is recommended to serve the fil
 python3 -m http.server
 ```
 
-Then open [http://localhost:8000/index.html](http://localhost:8000/index.html) in a modern browser.
+Then open [http://localhost:8000/index.html](http://localhost:8000/index.html) in a modern browser. From there you can navigate to the product synopsis page or the engineering master list.
 
 ## Features
 

--- a/index.html
+++ b/index.html
@@ -1,100 +1,51 @@
 <!DOCTYPE html>
 <html lang="es">
 <head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Sinóptico de Producto Barack</title>
-
-  <!-- Vinculamos el CSS externo -->
-  <link rel="stylesheet" href="styles.css" />
-
-  <!-- PapaParse para leer el CSV -->
-  <script src="https://cdn.jsdelivr.net/npm/papaparse@5.3.2/papaparse.min.js"></script>
-  <!-- SheetJS (xlsx) para exportar a Excel -->
-  <script src="https://cdn.jsdelivr.net/npm/xlsx@0.18.5/dist/xlsx.full.min.js"></script>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Ingeniería Barack</title>
+    <link rel="stylesheet" href="styles.css">
+    <style>
+      body, html {
+        height: 100%;
+        margin: 0;
+      }
+      .intro {
+        background-color: #003366;
+        color: white;
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        align-items: center;
+        height: 100%;
+        text-align: center;
+      }
+      .intro h1 {
+        font-size: 3rem;
+        margin-bottom: 1.5rem;
+        color: white; /* override global h1 color */
+      }
+      .btn-link {
+        display: inline-block;
+        margin: 0.5rem 0;
+        padding: 1rem 2rem;
+        background-color: #0066cc;
+        color: #fff;
+        text-decoration: none;
+        border-radius: 4px;
+        font-size: 1.2rem;
+      }
+      .btn-link:hover {
+        background-color: #004c99;
+      }
+    </style>
 </head>
 <body>
-  <h1>Sinóptico de Producto Barack</h1>
-  <div id="mensaje"></div>
-
-  <!-- ==============================
-       BLOQUE: Mostrar/Ocultar Columnas
-       ============================== -->
-  <div class="column-toggle-container">
-    <label><input type="checkbox" class="toggle-col" data-colindex="0" checked /> Ítem</label>
-    <label><input type="checkbox" class="toggle-col" data-colindex="1" checked /> Cliente</label>
-    <label><input type="checkbox" class="toggle-col" data-colindex="2" checked /> Vehículo</label>
-    <label><input type="checkbox" class="toggle-col" data-colindex="3" checked /> RefInterno</label>
-    <label><input type="checkbox" class="toggle-col" data-colindex="4" checked /> Versión</label>
-    <label><input type="checkbox" class="toggle-col" data-colindex="5" checked /> Imagen</label>
-    <label><input type="checkbox" class="toggle-col" data-colindex="6" checked /> Pzas/h</label>
-    <label><input type="checkbox" class="toggle-col" data-colindex="7" checked /> Unidad</label>
-    <label><input type="checkbox" class="toggle-col" data-colindex="8" checked /> Sourcing</label>
-    <label><input type="checkbox" class="toggle-col" data-colindex="9" checked /> Código</label>
-  </div>
-
-  <!-- ==============================
-       BLOQUE DE FILTROS + BOTONES GLOBALES + BOTÓN EXCEL
-       ============================== -->
-  <div class="filtro-contenedor">
-    <div class="filtros-texto">
-      <label for="filtroInsumo">🔍 Buscar Insumo:</label>
-      <input type="text" id="filtroInsumo" placeholder="Ej: Hilo 120, Corte 1..." />
-
-      <div class="filtro-opciones">
-        <input type="checkbox" id="chkIncluirAncestros" checked />
-        <label for="chkIncluirAncestros">Incluir jerarquía (padres)</label>
-      </div>
-      <div class="filtro-opciones">
-        <input type="checkbox" id="chkMostrarNivel0" checked />
-        <label for="chkMostrarNivel0">Mostrar Cliente (nivel 0)</label>
-      </div>
-      <div class="filtro-opciones">
-        <input type="checkbox" id="chkMostrarNivel1" checked />
-        <label for="chkMostrarNivel1">Mostrar Producto (nivel 1)</label>
-      </div>
-      <div class="filtro-opciones">
-        <input type="checkbox" id="chkMostrarNivel2" checked />
-        <label for="chkMostrarNivel2">Mostrar Subensamble (nivel 2)</label>
-      </div>
-      <div class="filtro-opciones">
-        <input type="checkbox" id="chkMostrarNivel3" checked />
-        <label for="chkMostrarNivel3">Mostrar Insumo (nivel 3)</label>
-      </div>
+    <div class="intro">
+        <h1>Ingeniería Barack</h1>
+        <a class="btn-link" href="sinoptico.html">Ver Sinóptico de Producto</a>
+        <br/>
+        <a class="btn-link" href="listado.html">Listado maestro de ingeniería</a>
     </div>
-
-    <!-- Botones globales -->
-    <button id="expandirTodo">Expandir Todo</button>
-    <button id="colapsarTodo">Colapsar Todo</button>
-    <!-- Botón para exportar la tabla visible a Excel -->
-    <button id="btnExcel">Exportar a Excel</button>
-  </div>
-
-  <!-- ==============================
-       CONTENEDOR DE LA TABLA
-       ============================== -->
-  <div class="tabla-contenedor">
-    <table id="sinoptico">
-      <thead>
-        <tr>
-          <th>Item</th>
-          <th>Cliente</th>
-          <th>Vehículo</th>
-          <th>RefInterno</th>
-          <th>Versión</th>
-          <th>Imagen</th>
-          <th>Pzas/h</th>
-          <th>Unidad</th>
-          <th>Sourcing</th>
-          <th>Código</th>
-        </tr>
-      </thead>
-      <tbody>
-        <!-- Aquí se insertarán las filas dinámicamente -->
-      </tbody>
-    </table>
-  </div>
-
-  <script src="main.js" defer></script>
 </body>
 </html>

--- a/listado.html
+++ b/listado.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Listado Maestro de Ingeniería</title>
+  <link rel="stylesheet" href="styles.css">
+  <style>
+    body, html {
+      height: 100%;
+      margin: 0;
+    }
+    .construction {
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      height: 100%;
+      flex-direction: column;
+      background-color: #f4f4f4;
+    }
+    .construction h1 {
+      color: #0d1b3d;
+    }
+  </style>
+</head>
+<body>
+  <div class="construction">
+    <h1>Página en construcción</h1>
+  </div>
+  <a href="index.html" class="home-button">Inicio</a>
+</body>
+</html>

--- a/sinoptico.html
+++ b/sinoptico.html
@@ -1,0 +1,101 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Sinóptico de Producto Barack</title>
+
+  <!-- Vinculamos el CSS externo -->
+  <link rel="stylesheet" href="styles.css" />
+
+  <!-- PapaParse para leer el CSV -->
+  <script src="https://cdn.jsdelivr.net/npm/papaparse@5.3.2/papaparse.min.js"></script>
+  <!-- SheetJS (xlsx) para exportar a Excel -->
+  <script src="https://cdn.jsdelivr.net/npm/xlsx@0.18.5/dist/xlsx.full.min.js"></script>
+</head>
+<body>
+  <h1>Sinóptico de Producto Barack</h1>
+  <div id="mensaje"></div>
+
+  <!-- ==============================
+       BLOQUE: Mostrar/Ocultar Columnas
+       ============================== -->
+  <div class="column-toggle-container">
+    <label><input type="checkbox" class="toggle-col" data-colindex="0" checked /> Ítem</label>
+    <label><input type="checkbox" class="toggle-col" data-colindex="1" checked /> Cliente</label>
+    <label><input type="checkbox" class="toggle-col" data-colindex="2" checked /> Vehículo</label>
+    <label><input type="checkbox" class="toggle-col" data-colindex="3" checked /> RefInterno</label>
+    <label><input type="checkbox" class="toggle-col" data-colindex="4" checked /> Versión</label>
+    <label><input type="checkbox" class="toggle-col" data-colindex="5" checked /> Imagen</label>
+    <label><input type="checkbox" class="toggle-col" data-colindex="6" checked /> Pzas/h</label>
+    <label><input type="checkbox" class="toggle-col" data-colindex="7" checked /> Unidad</label>
+    <label><input type="checkbox" class="toggle-col" data-colindex="8" checked /> Sourcing</label>
+    <label><input type="checkbox" class="toggle-col" data-colindex="9" checked /> Código</label>
+  </div>
+
+  <!-- ==============================
+       BLOQUE DE FILTROS + BOTONES GLOBALES + BOTÓN EXCEL
+       ============================== -->
+  <div class="filtro-contenedor">
+    <div class="filtros-texto">
+      <label for="filtroInsumo">🔍 Buscar Insumo:</label>
+      <input type="text" id="filtroInsumo" placeholder="Ej: Hilo 120, Corte 1..." />
+
+      <div class="filtro-opciones">
+        <input type="checkbox" id="chkIncluirAncestros" checked />
+        <label for="chkIncluirAncestros">Incluir jerarquía (padres)</label>
+      </div>
+      <div class="filtro-opciones">
+        <input type="checkbox" id="chkMostrarNivel0" checked />
+        <label for="chkMostrarNivel0">Mostrar Cliente (nivel 0)</label>
+      </div>
+      <div class="filtro-opciones">
+        <input type="checkbox" id="chkMostrarNivel1" checked />
+        <label for="chkMostrarNivel1">Mostrar Producto (nivel 1)</label>
+      </div>
+      <div class="filtro-opciones">
+        <input type="checkbox" id="chkMostrarNivel2" checked />
+        <label for="chkMostrarNivel2">Mostrar Subensamble (nivel 2)</label>
+      </div>
+      <div class="filtro-opciones">
+        <input type="checkbox" id="chkMostrarNivel3" checked />
+        <label for="chkMostrarNivel3">Mostrar Insumo (nivel 3)</label>
+      </div>
+    </div>
+
+    <!-- Botones globales -->
+    <button id="expandirTodo">Expandir Todo</button>
+    <button id="colapsarTodo">Colapsar Todo</button>
+    <!-- Botón para exportar la tabla visible a Excel -->
+    <button id="btnExcel">Exportar a Excel</button>
+  </div>
+
+  <!-- ==============================
+       CONTENEDOR DE LA TABLA
+       ============================== -->
+  <div class="tabla-contenedor">
+    <table id="sinoptico">
+      <thead>
+        <tr>
+          <th>Item</th>
+          <th>Cliente</th>
+          <th>Vehículo</th>
+          <th>RefInterno</th>
+          <th>Versión</th>
+          <th>Imagen</th>
+          <th>Pzas/h</th>
+          <th>Unidad</th>
+          <th>Sourcing</th>
+          <th>Código</th>
+        </tr>
+      </thead>
+      <tbody>
+        <!-- Aquí se insertarán las filas dinámicamente -->
+      </tbody>
+    </table>
+  </div>
+  <a href="index.html" class="home-button">Inicio</a>
+
+  <script src="main.js" defer></script>
+</body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -358,3 +358,21 @@ table#sinoptico tbody td {
     font-size: 0.8rem;
   }
 }
+
+/* Botón de Inicio */
+.home-button {
+  position: fixed;
+  bottom: 20px;
+  right: 20px;
+  padding: 10px 16px;
+  background-color: #0d1b3d;
+  color: #fff;
+  border-radius: 4px;
+  text-decoration: none;
+  font-weight: bold;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.2);
+}
+.home-button:hover {
+  background-color: #0a1a33;
+}
+


### PR DESCRIPTION
## Summary
- ensure the intro heading text is white
- link to new "Listado maestro de ingeniería" page from the landing page
- create placeholder page that shows a construction message
- add home button on the new page
- update README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68444477a6a883298545337ef3c27a27