### PR TITLE
Move landing search content to separate page

### DIFF
--- a/buscador.html
+++ b/buscador.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Ingeniería Barack</title>
+  <link rel="stylesheet" href="styles.css">
+  <script src="https://cdn.jsdelivr.net/npm/papaparse@5.3.2/papaparse.min.js"></script>
+</head>
+<body>
+  <!-- Navegación principal -->
+  <nav class="main-nav">
+    <a href="index.html">Inicio</a>
+    <a href="buscador.html">Buscador</a>
+    <a href="sinoptico.html">Sinóptico</a>
+    <a href="listado_maestro.html">Listado maestro</a>
+  </nav>
+
+  <header class="hero">
+    <h1>Buscador de productos</h1>
+  </header>
+
+  <main class="search-area">
+    <!-- Módulo Listado Maestro -->
+    <section class="search-module" aria-labelledby="maestro-label">
+      <h2 id="maestro-label">Listado Maestro</h2>
+      <div class="input-wrapper">
+        <input type="text" id="maestro-input" placeholder="Buscar documento" aria-label="Buscar en listado maestro">
+        <div class="loader" id="maestro-loader" aria-hidden="true"></div>
+      </div>
+      <select id="maestro-filter" aria-label="Filtrar listado maestro">
+        <option value="">Todos</option>
+        <option value="planos">Planos</option>
+        <option value="manuales">Manuales</option>
+        <option value="reportes">Reportes</option>
+      </select>
+      <div class="chips" id="maestro-chip"></div>
+    </section>
+
+    <!-- Módulo Sinóptico Producto -->
+    <section class="search-module" aria-labelledby="sinoptico-label">
+      <h2 id="sinoptico-label">Sinóptico Producto</h2>
+      <div class="input-wrapper">
+        <input type="text" id="sinoptico-input" placeholder="Buscar producto" aria-label="Buscar en sinóptico">
+        <div class="loader" id="sinoptico-loader" aria-hidden="true"></div>
+      </div>
+      <select id="sinoptico-filter" aria-label="Filtrar sinóptico">
+        <option value="">Todos</option>
+        <option value="cliente">Cliente</option>
+        <option value="proveedor">Proveedor</option>
+        <option value="interno">Interno</option>
+      </select>
+      <div class="chips" id="sinoptico-chip"></div>
+    </section>
+
+    <!-- Resultados combinados -->
+    <section class="results" aria-live="polite" id="results"></section>
+  </main>
+
+  <script src="search.js"></script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
   <body>
       <nav class="main-nav">
           <a href="index.html">Inicio</a>
+          <a href="buscador.html">Buscador</a>
           <a href="sinoptico.html">Sinóptico</a>
           <a href="listado_maestro.html">Listado maestro</a>
       </nav>

