### PR TITLE
Add login and edit features

### DIFF
--- a/auth.js
+++ b/auth.js
@@ -1,0 +1,85 @@
+(function(global){
+  const STORAGE_KEY = 'users';
+  let fs = null, path = null, jsonPath = null;
+  if (typeof window !== 'undefined' && window.require) {
+    try {
+      fs = window.require('fs');
+      path = window.require('path');
+      jsonPath = path.join(__dirname, 'no-borrar', 'users.json');
+    } catch(e) { fs = null; }
+  } else if (typeof require === 'function') {
+    try {
+      fs = require('fs');
+      path = require('path');
+      jsonPath = path.join(__dirname, 'no-borrar', 'users.json');
+    } catch(e){ fs = null; }
+  }
+
+  function loadUsers(){
+    let list = [];
+    if (fs && jsonPath && fs.existsSync(jsonPath)) {
+      try { list = JSON.parse(fs.readFileSync(jsonPath, 'utf8')) || []; } catch(e){ list = []; }
+    } else if (typeof localStorage !== 'undefined') {
+      try { list = JSON.parse(localStorage.getItem(STORAGE_KEY)) || []; } catch(e){ list = []; }
+    }
+    if (!Array.isArray(list) || list.length === 0) {
+      list = [
+        { username:'PAULO', password:'1234' },
+        { username:'LEO', password:'1234' },
+        { username:'FACUNDO', password:'1234' },
+        { username:'PABLO', password:'1234' }
+      ];
+      saveUsers(list);
+    }
+    return list;
+  }
+
+  function saveUsers(list){
+    if (fs && jsonPath) {
+      try { fs.writeFileSync(jsonPath, JSON.stringify(list, null, 2), 'utf8'); } catch(e) {}
+    }
+    if (typeof localStorage !== 'undefined') {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(list));
+    }
+  }
+
+  let users = loadUsers();
+
+  function login(username, password){
+    const u = users.find(x => x.username === username && x.password === password);
+    if (u) {
+      if (typeof sessionStorage !== 'undefined') {
+        sessionStorage.setItem('isAdmin', 'true');
+        sessionStorage.setItem('currentUser', username);
+      }
+      return true;
+    }
+    return false;
+  }
+
+  function logout(){
+    if (typeof sessionStorage !== 'undefined') {
+      sessionStorage.removeItem('isAdmin');
+      sessionStorage.removeItem('currentUser');
+    }
+  }
+
+  function createUser(username, password){
+    if (users.some(u => u.username === username)) return false;
+    users.push({ username, password });
+    saveUsers(users);
+    return true;
+  }
+
+  function changePassword(username, newPass){
+    const u = users.find(x => x.username === username);
+    if (!u) return false;
+    u.password = newPass;
+    saveUsers(users);
+    return true;
+  }
+
+  const api = { login, logout, createUser, changePassword, loadUsers };
+  if (typeof module !== 'undefined' && module.exports) module.exports = api;
+  global.auth = api;
+})(typeof globalThis !== 'undefined' ? globalThis : window);

--- a/index.html
+++ b/index.html
@@ -12,6 +12,7 @@
           <a href="index.html" aria-current="page">Inicio</a>
           <a href="sinoptico.html">Sinóptico</a>
           <a href="listado_maestro.html">Listado maestro</a>
+          <a href="login.html" id="loginLink">Log in</a>
           <button id="toggleTheme">🌙</button>
       </nav>
       <header>
@@ -30,10 +31,24 @@
             <li>Datos actualizados automáticamente</li>
           </ul>
       </main>
+      <script src="auth.js"></script>
       <script src="theme.js" defer></script>
       <script>
         document.addEventListener('DOMContentLoaded', () => {
           document.querySelector('main').classList.add('fade-in');
+          const link = document.getElementById('loginLink');
+          function update() {
+            const logged = sessionStorage.getItem('isAdmin') === 'true';
+            link.textContent = logged ? 'Cerrar sesión' : 'Log in';
+          }
+          link.addEventListener('click', e => {
+            if (sessionStorage.getItem('isAdmin') === 'true') {
+              auth.logout();
+              update();
+              e.preventDefault();
+            }
+          });
+          update();
         });
       </script>
   </body>

--- a/listado_maestro.html
+++ b/listado_maestro.html
@@ -39,33 +39,26 @@
     </div>
   </div>
   <a href="index.html" class="home-button">Inicio</a>
