### PR TITLE
Improve maestro list UX

### DIFF
--- a/index.html
+++ b/index.html
@@ -87,8 +87,7 @@
             <li>Datos actualizados automáticamente</li>
           </ul>
           <a class="btn-link" href="sinoptico.html">Ver Sinóptico de Producto</a>
-          <a class="btn-link" href="listado_maestro.html">Listado maestro (lectura)</a>
-          <a class="btn-link" href="listado_maestro.html?admin=true">Listado maestro (administrador)</a>
+          <a class="btn-link" href="listado_maestro.html">Listado maestro</a>
       </main>
   </body>
 </html>

--- a/listado_maestro.html
+++ b/listado_maestro.html
@@ -7,7 +7,7 @@
   <link rel="stylesheet" href="styles.css" />
 </head>
 <body>
-  <h1>Listado maestro de ingeniería</h1>
+  <h1>Listado maestro de ingeniería <button id="editBtn" class="edit-button">Editar</button></h1>
   <div class="maestro-container">
     <table id="maestro">
       <thead>
@@ -16,6 +16,10 @@
       <tbody></tbody>
     </table>
     <div class="maestro-form">
+      <select id="docCategory">
+        <option value="Operaciones">Operaciones</option>
+        <option value="AMFE">AMFE</option>
+      </select>
       <input type="text" id="docName" placeholder="Documento" />
       <input type="text" id="docNumber" placeholder="Número" />
       <input type="text" id="docDetail" placeholder="Detalle" />
