### PR TITLE
Add in-page highlight for maestro suggestions

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ This creates a small DOM environment so the script can be executed without a rea
 
 ## Fuzzy search flow
 
- Both `listado_maestro.html` and `sinoptico.html` load [Fuse.js](https://fusejs.io/) from a CDN. In the master list a drop-down of matching documents appears while you type; picking one stores the selection in `sessionStorage` and opens `sinoptico.html`. The product view now has its own search box powered by Fuse.js. Suggestions appear without hiding the table and clicking a row fills the input and triggers the normal filter/highlight logic. If no row matches the stored selection, a warning appears instead of highlighting. Removing the Fuse.js script tags disables these fuzzy searches.
+ Both `listado_maestro.html` and `sinoptico.html` load [Fuse.js](https://fusejs.io/) from a CDN. In the master list a drop-down of matching documents appears while you type; picking one now stores the selection in `sessionStorage`, highlights the chosen row and shows the filter banner without navigating away. The product view still has its own Fuse.js search box where suggestions appear without hiding the table and clicking a row fills the input and triggers the normal filter/highlight logic. If no row matches the stored selection, a warning appears instead of highlighting. Removing the Fuse.js script tags disables these fuzzy searches.
 
 ## License
 

--- a/maestro.js
+++ b/maestro.js
@@ -115,6 +115,22 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   }
 
+  function highlightDoc(number) {
+    const rows = Array.from(document.querySelectorAll('#maestro tbody tr'));
+    const sel = (number || '').toString().trim().toLowerCase();
+    const row = rows.find(tr => {
+      const cells = tr.querySelectorAll('td');
+      return (
+        cells[1] && cells[1].textContent.trim().toLowerCase() === sel
+      );
+    });
+    if (row) {
+      row.classList.add('highlight');
+      row.scrollIntoView({ block: 'center' });
+      setTimeout(() => row.classList.remove('highlight'), 2000);
+    }
+  }
+
   function applyFilter() {
     if (!filterInput) return;
 
@@ -151,7 +167,8 @@ document.addEventListener('DOMContentLoaded', () => {
         sessionStorage.setItem('maestroSelectedNumber', doc.number);
         suggestionList.style.display = 'none';
         suggestionList.innerHTML = '';
-        window.location.href = 'sinoptico.html';
+        updateBanner();
+        highlightDoc(doc.number);
       });
       suggestionList.appendChild(li);
     });


### PR DESCRIPTION
## Summary
- prevent navigating to `sinoptico.html` when picking a suggestion
- highlight the selected row in `listado_maestro.html`
- document the new fuzzy search behaviour

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68497f79035c832f841ef891bea55391