### PR TITLE
Fix synoptic highlight search

### DIFF
--- a/renderer.js
+++ b/renderer.js
@@ -399,9 +399,13 @@
               const filas = Array.from(
                 document.querySelectorAll('#sinoptico tbody tr')
               );
-              const fila = filas.find(tr =>
-                tr.textContent.toLowerCase().includes(sel.toLowerCase())
-              );
+              const selNorm = sel.trim().toLowerCase();
+              const fila = filas.find(tr => {
+                const codigoCell = tr.querySelector('td:last-child');
+                if (!codigoCell) return false;
+                const codigoText = codigoCell.textContent.trim().toLowerCase();
+                return codigoText === selNorm;
+              });
               if (fila) {
                 let parentId = fila.getAttribute('data-parent');
                 while (parentId) {


### PR DESCRIPTION
## Summary
- ensure product rows match `Código` exactly when highlighting after selecting from the master list

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684978a3e05c832fafd3cc2c4b19071c