### PR TITLE
Add warning for missing selected row

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ This creates a small DOM environment so the script can be executed without a rea
 
 ## Fuzzy search flow
 
-Both `listado_maestro.html` and `sinoptico.html` load [Fuse.js](https://fusejs.io/) from a CDN. In the master list a drop-down of matching documents appears while you type; picking one stores the selection in `sessionStorage` and opens `sinoptico.html`. The product view now has its own search box powered by Fuse.js. Suggestions appear without hiding the table and clicking a row fills the input and triggers the normal filter/highlight logic. Removing the Fuse.js script tags disables these fuzzy searches.
+ Both `listado_maestro.html` and `sinoptico.html` load [Fuse.js](https://fusejs.io/) from a CDN. In the master list a drop-down of matching documents appears while you type; picking one stores the selection in `sessionStorage` and opens `sinoptico.html`. The product view now has its own search box powered by Fuse.js. Suggestions appear without hiding the table and clicking a row fills the input and triggers the normal filter/highlight logic. If no row matches the stored selection, a warning appears instead of highlighting. Removing the Fuse.js script tags disables these fuzzy searches.
 
 ## License
 

--- a/renderer.js
+++ b/renderer.js
@@ -422,6 +422,8 @@
                 fila.classList.add('highlight');
                 fila.scrollIntoView({ block: 'center' });
                 setTimeout(() => fila.classList.remove('highlight'), 2000);
+              } else {
+                mostrarMensaje('No se encontró el documento seleccionado', 'warning');
               }
               sessionStorage.removeItem('maestroSelectedNumber');
             }


### PR DESCRIPTION
## Summary
- show a warning in sinoptico when the stored row is not found and only highlight when it exists
- document this behaviour in the Fuzzy search flow section

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684973f78ebc832fa75d7c72a747c017