### PR TITLE
Add Cliente support

### DIFF
--- a/renderer.js
+++ b/renderer.js
@@ -906,6 +906,9 @@
             Sourcing: '',
             Código: opts.Código || ''
           };
+          if (row.Tipo === 'Cliente') {
+            row.Cliente = row['Descripción'];
+          }
           sinopticoData.push(row);
           saveSinoptico();
           loadData();

--- a/sinoptico.html
+++ b/sinoptico.html
@@ -28,6 +28,7 @@
       <option value="Producto">Producto</option>
       <option value="Subensamble">Subensamble</option>
       <option value="Insumo">Insumo</option>
+      <option value="Cliente">Cliente</option>
     </select>
     <input type="text" id="newSecuencia" placeholder="Secuencia" />
     <input type="text" id="newDesc" placeholder="Descripción" />


### PR DESCRIPTION
## Summary
- add Cliente option in sinoptico admin select
- keep descripcion in Cliente field when creating Cliente nodes

## Testing
- `npm install` *(fails: 503 Service Unavailable)*
- `npm test` *(fails: Cannot find module 'jsdom-global')*

------
https://chatgpt.com/codex/tasks/task_e_684b188878f0832f8d31437398b7a81d