### PR TITLE
Add admin mode and AMFE details

### DIFF
--- a/index.html
+++ b/index.html
@@ -87,7 +87,8 @@
             <li>Datos actualizados automáticamente</li>
           </ul>
           <a class="btn-link" href="sinoptico.html">Ver Sinóptico de Producto</a>
-          <a class="btn-link" href="listado_maestro.html">Listado maestro de ingeniería</a>
+          <a class="btn-link" href="listado_maestro.html">Listado maestro (lectura)</a>
+          <a class="btn-link" href="listado_maestro.html?admin=true">Listado maestro (administrador)</a>
       </main>
   </body>
 </html>

--- a/listado_maestro.html
+++ b/listado_maestro.html
@@ -11,17 +11,34 @@
   <div class="maestro-container">
     <table id="maestro">
       <thead>
-        <tr><th>Documento</th><th>Número</th><th>Acciones</th></tr>
+        <tr><th>Documento</th><th>Número</th><th>Detalle</th><th>Acciones</th></tr>
       </thead>
       <tbody></tbody>
     </table>
     <div class="maestro-form">
       <input type="text" id="docName" placeholder="Documento" />
       <input type="text" id="docNumber" placeholder="Número" />
+      <input type="text" id="docDetail" placeholder="Detalle" />
       <button id="addDoc">Agregar</button>
     </div>
   </div>
   <a href="index.html" class="home-button">Inicio</a>
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      const params = new URLSearchParams(window.location.search);
+      if (params.get('admin') === 'true') {
+        const pass = prompt('Contraseña de administrador:');
+        if (pass === '1234') {
+          sessionStorage.setItem('maestroAdmin', 'true');
+        } else {
+          alert('Contraseña incorrecta. Ingresarás en modo lectura.');
+          sessionStorage.removeItem('maestroAdmin');
+        }
+      } else {
+        sessionStorage.removeItem('maestroAdmin');
+      }
+    });
+  </script>
   <script src="maestro.js"></script>
 </body>
 </html>

--- a/maestro.js
+++ b/maestro.js
@@ -2,15 +2,17 @@ document.addEventListener('DOMContentLoaded', () => {
   const tbody = document.querySelector('#maestro tbody');
   const nameInput = document.getElementById('docName');
   const numberInput = document.getElementById('docNumber');
+  const detailInput = document.getElementById('docDetail');
   const addBtn = document.getElementById('addDoc');
   const STORAGE_KEY = 'maestroDocs';
+  const isAdmin = sessionStorage.getItem('maestroAdmin') === 'true';
 
   let docs = JSON.parse(localStorage.getItem(STORAGE_KEY)) || [
-    { name: 'Hojas de operaciones', number: '' },
-    { name: 'AMFE', number: '' },
-    { name: 'Flujograma', number: '' },
-    { name: 'Mylar', number: '' },
-    { name: 'ULM', number: '' }
+    { name: 'Hojas de operaciones', number: '', detail: '' },
+    { name: 'AMFE', number: '', detail: '' },
+    { name: 'Flujograma', number: '', detail: '' },
+    { name: 'Mylar', number: '', detail: '' },
+    { name: 'ULM', number: '', detail: '' }
   ];
 
   function save() {
@@ -28,40 +30,71 @@ document.addEventListener('DOMContentLoaded', () => {
 
       const tdNum = document.createElement('td');
       tdNum.textContent = doc.number;
-      tdNum.addEventListener('click', () => {
-        const nuevo = prompt('Nuevo número', doc.number);
-        if (nuevo !== null) {
-          docs[idx].number = nuevo.trim();
-          save();
-          render();
-        }
-      });
+      if (isAdmin) {
+        tdNum.addEventListener('click', () => {
+          const nuevo = prompt('Nuevo número', doc.number);
+          if (nuevo !== null) {
+            docs[idx].number = nuevo.trim();
+            save();
+            render();
+          }
+        });
+      }
       tr.appendChild(tdNum);
 
+      const tdDet = document.createElement('td');
+      tdDet.textContent = doc.detail || '';
+      if (isAdmin) {
+        tdDet.addEventListener('click', () => {
+          const nuevo = prompt('Nuevo detalle', doc.detail || '');
+          if (nuevo !== null) {
+            docs[idx].detail = nuevo.trim();
+            save();
+            render();
+          }
+        });
+      }
+      tr.appendChild(tdDet);
+
       const tdAct = document.createElement('td');
-      const delBtn = document.createElement('button');
-      delBtn.textContent = 'Eliminar';
-      delBtn.addEventListener('click', () => {
-        docs.splice(idx, 1);
-        save();
-        render();
-      });
-      tdAct.appendChild(delBtn);
+      if (isAdmin) {
+        const delBtn = document.createElement('button');
+        delBtn.textContent = 'Eliminar';
+        delBtn.addEventListener('click', () => {
+          if (doc.name === 'AMFE') {
+            const count = docs.filter(d => d.name === 'AMFE').length;
+            if (count <= 1) {
+              alert('No se puede eliminar la columna AMFE');
+              return;
+            }
+          }
+          docs.splice(idx, 1);
+          save();
+          render();
+        });
+        tdAct.appendChild(delBtn);
+      }
       tr.appendChild(tdAct);
 
       tbody.appendChild(tr);
     });
+
+    // Mostrar u ocultar formulario según modo
+    const form = document.querySelector('.maestro-form');
+    form.style.display = isAdmin ? 'flex' : 'none';
   }
 
   addBtn.addEventListener('click', () => {
     const name = nameInput.value.trim();
     const num = numberInput.value.trim();
+    const det = detailInput.value.trim();
     if (!name || !num) return;
-    docs.push({ name, number: num });
+    docs.push({ name, number: num, detail: det });
     save();
     render();
     nameInput.value = '';
     numberInput.value = '';
+    detailInput.value = '';
   });
 
   render();


### PR DESCRIPTION
## Summary
- add links for read-only and admin access on the home page
- support admin login in `listado_maestro.html`
- allow editing document details and protect AMFE row in `maestro.js`

## Testing
- `node --check maestro.js`

------
https://chatgpt.com/codex/tasks/task_e_6845b57cd55c8329b965dc2bb1e9264b