-  <script type="module">
-    import { ADMIN_PASS } from "./config.js";
+  <script>
     document.addEventListener("DOMContentLoaded", () => {
       const editBtn = document.getElementById("editBtn");
 
       function updateButton() {
-        editBtn.textContent = sessionStorage.getItem("maestroAdmin") === "true"
-          ? "Salir de edición"
-          : "Editar";
+        const editing = sessionStorage.getItem("maestroAdmin") === "true";
+        editBtn.textContent = editing ? "Salir de edición" : "Editar";
+        editBtn.style.display = sessionStorage.getItem("isAdmin") === "true" ? "inline-block" : "none";
       }
 
       editBtn.addEventListener("click", () => {
-        const isAdmin = sessionStorage.getItem("maestroAdmin") === "true";
-        if (isAdmin) {
+        if (sessionStorage.getItem("isAdmin") !== "true") return;
+        const editing = sessionStorage.getItem("maestroAdmin") === "true";
+        if (editing) {
           sessionStorage.removeItem("maestroAdmin");
-          updateButton();
-          document.dispatchEvent(new CustomEvent("maestro-mode"));
         } else {
-          const pass = prompt("Contraseña de administrador:");
-          if (pass === ADMIN_PASS) {
-            sessionStorage.setItem("maestroAdmin", "true");
-            updateButton();
-            document.dispatchEvent(new CustomEvent("maestro-mode"));
-          } else {
-            alert("Contraseña incorrecta");
-          }
+          sessionStorage.setItem("maestroAdmin", "true");
         }
+        updateButton();
+        document.dispatchEvent(new CustomEvent("maestro-mode"));
       });
 
       updateButton();

--- a/login.html
+++ b/login.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Iniciar sesión</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <nav class="main-nav">
+    <a href="index.html">Inicio</a>
+    <a href="sinoptico.html">Sinóptico</a>
+    <a href="listado_maestro.html">Listado maestro</a>
+    <button id="toggleTheme">🌙</button>
+  </nav>
+
+  <div class="login-container fade-in">
+    <form id="loginForm" class="login-form">
+      <h1>Login</h1>
+      <input type="text" id="username" placeholder="Usuario" required>
+      <input type="password" id="password" placeholder="Contraseña" required>
+      <button type="submit">Entrar</button>
+      <button type="button" id="forgotBtn" disabled>Olvidé la contraseña</button>
+    </form>
+    <div id="adminPanel" class="admin-panel">
+      <h2>Administrar usuarios</h2>
+      <div class="admin-row">
+        <input type="text" id="newUser" placeholder="Usuario">
+        <input type="password" id="newPass" placeholder="Contraseña">
+        <button id="createUser">Crear</button>
+      </div>
+      <div class="admin-row">
+        <input type="text" id="chgUser" placeholder="Usuario">
+        <input type="password" id="chgPass" placeholder="Nueva contraseña">
+        <button id="changePassword">Cambiar</button>
+      </div>
+      <button id="logoutBtn">Cerrar sesión</button>
+    </div>
+  </div>
+
+  <script src="auth.js"></script>
+  <script src="theme.js" defer></script>
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      const form = document.getElementById('loginForm');
+      const panel = document.getElementById('adminPanel');
+      const logoutBtn = document.getElementById('logoutBtn');
+      function updatePanel() {
+        panel.style.display = sessionStorage.getItem('isAdmin') === 'true' ? 'block' : 'none';
+      }
+      form.addEventListener('submit', e => {
+        e.preventDefault();
+        const u = document.getElementById('username').value.trim();
+        const p = document.getElementById('password').value.trim();
+        if (auth.login(u, p)) {
+          location.href = 'index.html';
+        } else {
+          alert('Credenciales inválidas');
+        }
+      });
+      document.getElementById('createUser').addEventListener('click', () => {
+        const u = document.getElementById('newUser').value.trim();
+        const p = document.getElementById('newPass').value.trim();
+        if (u && p) {
+          if (auth.createUser(u, p)) {
+            alert('Usuario creado');
+          } else {
+            alert('Ya existe el usuario');
+          }
+        }
+      });
+      document.getElementById('changePassword').addEventListener('click', () => {
+        const u = document.getElementById('chgUser').value.trim();
+        const p = document.getElementById('chgPass').value.trim();
+        if (auth.changePassword(u, p)) {
+          alert('Contraseña actualizada');
+        } else {
+          alert('Usuario no encontrado');
+        }
+      });
+      logoutBtn.addEventListener('click', () => {
+        auth.logout();
+        updatePanel();
+      });
+      updatePanel();
+    });
+  </script>
+</body>
+</html>

--- a/no-borrar/users.json
+++ b/no-borrar/users.json
@@ -1,0 +1,6 @@
+[
+  {"username":"PAULO","password":"1234"},
+  {"username":"LEO","password":"1234"},
+  {"username":"FACUNDO","password":"1234"},
+  {"username":"PABLO","password":"1234"}
+]

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "",
   "scripts": {
-    "test": "node test-maestro.js && node test-renderer.js"
+    "test": "node test-maestro.js && node test-renderer.js && node test-auth.js"
   },
   "devDependencies": {
     "fuse.js": "^7.1.0",

--- a/sinoptico.html
+++ b/sinoptico.html
@@ -23,6 +23,10 @@
     <button id="toggleTheme">🌙</button>
   </nav>
   <h1>Sinóptico de Producto Barack</h1>
+  <button id="sinopticoEditBtn" class="edit-button">Editar</button>
+  <div id="sinopticoAdmin" style="display:none; margin-bottom:10px;">
+    <button id="addRow">Agregar fila</button>
+  </div>
   <div id="mensaje"></div>
 
   <!-- ==============================
@@ -103,6 +107,7 @@
           <th>Unidad</th>
           <th>Sourcing</th>
           <th>Código</th>
+          <th id="thActions" style="display:none">Acciones</th>
         </tr>
       </thead>
       <tbody>
@@ -112,7 +117,52 @@
   </div>
   <a href="index.html" class="home-button">Inicio</a>
 
+  <script src="auth.js"></script>
   <script src="theme.js" defer></script>
   <script src="renderer.js" defer></script>
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      const editBtn = document.getElementById('sinopticoEditBtn');
+      const admin = document.getElementById('sinopticoAdmin');
+      function update() {
+        const logged = sessionStorage.getItem('isAdmin') === 'true';
+        const editing = sessionStorage.getItem('sinopticoEdit') === 'true';
+        editBtn.style.display = logged ? 'inline-block' : 'none';
+        admin.style.display = logged && editing ? 'block' : 'none';
+        editBtn.textContent = editing ? 'Salir de edición' : 'Editar';
+      }
+      editBtn.addEventListener('click', () => {
+        const editing = sessionStorage.getItem('sinopticoEdit') === 'true';
+        if (editing) sessionStorage.removeItem('sinopticoEdit');
+        else sessionStorage.setItem('sinopticoEdit', 'true');
+        update();
+        document.dispatchEvent(new CustomEvent('sinoptico-mode'));
+      });
+      document.getElementById('addRow').addEventListener('click', () => {
+        const desc = prompt('Descripción del item:');
+        if (!desc) return;
+        const code = prompt('Código:') || '';
+        if (window.SinopticoEditor) {
+          window.SinopticoEditor.addNode({
+            ID: Date.now().toString(),
+            ParentID: '',
+            Tipo: 'Producto',
+            Secuencia: '',
+            Descripción: desc,
+            Cliente: '',
+            Vehículo: '',
+            RefInterno: '',
+            versión: '',
+            Imagen: '',
+            Consumo: '',
+            Unidad: '',
+            Sourcing: '',
+            Código: code
+          });
+        }
+      });
+      update();
+    });
+  </script>
 </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -800,3 +800,48 @@ select {
 @media (min-width: 700px) {
   .search-area { grid-template-columns: 1fr 1fr; }
 }
+
+/* ==============================
+   LOGIN
+   ============================== */
+.login-container {
+  max-width: 320px;
+  margin: 80px auto;
+  padding: 1rem;
+  background: var(--color-light);
+  border-radius: 6px;
+  box-shadow: 0 2px 6px rgba(0,0,0,0.2);
+}
+.login-form,
+.admin-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.admin-row {
+  display: flex;
+  gap: 6px;
+}
+.login-form input,
+.admin-panel input {
+  padding: 6px;
+  border: 1px solid #bbb;
+  border-radius: 4px;
+}
+.login-form button,
+.admin-panel button {
+  padding: 6px 10px;
+  background-color: var(--color-primary);
+  color: var(--color-light);
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+.login-form button:hover,
+.admin-panel button:hover {
+  background-color: var(--color-primary-hover);
+}
+
+.actions-col button {
+  padding: 2px 6px;
+}

--- a/test-auth.js
+++ b/test-auth.js
@@ -1,0 +1,21 @@
+const jsdom = require('jsdom-global');
+jsdom('', { url: 'http://localhost' });
+
+global.sessionStorage = window.sessionStorage;
+global.localStorage = window.localStorage;
+
+const auth = require('./auth.js');
+
+// clear storage
+localStorage.clear();
+sessionStorage.clear();
+
+auth.createUser('user1','pass1');
+if (!auth.login('user1','pass1')) throw new Error('login failed');
+if (sessionStorage.getItem('currentUser') !== 'user1') throw new Error('session not stored');
+auth.logout();
+if (sessionStorage.getItem('currentUser')) throw new Error('logout failed');
+auth.changePassword('user1','new');
+if (!auth.login('user1','new')) throw new Error('password change failed');
+
+console.log('auth tests passed');


### PR DESCRIPTION
## Summary
- implement `auth.js` module for user login and storage
- create `login.html` with admin panel
- add login link to index and log out logic
- update listado_maestro to use sessionStorage flag
- add edit controls for sinoptico and persist edits
- style login page and actions
- add tests for auth logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684b0de6f8a8832fad23d844f75ea113