### PR TITLE
Add sinoptico editor page

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,6 +11,7 @@
       <nav class="main-nav">
           <a href="index.html" aria-current="page">Inicio</a>
           <a href="sinoptico.html">Sinóptico</a>
+          <a href="sinoptico_edit.html" id="editSinLink" style="display:none">Editar sinóptico</a>
           <a href="listado_maestro.html">Listado maestro</a>
           <a href="login.html" id="loginLink">Log in</a>
           <button id="toggleTheme">🌙</button>
@@ -37,9 +38,11 @@
         document.addEventListener('DOMContentLoaded', () => {
           document.querySelector('main').classList.add('fade-in');
           const link = document.getElementById('loginLink');
+          const editLink = document.getElementById('editSinLink');
           function update() {
             const logged = sessionStorage.getItem('isAdmin') === 'true';
             link.textContent = logged ? 'Cerrar sesión' : 'Log in';
+            if (editLink) editLink.style.display = logged ? 'inline' : 'none';
           }
           link.addEventListener('click', e => {
             if (sessionStorage.getItem('isAdmin') === 'true') {

--- a/renderer.js
+++ b/renderer.js
@@ -889,7 +889,7 @@
       }
 
       window.SinopticoEditor = {
-        addNode(opts) {
+        addNode(opts, children) {
           const row = {
             ID: Date.now().toString(),
             ParentID: opts.ParentID || '',
@@ -907,6 +907,14 @@
             Código: opts.Código || ''
           };
           sinopticoData.push(row);
+          if (Array.isArray(children)) {
+            children.forEach(child => {
+              if (child) {
+                const sub = Object.assign({}, child, { ParentID: row.ID });
+                this.addNode(sub, child.children || []);
+              }
+            });
+          }
           saveSinoptico();
           loadData();
           return row.ID;

--- a/sinoptico-edit.js
+++ b/sinoptico-edit.js
@@ -1,0 +1,103 @@
+document.addEventListener('DOMContentLoaded', () => {
+  if (sessionStorage.getItem('isAdmin') !== 'true') {
+    alert('Debe iniciar sesión para editar');
+    location.href = 'login.html';
+    return;
+  }
+
+  const cForm = document.getElementById('clientForm');
+  const pForm = document.getElementById('productForm');
+  const sForm = document.getElementById('subForm');
+  const iForm = document.getElementById('insForm');
+
+  const prodClient = document.getElementById('prodClient');
+  const subParent = document.getElementById('subParent');
+  const insParent = document.getElementById('insParent');
+
+  function fillOptions() {
+    if (!window.SinopticoEditor || !SinopticoEditor.getNodes) return;
+    const nodes = SinopticoEditor.getNodes();
+    const clients = nodes.filter(n => (n.Tipo || '').toLowerCase() === 'cliente');
+    const prodParents = nodes.filter(n => ['pieza final','producto'].includes((n.Tipo||'').toLowerCase()) || (n.Tipo||'').toLowerCase() === 'cliente');
+    const subParentsList = nodes.filter(n => ['pieza final','producto','subensamble'].includes((n.Tipo||'').toLowerCase()));
+
+    function populate(sel, list) {
+      if (!sel) return;
+      sel.innerHTML = '';
+      list.forEach(n => {
+        const opt = document.createElement('option');
+        opt.value = n.ID;
+        opt.textContent = `${n.ID} - ${n['Descripción'] || ''}`;
+        sel.appendChild(opt);
+      });
+    }
+
+    populate(prodClient, clients);
+    populate(subParent, subParentsList);
+    populate(insParent, subParentsList);
+  }
+
+  function askChildren(parentId) {
+    if (!parentId) return;
+    while (true) {
+      const desc = prompt('Descripción del hijo (Cancelar para terminar)');
+      if (!desc) break;
+      const tipo = prompt('Tipo: S=subensamble, I=insumo', 'I');
+      if (!tipo) break;
+      if (tipo.toUpperCase().startsWith('I')) {
+        SinopticoEditor.addNode({ ParentID: parentId, Tipo: 'Insumo', Descripción: desc });
+      } else {
+        const id = SinopticoEditor.addNode({ ParentID: parentId, Tipo: 'Subensamble', Descripción: desc });
+        if (confirm('¿Agregar hijos para ' + desc + '?')) askChildren(id);
+      }
+    }
+  }
+
+  cForm.addEventListener('submit', e => {
+    e.preventDefault();
+    const desc = document.getElementById('clientDesc').value.trim();
+    if (!desc) return;
+    SinopticoEditor.addNode({ Tipo: 'Cliente', Descripción: desc, Cliente: desc });
+    cForm.reset();
+    fillOptions();
+  });
+
+  pForm.addEventListener('submit', e => {
+    e.preventDefault();
+    const parent = prodClient.value;
+    const desc = document.getElementById('prodDesc').value.trim();
+    const seq = document.getElementById('prodSeq').value.trim();
+    if (!desc) return;
+    const id = SinopticoEditor.addNode({ ParentID: parent, Tipo: 'Pieza final', Secuencia: seq, Descripción: desc });
+    pForm.reset();
+    fillOptions();
+    if (confirm('¿Desea agregar subelementos al producto?')) askChildren(id);
+  });
+
+  sForm.addEventListener('submit', e => {
+    e.preventDefault();
+    const parent = subParent.value;
+    const desc = document.getElementById('subDesc').value.trim();
+    const seq = document.getElementById('subSeq').value.trim();
+    if (!desc) return;
+    const id = SinopticoEditor.addNode({ ParentID: parent, Tipo: 'Subensamble', Secuencia: seq, Descripción: desc });
+    sForm.reset();
+    fillOptions();
+    if (confirm('¿Agregar subelementos a este subensamble?')) askChildren(id);
+  });
+
+  iForm.addEventListener('submit', e => {
+    e.preventDefault();
+    const parent = insParent.value;
+    const desc = document.getElementById('insDesc').value.trim();
+    const seq = document.getElementById('insSeq').value.trim();
+    const code = document.getElementById('insCode').value.trim();
+    if (!desc) return;
+    SinopticoEditor.addNode({ ParentID: parent, Tipo: 'Insumo', Secuencia: seq, Descripción: desc, Código: code });
+    iForm.reset();
+    fillOptions();
+  });
+
+  document.addEventListener('sinoptico-mode', fillOptions);
+  setTimeout(fillOptions, 300);
+});

--- a/sinoptico_edit.html
+++ b/sinoptico_edit.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Editor del Sinóptico</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <nav class="main-nav">
+    <a href="index.html">Inicio</a>
+    <a href="sinoptico.html">Sinóptico</a>
+    <a href="sinoptico_edit.html" aria-current="page">Editar sinóptico</a>
+    <a href="listado_maestro.html">Listado maestro</a>
+    <button id="toggleTheme">🌙</button>
+  </nav>
+
+  <h1>Editor del Sinóptico</h1>
+  <div class="editor-container">
+    <form id="clientForm" class="node-form">
+      <h2>Agregar cliente</h2>
+      <input type="text" id="clientDesc" placeholder="Nombre" required />
+      <button type="submit">Agregar</button>
+    </form>
+
+    <form id="productForm" class="node-form">
+      <h2>Agregar producto</h2>
+      <select id="prodClient"></select>
+      <input type="text" id="prodSeq" placeholder="Secuencia" />
+      <input type="text" id="prodDesc" placeholder="Descripción" required />
+      <button type="submit">Agregar</button>
+    </form>
+
+    <form id="subForm" class="node-form">
+      <h2>Agregar subensamble</h2>
+      <select id="subParent"></select>
+      <input type="text" id="subSeq" placeholder="Secuencia" />
+      <input type="text" id="subDesc" placeholder="Descripción" required />
+      <button type="submit">Agregar</button>
+    </form>
+
+    <form id="insForm" class="node-form">
+      <h2>Agregar insumo</h2>
+      <select id="insParent"></select>
+      <input type="text" id="insSeq" placeholder="Secuencia" />
+      <input type="text" id="insDesc" placeholder="Descripción" required />
+      <input type="text" id="insCode" placeholder="Código" />
+      <button type="submit">Agregar</button>
+    </form>
+  </div>
+
+  <script src="auth.js"></script>
+  <script src="theme.js" defer></script>
+  <script src="renderer.js" defer></script>
+  <script src="sinoptico-edit.js" defer></script>
+</body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -875,3 +875,42 @@ select {
 .actions-col button {
   padding: 2px 6px;
 }
+
+/* ==============================
+   EDITOR DE SINÓPTICO
+   ============================== */
+.editor-container {
+  width: 95%;
+  margin: 20px auto;
+  max-width: 600px;
+}
+
+.node-form {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-bottom: 16px;
+  align-items: center;
+}
+.node-form h2 {
+  flex-basis: 100%;
+  margin: 0 0 4px 0;
+}
+.node-form input,
+.node-form select {
+  padding: 6px;
+  border: 1px solid #bbb;
+  border-radius: 4px;
+  flex: 1;
+}
+.node-form button {
+  padding: 6px 12px;
+  background-color: var(--color-primary);
+  color: var(--color-light);
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+.node-form button:hover {
+  background-color: var(--color-primary-hover);
+}


### PR DESCRIPTION
## Summary
- create dedicated editor page for the product tree
- link to new page from the home menu when logged in
- extend `addNode` to support creating child nodes
- style the editor forms

## Testing
- `npm test` *(fails: Cannot find module 'jsdom-global')*

------
https://chatgpt.com/codex/tasks/task_e_684b1889c5a4832f8df49a416f3ecb1d