### PR TITLE
Fix master doc list categories

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ Then open [http://localhost:8000/index.html](http://localhost:8000/index.html) i
 - **Expand/Collapse** – the tree of products can be expanded node by node or all at once.
 - **Automatic refresh** – `sinoptico.csv` is reloaded every 30 seconds so changes appear automatically.
 - **Excel export** – visible rows can be exported to `sinoptico.xlsx`.
+- **Dynamic categories** – the master list starts empty and new document sections
+  appear automatically when items are added.
 
 ## Dependencies and browser requirements
 

--- a/maestro.js
+++ b/maestro.js
@@ -15,8 +15,13 @@ document.addEventListener('DOMContentLoaded', () => {
   const STORAGE_KEY = 'maestroDocs';
   let isAdmin = sessionStorage.getItem('maestroAdmin') === 'true';
 
-  let docs = JSON.parse(localStorage.getItem(STORAGE_KEY)) ||
-    DOC_TYPES.map(t => ({ name: t.name, number: '', detail: '', category: t.category }));
+  let docs = JSON.parse(localStorage.getItem(STORAGE_KEY)) || [];
+  if (Array.isArray(docs)) {
+    // Remove empty placeholder entries from older versions
+    docs = docs.filter(d => !(DOC_TYPES.some(t => t.name === d.name) && !d.number && !d.detail));
+  } else {
+    docs = [];
+  }
 
   function updateDocOptions() {
     if (!nameInput) return;


### PR DESCRIPTION
## Summary
- remove placeholder document rows
- clean up previously stored docs on load
- document dynamic category behaviour in README

## Testing
- `npm install`
- `node test-maestro.js`

------
https://chatgpt.com/codex/tasks/task_e_6845c24781e08329b130fb32a7b100c8