### PR TITLE
Fix maestro dropdown options and node test

### DIFF
--- a/maestro.js
+++ b/maestro.js
@@ -4,11 +4,11 @@ document.addEventListener('DOMContentLoaded', () => {
   const numberInput = document.getElementById('docNumber');
   const detailInput = document.getElementById('docDetail');
   const DOC_TYPES = [
+    { name: 'Amfe', category: 'AMFE' },
     { name: 'Hojas de operaciones', category: 'Operaciones' },
-    { name: 'Flujograma', category: 'Operaciones' },
     { name: 'Mylar', category: 'Operaciones' },
-    { name: 'ULM', category: 'Operaciones' },
-    { name: 'AMFE', category: 'AMFE' }
+    { name: 'Ulm', category: 'Operaciones' },
+    { name: 'Flujograma', category: 'Operaciones' }
   ];
   const filterInput = document.getElementById('maestroFilter');
   const addBtn = document.getElementById('addDoc');
@@ -21,11 +21,25 @@ document.addEventListener('DOMContentLoaded', () => {
   function updateDocOptions() {
     if (!nameInput) return;
     nameInput.innerHTML = '';
+    const def = document.createElement('option');
+    def.value = '';
+    def.textContent = 'Seleccione...';
+    def.disabled = true;
+    def.selected = true;
+    nameInput.appendChild(def);
+
+    const groups = {};
     DOC_TYPES.forEach(t => {
+      if (!groups[t.category]) {
+        const g = document.createElement('optgroup');
+        g.label = t.category;
+        groups[t.category] = g;
+        nameInput.appendChild(g);
+      }
       const opt = document.createElement('option');
       opt.value = t.name;
       opt.textContent = t.name;
-      nameInput.appendChild(opt);
+      groups[t.category].appendChild(opt);
     });
   }
 
@@ -114,10 +128,10 @@ document.addEventListener('DOMContentLoaded', () => {
         const delBtn = document.createElement('button');
         delBtn.textContent = 'Eliminar';
         delBtn.addEventListener('click', () => {
-          if (doc.name === 'AMFE') {
-            const count = docs.filter(d => d.name === 'AMFE').length;
+          if (doc.name === 'Amfe') {
+            const count = docs.filter(d => d.name === 'Amfe').length;
             if (count <= 1) {
-              alert('No se puede eliminar la columna AMFE');
+              alert('No se puede eliminar la columna Amfe');
               return;
             }
           }

--- a/styles.css
+++ b/styles.css
@@ -431,6 +431,10 @@ table#sinoptico tbody td {
   padding: 6px;
   border: 1px solid #bbb;
   border-radius: 4px;
+  min-width: 180px;
+}
+.maestro-form optgroup {
+  font-weight: bold;
 }
 .maestro-form input {
   flex: 1;

--- a/test-maestro.js
+++ b/test-maestro.js
@@ -1,2 +1,18 @@
-require('jsdom-global')();
+const jsdom = require('jsdom-global');
+jsdom('', { url: 'http://localhost' });
+global.sessionStorage = window.sessionStorage;
+global.localStorage = window.localStorage;
+
+// Minimal DOM structure expected by maestro.js
+document.body.innerHTML = `
+  <div id="maestro"></div>
+  <select id="docName"></select>
+  <input id="docNumber" />
+  <input id="docDetail" />
+  <button id="addDoc"></button>
+  <input id="maestroFilter" />
+  <div class="maestro-form"></div>
+`;
+
 require('./maestro.js');
+document.dispatchEvent(new Event('DOMContentLoaded'));


### PR DESCRIPTION
## Summary
- group master list dropdown by category and add placeholder option
- reorder document types and adjust related code
- improve dropdown styling
- make test-maestro.js create DOM and register storage so maestro.js runs without errors

## Testing
- `npm install`
- `node test-maestro.js`

------
https://chatgpt.com/codex/tasks/task_e_6845c08527408329b73150562e565f7a