### PR TITLE
Fix product search layout

### DIFF
--- a/sinoptico.html
+++ b/sinoptico.html
@@ -43,7 +43,14 @@
   <!-- ==============================
        BLOQUE DE FILTROS + BOTONES GLOBALES + BOTÓN EXCEL
        ============================== -->
-  <div class="filtro-contenedor">
+
+  <!-- ==============================
+       CONTENEDOR DE LA TABLA
+       ============================== -->
+  <div class="tabla-contenedor">
+
+  <!-- Moved inside tabla-contenedor for better layout -->
+  <div class="filtro-contenedor" id="filtrosSinoptico">
     <div class="filtros-texto">
       <label for="filtroInsumo">🔍 Buscar Insumo:</label>
       <div class="search-wrap">
@@ -81,11 +88,6 @@
     <!-- Botón para exportar la tabla visible a Excel -->
     <button id="btnExcel" aria-label="Exportar la tabla visible a Excel">Exportar a Excel</button>
   </div>
-
-  <!-- ==============================
-       CONTENEDOR DE LA TABLA
-       ============================== -->
-  <div class="tabla-contenedor">
     <table id="sinoptico">
       <thead>
         <tr>


### PR DESCRIPTION
## Summary
- move filter block inside `.tabla-contenedor` so the product search sits within the synoptic view

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ab9d0c63c832fbd7706b65fc420c1