### PR TITLE
Update logout to clear edit flags

### DIFF
--- a/auth.js
+++ b/auth.js
@@ -61,6 +61,8 @@
     if (typeof sessionStorage !== 'undefined') {
       sessionStorage.removeItem('isAdmin');
       sessionStorage.removeItem('currentUser');
+      sessionStorage.removeItem('sinopticoEdit');
+      sessionStorage.removeItem('maestroAdmin');
     }
   }
 


### PR DESCRIPTION
## Summary
- remove `sinopticoEdit` and `maestroAdmin` from session storage during logout

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684b18896340832f8eed458d727b4213