### PR TITLE
Add manual refresh button for sinoptico

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ The list is normally stored in your browser's `localStorage`. When running in an
 - **Filtering** – search for text and control which hierarchy levels are visible.
 - **Expand/Collapse** – the tree of products can be expanded node by node or all at once.
 - **Automatic refresh** – `data/sinoptico.csv` is reloaded every 30 seconds so changes appear automatically.
+- **Manual refresh** – click the **Refrescar** button in `sinoptico.html` to reload data on demand.
 - **Excel export** – visible rows can be exported to `sinoptico.xlsx`.
 - **Dynamic categories** – the master list starts empty and new document sections appear automatically when items are added.
 - **Client grouping** – rows with a value in the `Cliente` column are grouped under that client in the product tree.

--- a/renderer.js
+++ b/renderer.js
@@ -208,6 +208,7 @@
       }
       document.getElementById('expandirTodo').addEventListener('click', expandirTodo);
       document.getElementById('colapsarTodo').addEventListener('click', colapsarTodo);
+      document.getElementById('btnRefrescar').addEventListener('click', loadData);
 
       /* ==================================================
          4) Exportar a Excel (solo filas visibles)

--- a/sinoptico.html
+++ b/sinoptico.html
@@ -71,6 +71,7 @@
     <!-- Botones globales -->
     <button id="expandirTodo" aria-label="Expandir todas las filas">Expandir Todo</button>
     <button id="colapsarTodo" aria-label="Colapsar todas las filas">Colapsar Todo</button>
+    <button id="btnRefrescar" aria-label="Recargar datos">Refrescar</button>
     <!-- Botón para exportar la tabla visible a Excel -->
     <button id="btnExcel" aria-label="Exportar la tabla visible a Excel">Exportar a Excel</button>
   </div>


### PR DESCRIPTION
## Summary
- add `btnRefrescar` button near Expandir/Colapsar controls
- wire up button in `renderer.js` to call `loadData`
- document new manual refresh feature in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6846d4c062348329ae8a328bc47e91e0