### PR TITLE
Improve table refresh and add editable master list

### DIFF
--- a/listado_maestro.html
+++ b/listado_maestro.html
@@ -8,7 +8,20 @@
 </head>
 <body>
   <h1>Listado maestro de ingeniería</h1>
-  <p style="text-align:center; margin-top:40px; font-size:1.2rem;">Página en construcción</p>
+  <div class="maestro-container">
+    <table id="maestro">
+      <thead>
+        <tr><th>Documento</th><th>Número</th><th>Acciones</th></tr>
+      </thead>
+      <tbody></tbody>
+    </table>
+    <div class="maestro-form">
+      <input type="text" id="docName" placeholder="Documento" />
+      <input type="text" id="docNumber" placeholder="Número" />
+      <button id="addDoc">Agregar</button>
+    </div>
+  </div>
   <a href="index.html" class="home-button">Inicio</a>
+  <script src="maestro.js"></script>
 </body>
 </html>

--- a/maestro.js
+++ b/maestro.js
@@ -1,0 +1,68 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const tbody = document.querySelector('#maestro tbody');
+  const nameInput = document.getElementById('docName');
+  const numberInput = document.getElementById('docNumber');
+  const addBtn = document.getElementById('addDoc');
+  const STORAGE_KEY = 'maestroDocs';
+
+  let docs = JSON.parse(localStorage.getItem(STORAGE_KEY)) || [
+    { name: 'Hojas de operaciones', number: '' },
+    { name: 'AMFE', number: '' },
+    { name: 'Flujograma', number: '' },
+    { name: 'Mylar', number: '' },
+    { name: 'ULM', number: '' }
+  ];
+
+  function save() {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(docs));
+  }
+
+  function render() {
+    tbody.textContent = '';
+    docs.forEach((doc, idx) => {
+      const tr = document.createElement('tr');
+
+      const tdName = document.createElement('td');
+      tdName.textContent = doc.name;
+      tr.appendChild(tdName);
+
+      const tdNum = document.createElement('td');
+      tdNum.textContent = doc.number;
+      tdNum.addEventListener('click', () => {
+        const nuevo = prompt('Nuevo número', doc.number);
+        if (nuevo !== null) {
+          docs[idx].number = nuevo.trim();
+          save();
+          render();
+        }
+      });
+      tr.appendChild(tdNum);
+
+      const tdAct = document.createElement('td');
+      const delBtn = document.createElement('button');
+      delBtn.textContent = 'Eliminar';
+      delBtn.addEventListener('click', () => {
+        docs.splice(idx, 1);
+        save();
+        render();
+      });
+      tdAct.appendChild(delBtn);
+      tr.appendChild(tdAct);
+
+      tbody.appendChild(tr);
+    });
+  }
+
+  addBtn.addEventListener('click', () => {
+    const name = nameInput.value.trim();
+    const num = numberInput.value.trim();
+    if (!name || !num) return;
+    docs.push({ name, number: num });
+    save();
+    render();
+    nameInput.value = '';
+    numberInput.value = '';
+  });
+
+  render();
+});

--- a/renderer.js
+++ b/renderer.js
@@ -274,8 +274,10 @@
           datosMod.push(fila);
         });
         construirSinoptico(datosMod);
-        setTimeout(ajustarIndentacion, 20);
+        // Colapsar todo para que la recarga no expanda la tabla por defecto
+        colapsarTodo();
         setTimeout(() => {
+          ajustarIndentacion();
           expandedIds.forEach(id => {
             showChildren(id);
             const btn = document.querySelector(`#sinoptico tbody tr[data-id="${id}"] .toggle-btn`);

--- a/styles.css
+++ b/styles.css
@@ -376,3 +376,43 @@ table#sinoptico tbody td {
   background-color: #0a1a33;
 }
 
+
+/* ==============================
+   LISTADO MAESTRO
+   ============================== */
+.maestro-container {
+  width: 95%;
+  margin: 0 auto;
+}
+#maestro {
+  width: 100%;
+  border-collapse: collapse;
+  margin-bottom: 15px;
+}
+#maestro th,
+#maestro td {
+  border: 1px solid #ccc;
+  padding: 8px;
+  text-align: left;
+}
+.maestro-form {
+  display: flex;
+  gap: 8px;
+}
+.maestro-form input {
+  flex: 1;
+  padding: 6px;
+  border: 1px solid #bbb;
+  border-radius: 4px;
+}
+.maestro-form button {
+  padding: 6px 12px;
+  background-color: #0d1b3d;
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+.maestro-form button:hover {
+  background-color: #0a1a33;
+}


### PR DESCRIPTION
## Summary
- preserve expanded rows when data auto-refreshes by collapsing first
- build editable document list for `listado_maestro.html`
- add basic styles and scripting for the new list

## Testing
- `node --check maestro.js`
- `node --check renderer.js`


------
https://chatgpt.com/codex/tasks/task_e_6845b221f5308329b9b0c58b5fb7719c