### PR TITLE
Fix synoptic filter persistence

### DIFF
--- a/renderer.js
+++ b/renderer.js
@@ -252,6 +252,7 @@
             suggestionList.style.display = 'none';
             suggestionList.innerHTML = '';
             highlightRow(row['Código']);
+            aplicarFiltro();
           });
           suggestionList.appendChild(li);
         });


### PR DESCRIPTION
## Summary
- ensure filtering remains active after selecting a suggestion in the synoptic view

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68498a47f148832fba2014d82f330465