### PR TITLE
Add editing form for sinoptico

### DIFF
--- a/renderer.js
+++ b/renderer.js
@@ -924,10 +924,27 @@
       }
 
       window.SinopticoEditor = {
-        addNode(row) {
+        addNode(opts) {
+          const row = {
+            ID: Date.now().toString(),
+            ParentID: opts.ParentID || '',
+            Tipo: opts.Tipo || 'Producto',
+            Secuencia: opts.Secuencia || '',
+            Descripción: opts.Descripción || '',
+            Cliente: '',
+            Vehículo: '',
+            RefInterno: '',
+            versión: '',
+            Imagen: '',
+            Consumo: '',
+            Unidad: '',
+            Sourcing: '',
+            Código: opts.Código || ''
+          };
           sinopticoData.push(row);
           saveSinoptico();
           loadData();
+          return row.ID;
         },
         deleteSubtree(id) {
           const ids = new Set();
@@ -938,6 +955,9 @@
           sinopticoData = sinopticoData.filter(r => !ids.has(r.ID));
           saveSinoptico();
           loadData();
+        },
+        getNodes() {
+          return sinopticoData.slice();
         }
       };
 

--- a/sinoptico.html
+++ b/sinoptico.html
@@ -24,8 +24,18 @@
   </nav>
   <h1>Sinóptico de Producto Barack</h1>
   <button id="sinopticoEditBtn" class="edit-button">Editar</button>
-  <div id="sinopticoAdmin" style="display:none; margin-bottom:10px;">
-    <button id="addRow">Agregar fila</button>
+  <div id="sinopticoAdmin" class="sinoptico-admin" style="display:none; margin-bottom:10px;">
+    <select id="newParent"></select>
+    <select id="newTipo">
+      <option value="Producto">Producto</option>
+      <option value="Subensamble">Subensamble</option>
+      <option value="Insumo">Insumo</option>
+    </select>
+    <input type="text" id="newSecuencia" placeholder="Secuencia" />
+    <input type="text" id="newDesc" placeholder="Descripción" />
+    <button id="addRow">Agregar</button>
+    <select id="deleteNode"></select>
+    <button id="deleteTree">Eliminar</button>
   </div>
   <div id="mensaje"></div>
 
@@ -138,29 +148,56 @@
         update();
         document.dispatchEvent(new CustomEvent('sinoptico-mode'));
       });
+      const parentSel = document.getElementById('newParent');
+      const tipoSel = document.getElementById('newTipo');
+      const seqInput = document.getElementById('newSecuencia');
+      const descInput = document.getElementById('newDesc');
+      const delSel = document.getElementById('deleteNode');
+
+      function fillOptions() {
+        if (!window.SinopticoEditor || !window.SinopticoEditor.getNodes) return;
+        const nodes = window.SinopticoEditor.getNodes();
+        parentSel.innerHTML = '<option value="">(raíz)</option>';
+        delSel.innerHTML = '<option value="">Seleccione nodo...</option>';
+        nodes.forEach(n => {
+          const txt = `${n.ID} - ${(n['Descripción'] || '').toString()}`;
+          const opt1 = document.createElement('option');
+          opt1.value = n.ID;
+          opt1.textContent = txt;
+          parentSel.appendChild(opt1);
+          const opt2 = document.createElement('option');
+          opt2.value = n.ID;
+          opt2.textContent = txt;
+          delSel.appendChild(opt2);
+        });
+      }
+
       document.getElementById('addRow').addEventListener('click', () => {
-        const desc = prompt('Descripción del item:');
+        const desc = descInput.value.trim();
         if (!desc) return;
-        const code = prompt('Código:') || '';
         if (window.SinopticoEditor) {
           window.SinopticoEditor.addNode({
-            ID: Date.now().toString(),
-            ParentID: '',
-            Tipo: 'Producto',
-            Secuencia: '',
-            Descripción: desc,
-            Cliente: '',
-            Vehículo: '',
-            RefInterno: '',
-            versión: '',
-            Imagen: '',
-            Consumo: '',
-            Unidad: '',
-            Sourcing: '',
-            Código: code
+            ParentID: parentSel.value,
+            Tipo: tipoSel.value,
+            Secuencia: seqInput.value,
+            Descripción: desc
           });
+          descInput.value = '';
+          seqInput.value = '';
+          fillOptions();
         }
       });
+
+      document.getElementById('deleteTree').addEventListener('click', () => {
+        const id = delSel.value;
+        if (id && window.SinopticoEditor) {
+          window.SinopticoEditor.deleteSubtree(id);
+          fillOptions();
+        }
+      });
+
+      document.addEventListener('sinoptico-mode', fillOptions);
+      fillOptions();
       update();
     });
   </script>

--- a/styles.css
+++ b/styles.css
@@ -570,6 +570,27 @@ table#sinoptico tbody td {
 .maestro-form button:hover {
   background-color: var(--color-primary-hover);
 }
+.sinoptico-admin {
+  display: flex;
+  gap: 8px;
+}
+.sinoptico-admin select,
+.sinoptico-admin input {
+  padding: 6px;
+  border: 1px solid #bbb;
+  border-radius: 4px;
+}
+.sinoptico-admin button {
+  padding: 6px 12px;
+  background-color: var(--color-primary);
+  color: var(--color-light);
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+.sinoptico-admin button:hover {
+  background-color: var(--color-primary-hover);
+}
 .maestro-header {
   display: flex;
   justify-content: center;


### PR DESCRIPTION
## Summary
- add editing controls to `sinoptico.html`
- extend `SinopticoEditor` to handle structured node data and expose nodes
- style the new editing panel
- provide UI buttons for node add/delete instead of prompts

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684b14003c98832f90d4642ef49f26a8