### PR TITLE
Improve client addition feedback

### DIFF
--- a/renderer.js
+++ b/renderer.js
@@ -70,11 +70,30 @@
       ================================================== */
       function mostrarMensaje(texto, tipo = 'error') {
         const div = document.getElementById('mensaje');
+        const colores = {
+          error: '#e74c3c',
+          warning: '#f39c12',
+          success: '#2ecc71'
+        };
         div.textContent = texto;
-        div.style.display = 'block';
-        div.style.backgroundColor = tipo === 'error' ? '#e74c3c' : '#f39c12';
+        div.style.backgroundColor = colores[tipo] || colores.error;
         div.style.color = '#ffffff';
+        div.style.display = 'block';
+        requestAnimationFrame(() => {
+          div.style.opacity = '1';
+        });
+        setTimeout(() => {
+          div.style.opacity = '0';
+          div.addEventListener(
+            'transitionend',
+            () => {
+              div.style.display = 'none';
+            },
+            { once: true }
+          );
+        }, 2000);
       }
+      window.mostrarMensaje = mostrarMensaje;
 
       function aplicarFiltro() {
         const criterio = document

--- a/sinoptico-edit.js
+++ b/sinoptico-edit.js
@@ -60,6 +60,8 @@ document.addEventListener('DOMContentLoaded', () => {
     SinopticoEditor.addNode({ Tipo: 'Cliente', Descripción: desc, Cliente: desc });
     cForm.reset();
     fillOptions();
+    if (window.mostrarMensaje)
+      window.mostrarMensaje('Cliente agregado exitosamente!', 'success');
   });
 
   pForm.addEventListener('submit', e => {
@@ -71,6 +73,8 @@ document.addEventListener('DOMContentLoaded', () => {
     const id = SinopticoEditor.addNode({ ParentID: parent, Tipo: 'Pieza final', Secuencia: seq, Descripción: desc });
     pForm.reset();
     fillOptions();
+    if (window.mostrarMensaje)
+      window.mostrarMensaje('Producto agregado exitosamente!', 'success');
     if (confirm('¿Desea agregar subelementos al producto?')) askChildren(id);
   });
 
@@ -83,6 +87,8 @@ document.addEventListener('DOMContentLoaded', () => {
     const id = SinopticoEditor.addNode({ ParentID: parent, Tipo: 'Subensamble', Secuencia: seq, Descripción: desc });
     sForm.reset();
     fillOptions();
+    if (window.mostrarMensaje)
+      window.mostrarMensaje('Subensamble agregado exitosamente!', 'success');
     if (confirm('¿Agregar subelementos a este subensamble?')) askChildren(id);
   });
 
@@ -96,6 +102,8 @@ document.addEventListener('DOMContentLoaded', () => {
     SinopticoEditor.addNode({ ParentID: parent, Tipo: 'Insumo', Secuencia: seq, Descripción: desc, Código: code });
     iForm.reset();
     fillOptions();
+    if (window.mostrarMensaje)
+      window.mostrarMensaje('Insumo agregado exitosamente!', 'success');
   });
 
   document.addEventListener('sinoptico-mode', fillOptions);

--- a/sinoptico_edit.html
+++ b/sinoptico_edit.html
@@ -16,6 +16,7 @@
   </nav>
 
   <h1>Editor del Sinóptico</h1>
+  <div id="mensaje"></div>
   <div class="editor-container">
     <form id="clientForm" class="node-form">
       <h2>Agregar cliente</h2>

--- a/styles.css
+++ b/styles.css
@@ -54,11 +54,13 @@ h1 {
   max-width: 90%;
   padding: 10px;
   color: var(--color-light);
-  background-color: #e74c3c; /* rojo para alertas */
+  background-color: #e74c3c; /* rojo por defecto */
   display: none;
   border-radius: 4px;
   font-weight: bold;
   text-align: center;
+  opacity: 0;
+  transition: opacity 0.4s ease-in-out;
 }
 
 .hidden {


### PR DESCRIPTION
## Summary
- enhance message styling to support fade animations
- expose `mostrarMensaje` globally and allow success messages
- show success notifications when adding nodes in `sinoptico-edit.js`
- include message container in edit page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684b2222e124832f8ccc4bae9d82876a