### PR TITLE
Add sinoptico admin styles

### DIFF
--- a/sinoptico.html
+++ b/sinoptico.html
@@ -22,7 +22,7 @@
   </nav>
   <h1>Sinóptico de Producto Barack</h1>
   <button id="sinopticoEditBtn" class="edit-button">Editar</button>
-  <div id="sinopticoAdmin" class="sinoptico-admin" style="display:none; margin-bottom:10px;">
+  <div id="sinopticoAdmin" class="sinoptico-admin hidden">
     <select id="newParent"></select>
     <select id="newTipo">
       <option value="Producto">Producto</option>

--- a/styles.css
+++ b/styles.css
@@ -61,6 +61,10 @@ h1 {
   text-align: center;
 }
 
+.hidden {
+  display: none !important;
+}
+
 /* ==============================
    BLOQUE: Mostrar/Ocultar Columnas
    ============================== */
@@ -573,6 +577,11 @@ table#sinoptico tbody td {
 .sinoptico-admin {
   display: flex;
   gap: 8px;
+  margin: 10px 0;
+  padding: 8px;
+  background-color: var(--color-light);
+  border-radius: 6px;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.1);
 }
 .sinoptico-admin select,
 .sinoptico-admin input {


### PR DESCRIPTION
## Summary
- style the sinoptico admin panel with margins, padding and background
- hide the admin panel using a reusable `.hidden` class
- apply the new classes in `sinoptico.html`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684b18875a50832fbede8ed1f51aa317