### PR TITLE
Add hero section with Poppins font

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,27 +4,30 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Ingeniera barack</title>
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="styles.css">
 </head>
-  <body>
+  <body class="home">
       <nav class="main-nav">
           <a href="index.html">Inicio</a>
           <a href="sinoptico.html">Sinóptico</a>
           <a href="listado_maestro.html">Listado maestro</a>
       </nav>
       <header>
-          <img src="images/LOGO BARACK.png" alt="Logo Barack" class="logo">
+          <section class="hero">
+              <img src="images/LOGO BARACK.png" alt="Logo Barack" class="logo">
+              <h1>Ingeniería Barack</h1>
+              <p class="tagline">Soluciones integrales para la industria automotriz</p>
+              <a class="btn-link" href="sinoptico.html">Ver Sinóptico de Producto</a>
+              <a class="btn-link" href="listado_maestro.html">Listado maestro</a>
+          </section>
       </header>
       <main class="intro">
-          <h1>Ingeniería Barack</h1>
-          <p class="tagline">Soluciones integrales para la industria automotriz</p>
           <ul class="features">
             <li>Consulta del sinóptico de productos</li>
             <li>Listado maestro de ingeniería</li>
             <li>Datos actualizados automáticamente</li>
           </ul>
-          <a class="btn-link" href="sinoptico.html">Ver Sinóptico de Producto</a>
-          <a class="btn-link" href="listado_maestro.html">Listado maestro</a>
       </main>
       <script>
         document.addEventListener('DOMContentLoaded', () => {

--- a/styles.css
+++ b/styles.css
@@ -9,7 +9,7 @@
   --color-accent: #0066cc;
   --color-accent-hover: #004c99;
   --color-light: #ffffff;
-  --font-base: Arial, sans-serif;
+  --font-base: 'Poppins', Arial, sans-serif;
 
   /* new mappings used later in the file */
   --primary-color: var(--color-primary);
@@ -23,6 +23,10 @@ body {
   padding: 60px 0 0 0;
   background-color: var(--color-bg);
   color: var(--color-text);
+}
+
+body.home {
+  padding-top: 0;
 }
 h1 {
   text-align: center;
@@ -559,7 +563,7 @@ body, html {
   top: 0;
   left: 0;
   width: 100%;
-  background-color: var(--color-primary);
+  background-color: rgba(13, 27, 61, 0.9);
   display: flex;
   justify-content: center;
   gap: 20px;
@@ -574,12 +578,25 @@ body, html {
 }
 
 header {
-  padding: 20px;
+  padding: 0;
   text-align: center;
 }
 .logo {
   max-width: 180px;
   height: auto;
+}
+
+.hero {
+  min-height: 100vh;
+  background: linear-gradient(135deg, var(--color-primary), var(--color-accent));
+  color: var(--color-light);
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+  padding: 100px 20px 40px;
+  font-family: var(--font-base);
 }
 .intro {
   background-color: var(--color-light);


### PR DESCRIPTION
## Summary
- include Google Font link in index.html
- wrap heading and CTA in a new `.hero` section
- style `.hero` for full viewport height and gradient background
- let `.main-nav` overlay the hero with transparency
- remove top padding on the home page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ae2530624832fa5868d52ce73c090