### PR TITLE
Fix sinoptico admin toggle and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,11 +31,10 @@ The list is normally stored in your browser's `localStorage`. When running in an
 - **Column toggles** – checkboxes let you hide or show specific table columns.
 - **Filtering** – search for text and control which hierarchy levels are visible.
 - **Expand/Collapse** – the tree of products can be expanded node by node or all at once.
-- **Automatic refresh** – `no-borrar/sinoptico.json` is reloaded every 30 seconds so changes appear automatically.
 - **Manual refresh** – click the **Refrescar** button in `sinoptico.html` to reload data on demand.
-- **Editing modes** – once logged in you can edit the master list and the sinóptico using their respective **Editar** buttons.
-- **Excel export** – visible rows can be exported to `sinoptico.xlsx` which
-  resides in the `data/` folder.
+- **Editing modes** – once logged in you can edit the master list and the sinóptico using their respective **Editar** buttons. The product view is maintained through the interface at `sinoptico_edit.html`.
+- **Excel export** – visible rows can be saved as `sinoptico.xlsx`. The file
+  downloads to your browser's default folder.
 - **Dynamic categories** – the master list starts empty and new document sections appear automatically when items are added.
 - **Client grouping** – rows with a value in the `Cliente` column are grouped under that client in the product tree.
 - **Smooth animations** – buttons and rows fade and scale for a more polished experience.

--- a/sinoptico.html
+++ b/sinoptico.html
@@ -22,7 +22,7 @@
   </nav>
   <h1>Sinóptico de Producto Barack</h1>
   <button id="sinopticoEditBtn" class="edit-button">Editar</button>
-  <div id="sinopticoAdmin" class="sinoptico-admin hidden">
+  <div id="sinopticoAdmin" class="sinoptico-admin">
     <select id="newParent"></select>
     <select id="newTipo">
       <option value="Producto">Producto</option>
@@ -137,7 +137,7 @@
         const logged = sessionStorage.getItem('isAdmin') === 'true';
         const editing = sessionStorage.getItem('sinopticoEdit') === 'true';
         editBtn.style.display = logged ? 'inline-block' : 'none';
-        admin.style.display = logged && editing ? 'block' : 'none';
+        admin.classList.toggle('hidden', !(logged && editing));
         editBtn.textContent = editing ? 'Salir de edición' : 'Editar';
       }
       editBtn.addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- remove default hidden class from sinoptico admin panel
- toggle admin panel visibility via JS using `classList.toggle`
- document how to edit the sinóptico and clarify Excel export location

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684b1e68e4e0832f942a70c024924692