@@ -25,18 +29,33 @@
   <a href="index.html" class="home-button">Inicio</a>
   <script>
     document.addEventListener('DOMContentLoaded', () => {
-      const params = new URLSearchParams(window.location.search);
-      if (params.get('admin') === 'true') {
-        const pass = prompt('Contraseña de administrador:');
-        if (pass === '1234') {
-          sessionStorage.setItem('maestroAdmin', 'true');
-        } else {
-          alert('Contraseña incorrecta. Ingresarás en modo lectura.');
-          sessionStorage.removeItem('maestroAdmin');
-        }
-      } else {
-        sessionStorage.removeItem('maestroAdmin');
+      const editBtn = document.getElementById('editBtn');
+
+      function updateButton() {
+        editBtn.textContent = sessionStorage.getItem('maestroAdmin') === 'true'
+          ? 'Salir de edición'
+          : 'Editar';
       }
+
+      editBtn.addEventListener('click', () => {
+        const isAdmin = sessionStorage.getItem('maestroAdmin') === 'true';
+        if (isAdmin) {
+          sessionStorage.removeItem('maestroAdmin');
+          updateButton();
+          document.dispatchEvent(new CustomEvent('maestro-mode'));
+        } else {
+          const pass = prompt('Contraseña de administrador:');
+          if (pass === '1234') {
+            sessionStorage.setItem('maestroAdmin', 'true');
+            updateButton();
+            document.dispatchEvent(new CustomEvent('maestro-mode'));
+          } else {
+            alert('Contraseña incorrecta');
+          }
+        }
+      });
+
+      updateButton();
     });
   </script>
   <script src="maestro.js"></script>

--- a/maestro.js
+++ b/maestro.js
@@ -3,16 +3,17 @@ document.addEventListener('DOMContentLoaded', () => {
   const nameInput = document.getElementById('docName');
   const numberInput = document.getElementById('docNumber');
   const detailInput = document.getElementById('docDetail');
+  const categorySelect = document.getElementById('docCategory');
   const addBtn = document.getElementById('addDoc');
   const STORAGE_KEY = 'maestroDocs';
-  const isAdmin = sessionStorage.getItem('maestroAdmin') === 'true';
+  let isAdmin = sessionStorage.getItem('maestroAdmin') === 'true';
 
   let docs = JSON.parse(localStorage.getItem(STORAGE_KEY)) || [
-    { name: 'Hojas de operaciones', number: '', detail: '' },
-    { name: 'AMFE', number: '', detail: '' },
-    { name: 'Flujograma', number: '', detail: '' },
-    { name: 'Mylar', number: '', detail: '' },
-    { name: 'ULM', number: '', detail: '' }
+    { name: 'Hojas de operaciones', number: '', detail: '', category: 'Operaciones' },
+    { name: 'Flujograma', number: '', detail: '', category: 'Operaciones' },
+    { name: 'Mylar', number: '', detail: '', category: 'Operaciones' },
+    { name: 'ULM', number: '', detail: '', category: 'Operaciones' },
+    { name: 'AMFE', number: '', detail: '', category: 'AMFE' }
   ];
 
   function save() {
@@ -20,13 +21,26 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   function render() {
+    isAdmin = sessionStorage.getItem('maestroAdmin') === 'true';
     tbody.textContent = '';
-    docs.forEach((doc, idx) => {
-      const tr = document.createElement('tr');
 
-      const tdName = document.createElement('td');
-      tdName.textContent = doc.name;
-      tr.appendChild(tdName);
+    const categories = Array.from(new Set(docs.map(d => d.category)));
+    categories.forEach(cat => {
+      const header = document.createElement('tr');
+      header.className = 'category-row';
+      const th = document.createElement('th');
+      th.colSpan = 4;
+      th.textContent = cat;
+      header.appendChild(th);
+      tbody.appendChild(header);
+
+      docs.forEach((doc, idx) => {
+        if (doc.category !== cat) return;
+        const tr = document.createElement('tr');
+
+        const tdName = document.createElement('td');
+        tdName.textContent = doc.name;
+        tr.appendChild(tdName);
 
       const tdNum = document.createElement('td');
       tdNum.textContent = doc.number;
@@ -74,9 +88,10 @@ document.addEventListener('DOMContentLoaded', () => {
         });
         tdAct.appendChild(delBtn);
       }
-      tr.appendChild(tdAct);
+        tr.appendChild(tdAct);
 
-      tbody.appendChild(tr);
+        tbody.appendChild(tr);
+      });
     });
 
     // Mostrar u ocultar formulario según modo
@@ -88,14 +103,17 @@ document.addEventListener('DOMContentLoaded', () => {
     const name = nameInput.value.trim();
     const num = numberInput.value.trim();
     const det = detailInput.value.trim();
+    const cat = categorySelect.value;
     if (!name || !num) return;
-    docs.push({ name, number: num, detail: det });
+    docs.push({ name, number: num, detail: det, category: cat });
     save();
     render();
     nameInput.value = '';
     numberInput.value = '';
     detailInput.value = '';
+    categorySelect.value = 'Operaciones';
   });
 
+  document.addEventListener('maestro-mode', render);
   render();
 });

--- a/styles.css
+++ b/styles.css
@@ -388,6 +388,9 @@ table#sinoptico tbody td {
   width: 100%;
   border-collapse: collapse;
   margin-bottom: 15px;
+  background-color: #fff;
+  border-radius: 6px;
+  overflow: hidden;
 }
 #maestro th,
 #maestro td {
@@ -395,9 +398,17 @@ table#sinoptico tbody td {
   padding: 8px;
   text-align: left;
 }
+#maestro tbody tr:nth-child(even) {
+  background-color: #f7f7f7;
+}
 .maestro-form {
   display: flex;
   gap: 8px;
+}
+.maestro-form select {
+  padding: 6px;
+  border: 1px solid #bbb;
+  border-radius: 4px;
 }
 .maestro-form input {
   flex: 1;
@@ -415,4 +426,14 @@ table#sinoptico tbody td {
 }
 .maestro-form button:hover {
   background-color: #0a1a33;
+}
+.edit-button {
+  margin-left: 10px;
+  padding: 4px 8px;
+  font-size: 0.9rem;
+}
+
+.category-row th {
+  background-color: #efefef;
+  text-align: left;
 }


### PR DESCRIPTION
## Summary
- show single 'Listado maestro' entry on home page
- group maestro entries by category with nicer styling
- allow switching to admin mode via new Edit button
- tweak master list table styles

## Testing
- `node -v`
- `node -e "require('./maestro.js');"` *(fails: document is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6845b7be96b88329b55b7b6be8dfdc58