--- a/search.js
+++ b/search.js
@@ -1,0 +1,178 @@
+// Utilidad para "debounce". Ejecuta fn 300ms luego del ultimo llamado
+function debounce(fn, delay = 300) {
+  let timeout;
+  return (...args) => {
+    clearTimeout(timeout);
+    timeout = setTimeout(() => fn.apply(this, args), delay);
+  };
+}
+
+// Datos cargados desde data/sinoptico.csv
+let data = [];
+
+const state = {
+  maestro: { query: '', filter: '' },
+  sinoptico: { query: '', filter: '' }
+};
+
+const maestroInput = document.getElementById('maestro-input');
+const maestroFilter = document.getElementById('maestro-filter');
+const maestroChip = document.getElementById('maestro-chip');
+const maestroLoader = document.getElementById('maestro-loader');
+
+const sinInput = document.getElementById('sinoptico-input');
+const sinFilter = document.getElementById('sinoptico-filter');
+const sinChip = document.getElementById('sinoptico-chip');
+const sinLoader = document.getElementById('sinoptico-loader');
+
+const resultsEl = document.getElementById('results');
+
+function renderChips() {
+  maestroChip.innerHTML = '';
+  sinChip.innerHTML = '';
+  if (state.maestro.filter) {
+    maestroChip.appendChild(createChip(state.maestro.filter, () => {
+      maestroFilter.value = '';
+      state.maestro.filter = '';
+      updateResults();
+    }));
+  }
+  if (state.sinoptico.filter) {
+    sinChip.appendChild(createChip(state.sinoptico.filter, () => {
+      sinFilter.value = '';
+      state.sinoptico.filter = '';
+      updateResults();
+    }));
+  }
+}
+
+function createChip(text, onRemove) {
+  const chip = document.createElement('span');
+  chip.className = 'chip';
+  chip.textContent = text;
+  const btn = document.createElement('button');
+  btn.setAttribute('aria-label', 'Eliminar filtro');
+  btn.innerHTML = '&times;';
+  btn.addEventListener('click', onRemove);
+  chip.appendChild(btn);
+  return chip;
+}
+
+// Filtro de datos segun el estado
+function filterData() {
+  return data.filter(item => {
+    const q1 = state.maestro.query.toLowerCase();
+    const q2 = state.sinoptico.query.toLowerCase();
+    const matchesMaestro = !q1 || item.nombre.toLowerCase().includes(q1);
+    const matchesSin = !q2 || item.nombre.toLowerCase().includes(q2);
+    const filterMaestro = !state.maestro.filter || item.tipoMaestro === state.maestro.filter;
+    const filterSin = !state.sinoptico.filter || item.tipoSinoptico === state.sinoptico.filter;
+    return matchesMaestro && matchesSin && filterMaestro && filterSin;
+  });
+}
+
+function showLoader(module, show) {
+  module.style.display = show ? 'block' : 'none';
+}
+
+function updateResults() {
+  showLoader(maestroLoader, false);
+  showLoader(sinLoader, false);
+  renderChips();
+  const results = filterData();
+  resultsEl.innerHTML = '';
+  if (!results.length) {
+    resultsEl.innerHTML = '<div class="no-results">No se encontraron coincidencias.</div>';
+    return;
+  }
+  results.forEach(r => {
+    const div = document.createElement('div');
+    div.className = 'result-item';
+    div.textContent = r.nombre;
+    resultsEl.appendChild(div);
+  });
+}
+
+const processMaestro = debounce(() => {
+  showLoader(maestroLoader, false);
+  updateResults();
+});
+
+const processSin = debounce(() => {
+  showLoader(sinLoader, false);
+  updateResults();
+});
+
+maestroInput.addEventListener('input', () => {
+  showLoader(maestroLoader, true);
+  state.maestro.query = maestroInput.value;
+  processMaestro();
+});
+
+sinInput.addEventListener('input', () => {
+  showLoader(sinLoader, true);
+  state.sinoptico.query = sinInput.value;
+  processSin();
+});
+
+maestroFilter.addEventListener('change', () => {
+  state.maestro.filter = maestroFilter.value;
+  updateResults();
+});
+
+sinFilter.addEventListener('change', () => {
+  state.sinoptico.filter = sinFilter.value;
+  updateResults();
+});
+
+// Cerrar dropdowns al hacer click fuera
+window.addEventListener('click', e => {
+  document.querySelectorAll('.has-dropdown').forEach(d => {
+    if (!d.contains(e.target)) {
+      d.querySelectorAll('.dropdown').forEach(menu => {
+        menu.style.display = '';
+      });
+      const link = d.querySelector('a');
+      if (link) link.setAttribute('aria-expanded', 'false');
+    }
+  });
+});
+
+// Alternar menús desplegables en dispositivos táctiles
+document.querySelectorAll('.has-dropdown > a').forEach(link => {
+  link.addEventListener('click', e => {
+    const submenu = link.nextElementSibling;
+    if (!submenu) return;
+    const expanded = link.getAttribute('aria-expanded') === 'true';
+    e.preventDefault();
+    link.setAttribute('aria-expanded', String(!expanded));
+    submenu.style.display = expanded ? '' : 'block';
+  });
+});
+
+function loadCsvData() {
+  showLoader(maestroLoader, true);
+  showLoader(sinLoader, true);
+  fetch('data/sinoptico.csv')
+    .then(resp => {
+      if (!resp.ok) throw new Error('CSV no encontrado');
+      return resp.text();
+    })
+    .then(text => {
+      const parsed = Papa.parse(text, { header: true, delimiter: ';' });
+      data = parsed.data.map(r => ({
+        nombre: r['Descripción'] || '',
+        tipoMaestro: (r['Tipo'] || '').toLowerCase(),
+        tipoSinoptico: (r['Cliente'] || '').toLowerCase()
+      }));
+      updateResults();
+    })
+    .catch(err => {
+      console.error(err);
+      data = [];
+      updateResults();
+    });
+}
+
+// Inicial
+loadCsvData();

--- a/styles.css
+++ b/styles.css
@@ -642,3 +642,100 @@ header {
     animation: none;
   }
 }
+.search-area {
+  padding: 2rem 1rem;
+  display: grid;
+  gap: 2rem;
+  max-width: 900px;
+  margin: auto;
+}
+
+.search-module {
+  background: #f9f9f9;
+  padding: 1rem;
+  border-radius: 6px;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.05);
+}
+
+.search-module h2 { margin-top: 0; color: var(--primary-color); }
+.input-wrapper { position: relative; }
+.input-wrapper input {
+  width: 100%;
+  padding: 0.5rem;
+  border-radius: 4px;
+  border: 1px solid #ccc;
+  transition: box-shadow 0.2s;
+}
+.input-wrapper input:focus {
+  outline: none;
+  box-shadow: 0 0 0 2px var(--secondary-color);
+}
+.loader {
+  position: absolute;
+  right: 8px;
+  top: 50%;
+  width: 16px;
+  height: 16px;
+  border: 2px solid transparent;
+  border-top-color: var(--accent-color);
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+  transform: translateY(-50%);
+  display: none;
+}
+
+select {
+  margin-top: 0.5rem;
+  padding: 0.4rem;
+  border-radius: 4px;
+  border: 1px solid #ccc;
+  width: 100%;
+}
+
+.chips {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  margin-top: 0.5rem;
+}
+
+.chip {
+  background: var(--accent-color);
+  color: #fff;
+  padding: 0.25rem 0.5rem;
+  border-radius: 16px;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.chip button {
+  background: none;
+  border: none;
+  color: #fff;
+  cursor: pointer;
+  font-size: 1rem;
+  line-height: 1;
+}
+
+.results { margin-top: 2rem; }
+.result-item {
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid #eee;
+  transition: background 0.2s;
+}
+.result-item:hover { background: #fafafa; }
+.no-results {
+  padding: 1rem;
+  text-align: center;
+  color: var(--secondary-color);
+}
+
+@keyframes spin {
+  from { transform: translateY(-50%) rotate(0); }
+  to { transform: translateY(-50%) rotate(360deg); }
+}
+
+@media (min-width: 700px) {
+  .search-area { grid-template-columns: 1fr 1fr; }
+}


### PR DESCRIPTION
## Summary
- add new **buscador.html** page with search modules
- restore link to the buscador from landing page
- include search logic (**search.js**)
- append search styles to **styles.css**

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684aaf655ce4832fbec857ad57cf46d2