### PR TITLE
Fix description handling and remove 'Barack' prefix

### DIFF
--- a/renderer.js
+++ b/renderer.js
@@ -478,11 +478,8 @@
             tdItem.appendChild(btnToggle);
 
             let nombreItem = (fila['Descripción'] || '').toString().trim();
-            if (
-              nivel === 1 &&
-              fila.Tipo.toString().trim().toLowerCase() === 'pieza final'
-            ) {
-              nombreItem = 'Barack ' + nombreItem;
+            if (!nombreItem) {
+              nombreItem = 'N/D';
             }
 
             if (nivel === 0) {


### PR DESCRIPTION
## Summary
- stop prefixing "Barack" to level‑1 pieza final names
- show `N/D` when a description value is missing

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6846cf4214b08329bb18282c4147f539