### PR TITLE
Improve sinoptico fuzzy search

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ This creates a small DOM environment so the script can be executed without a rea
 
 ## Fuzzy search flow
 
- Both `listado_maestro.html` and `sinoptico.html` load [Fuse.js](https://fusejs.io/) from a CDN. In the master list a drop-down of matching documents appears while you type; picking one now stores the selection in `sessionStorage`, highlights the chosen row and shows the filter banner without navigating away. The product view still has its own Fuse.js search box where suggestions appear without hiding the table and clicking a row fills the input and triggers the normal filter/highlight logic. If no row matches the stored selection, a warning appears instead of highlighting. Removing the Fuse.js script tags disables these fuzzy searches.
+ Both `listado_maestro.html` and `sinoptico.html` load [Fuse.js](https://fusejs.io/) from a CDN. In the master list a drop-down of matching documents appears while you type; picking one stores the selection in `sessionStorage`, highlights the chosen row and shows the filter banner without navigating away. The product view also leverages Fuse.js for its filter box: multiple keywords separated by spaces or commas are accepted and the fuzzy results of each term are combined. Suggestions no longer reload the table; clicking one simply highlights the corresponding row and scrolls it into view. If no row matches the stored selection a warning is shown. Removing the Fuse.js script tags disables these fuzzy searches.
 
 ## License
 


### PR DESCRIPTION
## Summary
- add `highlightRow` helper for sinoptico rows
- switch filters to use Fuse.js when available
- highlight table rows directly from fuzzy search results
- describe updated fuzzy search behaviour in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684986e719b8832fb28f921e4a8797eb