### PR TITLE
Fix sinoptico.xlsx location

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ The list is normally stored in your browser's `localStorage`. When running in an
 - **Expand/Collapse** – the tree of products can be expanded node by node or all at once.
 - **Automatic refresh** – `data/sinoptico.csv` is reloaded every 30 seconds so changes appear automatically.
 - **Manual refresh** – click the **Refrescar** button in `sinoptico.html` to reload data on demand.
-- **Excel export** – visible rows can be exported to `sinoptico.xlsx`.
+- **Excel export** – visible rows can be exported to `sinoptico.xlsx` which
+  resides in the `data/` folder.
 - **Dynamic categories** – the master list starts empty and new document sections appear automatically when items are added.
 - **Client grouping** – rows with a value in the `Cliente` column are grouped under that client in the product tree.
 - **Smooth animations** – buttons and rows fade and scale for a more polished experience.

--- a/renderer.js
+++ b/renderer.js
@@ -360,7 +360,7 @@
       }
 
       function tryLoadXlsx(expandedIds) {
-        fetch('sinoptico.xlsx')
+        fetch('data/sinoptico.xlsx')
           .then(resp => {
             if (!resp.ok) throw new Error('No xlsx');
             return resp.arrayBuffer();
@@ -402,7 +402,9 @@
           } catch (err) {
             console.error('Error al leer sinoptico.csv:', err);
             try {
-              const xlsxBuffer = fs.readFileSync(pathModule.join(__dirname, 'sinoptico.xlsx'));
+              const xlsxBuffer = fs.readFileSync(
+                pathModule.join(__dirname, 'data', 'sinoptico.xlsx')
+              );
               const wb = XLSX.read(xlsxBuffer, { type: 'buffer' });
               const sheet = wb.Sheets[wb.SheetNames[0]];
               const datosOriginal = XLSX.utils.sheet_to_json(sheet, { defval: '' });


### PR DESCRIPTION
## Summary
- fetch xlsx file from `data/sinoptico.xlsx`
- read the xlsx file from the data folder when running under Node
- document xlsx location in README

## Testing
- `npm test`
- `python3 -m http.server` then `curl -I http://localhost:8000/sinoptico.html`
- `curl -I http://localhost:8000/data/sinoptico.xlsx`

------
https://chatgpt.com/codex/tasks/task_e_6846e22df2bc8329bcabb67f21467dc0