### PR TITLE
Add dark theme and navigation improvements

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,9 +9,10 @@
 </head>
   <body class="home">
       <nav class="main-nav">
-          <a href="index.html">Inicio</a>
+          <a href="index.html" aria-current="page">Inicio</a>
           <a href="sinoptico.html">Sinóptico</a>
           <a href="listado_maestro.html">Listado maestro</a>
+          <button id="toggleTheme">🌙</button>
       </nav>
       <header>
           <section class="hero">
@@ -29,6 +30,7 @@
             <li>Datos actualizados automáticamente</li>
           </ul>
       </main>
+      <script src="theme.js" defer></script>
       <script>
         document.addEventListener('DOMContentLoaded', () => {
           document.querySelector('main').classList.add('fade-in');

--- a/listado_maestro.html
+++ b/listado_maestro.html
@@ -10,7 +10,8 @@
   <nav class="main-nav">
     <a href="index.html">Inicio</a>
     <a href="sinoptico.html">Sinóptico</a>
-    <a href="listado_maestro.html">Listado maestro</a>
+    <a href="listado_maestro.html" aria-current="page">Listado maestro</a>
+    <button id="toggleTheme">🌙</button>
   </nav>
   <header class="maestro-header">
     <h1>Listado maestro de ingeniería</h1>
@@ -19,6 +20,7 @@
 
   <div class="maestro-container">
     <div class="search-wrap">
+      <label for="maestroFilter">Buscar documento</label>
       <input type="text" id="maestroFilter" placeholder="Buscar documento o número" class="maestro-filter" />
       <button id="clearSearch" aria-label="Limpiar búsqueda">×</button>
       <ul id="maestroSuggestions" class="suggestions-list"></ul>
@@ -69,6 +71,7 @@
       updateButton();
     });
   </script>
+  <script src="theme.js" defer></script>
   <script src="https://cdn.jsdelivr.net/npm/fuse.js@6.6.2/dist/fuse.min.js"></script>
   <script src="maestro.js"></script>
 </body>

--- a/sinoptico.html
+++ b/sinoptico.html
@@ -18,8 +18,9 @@
 <body>
   <nav class="main-nav">
     <a href="index.html">Inicio</a>
-    <a href="sinoptico.html">Sinóptico</a>
+    <a href="sinoptico.html" aria-current="page">Sinóptico</a>
     <a href="listado_maestro.html">Listado maestro</a>
+    <button id="toggleTheme">🌙</button>
   </nav>
   <h1>Sinóptico de Producto Barack</h1>
   <div id="mensaje"></div>
@@ -111,6 +112,7 @@
   </div>
   <a href="index.html" class="home-button">Inicio</a>
 
+  <script src="theme.js" defer></script>
   <script src="renderer.js" defer></script>
 </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -17,6 +17,13 @@
   --accent-color: var(--color-accent);
 }
 
+body.dark-mode {
+  --color-bg: #111;
+  --color-text: #e0e0e0;
+  --color-primary: #7986cb;
+  --color-accent: #00bcd4;
+}
+
 body {
   font-family: var(--font-base);
   margin: 0;
@@ -591,6 +598,9 @@ body, html {
   color: var(--color-light);
   text-decoration: none;
   font-weight: bold;
+}
+.main-nav a[aria-current="page"] {
+  text-decoration: underline;
 }
 
 header {

--- a/theme.js
+++ b/theme.js
@@ -1,0 +1,13 @@
+// Toggle dark mode and remember choice
+window.addEventListener('DOMContentLoaded', () => {
+  const btn = document.getElementById('toggleTheme');
+  if (!btn) return;
+  if (localStorage.getItem('theme') === 'dark') {
+    document.body.classList.add('dark-mode');
+  }
+  btn.addEventListener('click', () => {
+    document.body.classList.toggle('dark-mode');
+    const mode = document.body.classList.contains('dark-mode') ? 'dark' : 'light';
+    localStorage.setItem('theme', mode);
+  });
+});


### PR DESCRIPTION
## Summary
- add dark mode variables and highlight for current page
- create theme toggle button in all pages
- implement theme persistence in `theme.js`
- label master list filter for accessibility

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684afe5a70d4832f8b6bb1a44139f293