### PR TITLE
Update test instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ The page loads [SheetJS](https://sheetjs.com/) and [Fuse.js](https://fusejs.io/)
 
 ## Node testing
 
-Running the project in a browser is enough to use the page. Optionally you can run an automated test that executes `maestro.js` under Node using JSDOM. Install the dev dependencies once with:
+Running the project in a browser is enough to use the page. Optionally you can run an automated test that executes `maestro.js` under Node using JSDOM. The tests rely on `jsdom-global`, `jsdom` and `fuse.js`, which `npm install` will download for you. Install the dev dependencies once with:
 
 ```bash
 npm install


### PR DESCRIPTION
## Summary
- clarify that tests need `jsdom-global`, `jsdom` and `fuse.js` installed via `npm install`

## Testing
- `npm test` *(fails: cannot find module 'jsdom-global')*

------
https://chatgpt.com/codex/tasks/task_e_684b1882a69c832f95aa96cc975b39e2