### PR TITLE
Fix Excel export column symbol

### DIFF
--- a/renderer.js
+++ b/renderer.js
@@ -413,7 +413,11 @@
                 );
                 return th && th.style.display !== 'none';
               })
-              .map(td => td.textContent.trim());
+              .map((td, idx) => {
+                let text = td.textContent.trim();
+                if (idx === 0) text = text.replace(/^[+-]\s*/, '');
+                return text;
+              });
             filasVisibles.push(celdas);
           }
         });


### PR DESCRIPTION
## Summary
- when exporting the visible rows to Excel, strip leading +/– symbols from the first column only

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684aecc6e948832f88cc188a1373ac2b