### PR TITLE
Improve chip display

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -701,6 +701,11 @@ select {
   margin-top: 0.5rem;
 }
 
+#selectedItems {
+  flex-basis: 100%;
+  margin-top: 4px;
+}
+
 .chip {
   background: var(--accent-color);
   color: #fff;
@@ -709,6 +714,8 @@ select {
   display: flex;
   align-items: center;
   gap: 0.5rem;
+  border: 1px solid var(--color-accent-hover);
+  font-weight: bold;
 }
 
 .chip button {
@@ -716,7 +723,7 @@ select {
   border: none;
   color: #fff;
   cursor: pointer;
-  font-size: 1rem;
+  font-size: 1.2rem;
   line-height: 1;
 }
 


### PR DESCRIPTION
## Summary
- support chip wrapping by giving `#selectedItems` its own line
- make chips stand out with bold white text, accent border, and bigger close button

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684add1a6cc8832fa223f205d1b75cec