### PR TITLE
Refactor sinoptico interactions

### DIFF
--- a/renderer.js
+++ b/renderer.js
@@ -4,6 +4,7 @@
       const jsonFile = pathModule ? pathModule.join(__dirname, "no-borrar", "sinoptico.json") : null;
       let fuseSinoptico = null;
       let sinopticoData = [];
+      const sinopticoElem = document.getElementById('sinoptico');
 
       function generarDatosIniciales() {
         return [
@@ -96,15 +97,18 @@
       window.mostrarMensaje = mostrarMensaje;
 
       function aplicarFiltro() {
-        const criterio = document
-          .getElementById('filtroInsumo')
-          .value.trim()
-          .toLowerCase();
-        const incluirAncestros = document.getElementById('chkIncluirAncestros').checked;
-        const mostrar0 = document.getElementById('chkMostrarNivel0').checked;
-        const mostrar1 = document.getElementById('chkMostrarNivel1').checked;
-        const mostrar2 = document.getElementById('chkMostrarNivel2').checked;
-        const mostrar3 = document.getElementById('chkMostrarNivel3').checked;
+        const criterioElem = document.getElementById('filtroInsumo');
+        const criterio = criterioElem ? criterioElem.value.trim().toLowerCase() : '';
+        const incluirAncestrosElem = document.getElementById('chkIncluirAncestros');
+        const incluirAncestros = incluirAncestrosElem ? incluirAncestrosElem.checked : true;
+        const mostrar0Elem = document.getElementById('chkMostrarNivel0');
+        const mostrar0 = mostrar0Elem ? mostrar0Elem.checked : true;
+        const mostrar1Elem = document.getElementById('chkMostrarNivel1');
+        const mostrar1 = mostrar1Elem ? mostrar1Elem.checked : true;
+        const mostrar2Elem = document.getElementById('chkMostrarNivel2');
+        const mostrar2 = mostrar2Elem ? mostrar2Elem.checked : true;
+        const mostrar3Elem = document.getElementById('chkMostrarNivel3');
+        const mostrar3 = mostrar3Elem ? mostrar3Elem.checked : true;
 
         const todasFilas = Array.from(document.querySelectorAll('#sinoptico tbody tr'));
         const mapIdToRow = {};
@@ -255,11 +259,16 @@
           aplicarFiltro();
         });
       }
-      document.getElementById('chkIncluirAncestros').addEventListener('change', aplicarFiltro);
-      document.getElementById('chkMostrarNivel0').addEventListener('change', aplicarFiltro);
-      document.getElementById('chkMostrarNivel1').addEventListener('change', aplicarFiltro);
-      document.getElementById('chkMostrarNivel2').addEventListener('change', aplicarFiltro);
-      document.getElementById('chkMostrarNivel3').addEventListener('change', aplicarFiltro);
+      const chkIncluir = document.getElementById('chkIncluirAncestros');
+      if (chkIncluir) chkIncluir.addEventListener('change', aplicarFiltro);
+      const chk0 = document.getElementById('chkMostrarNivel0');
+      if (chk0) chk0.addEventListener('change', aplicarFiltro);
+      const chk1 = document.getElementById('chkMostrarNivel1');
+      if (chk1) chk1.addEventListener('change', aplicarFiltro);
+      const chk2 = document.getElementById('chkMostrarNivel2');
+      if (chk2) chk2.addEventListener('change', aplicarFiltro);
+      const chk3 = document.getElementById('chkMostrarNivel3');
+      if (chk3) chk3.addEventListener('change', aplicarFiltro);
 
       /* ==================================================
          3) Botones Expandir / Colapsar (nodos + recursivo)
@@ -445,14 +454,18 @@
           }
         });
       }
-      document.getElementById('expandirTodo').addEventListener('click', expandirTodo);
-      document.getElementById('colapsarTodo').addEventListener('click', colapsarTodo);
-      document.getElementById('btnRefrescar').addEventListener('click', loadData);
+      const btnExp = document.getElementById('expandirTodo');
+      if (btnExp) btnExp.addEventListener('click', expandirTodo);
+      const btnCol = document.getElementById('colapsarTodo');
+      if (btnCol) btnCol.addEventListener('click', colapsarTodo);
+      const btnRef = document.getElementById('btnRefrescar');
+      if (btnRef) btnRef.addEventListener('click', loadData);
 
       /* ==================================================
          4) Exportar a Excel (solo filas visibles)
       ================================================== */
-      document.getElementById('btnExcel').addEventListener('click', () => {
+      const btnExcel = document.getElementById('btnExcel');
+      if (btnExcel) btnExcel.addEventListener('click', () => {
         const filasVisibles = [];
         const encabezados = Array.from(
           document.querySelectorAll('#sinoptico thead th')
@@ -618,10 +631,12 @@
         const thAct = document.getElementById('thActions');
         if (thAct) thAct.style.display = sessionStorage.getItem('sinopticoEdit') === 'true' ? '' : 'none';
         // Colapsar todo para que la recarga no expanda la tabla por defecto
-        colapsarTodo();
+        if (sinopticoElem) colapsarTodo();
           setTimeout(() => {
-            ajustarIndentacion();
-            applyColumnVisibility();
+            if (sinopticoElem) {
+              ajustarIndentacion();
+              applyColumnVisibility();
+            }
             expandedIds.forEach(id => {
               showChildren(id);
               const btn = document.querySelector(`#sinoptico tbody tr[data-id="${id}"] .toggle-btn`);
@@ -631,7 +646,7 @@
                 btn.setAttribute('aria-expanded', 'true');
               }
             });
-            aplicarFiltro();
+            if (sinopticoElem) aplicarFiltro();
             const sel = sessionStorage.getItem('maestroSelectedNumber');
             if (sel) {
               highlightRow(sel);
@@ -642,9 +657,11 @@
 
 
       function loadData() {
-        const expandedIds = Array.from(
-          document.querySelectorAll('#sinoptico tbody .toggle-btn[data-expanded="true"]')
-        ).map(btn => btn.closest('tr').getAttribute('data-id'));
+        const expandedIds = sinopticoElem
+          ? Array.from(
+              document.querySelectorAll('#sinoptico tbody .toggle-btn[data-expanded="true"]')
+            ).map(btn => btn.closest('tr').getAttribute('data-id'))
+          : [];
 
         if (fs && jsonFile) {
           try {
@@ -664,7 +681,9 @@
           sinopticoData = stored ? JSON.parse(stored) : generarDatosIniciales();
         }
 
-        procesarDatos(sinopticoData, expandedIds);
+        if (sinopticoElem) {
+          procesarDatos(sinopticoData, expandedIds);
+        }
       }
 
       // Llamo inmediatamente a loadData()
@@ -683,12 +702,12 @@
           if (!agrupadoPorPadre[padre]) agrupadoPorPadre[padre] = [];
           agrupadoPorPadre[padre].push(fila);
         });
-        // b) Ordenar cada grupo según Secuencia
+        // b) Ordenar cada grupo por Descripción (alfanumérico, sin distinguir mayúsculas)
         Object.keys(agrupadoPorPadre).forEach(key => {
           agrupadoPorPadre[key].sort((a, b) => {
-            const sa = parseInt(a.Secuencia) || 0;
-            const sb = parseInt(b.Secuencia) || 0;
-            return sa - sb;
+            const da = (a['Descripción'] || '').toString().toLowerCase();
+            const db = (b['Descripción'] || '').toString().toLowerCase();
+            return da.localeCompare(db, undefined, { numeric: true, sensitivity: 'base' });
           });
         });
 

--- a/sinoptico-edit.js
+++ b/sinoptico-edit.js
@@ -18,7 +18,6 @@ document.addEventListener('DOMContentLoaded', () => {
     if (!window.SinopticoEditor || !SinopticoEditor.getNodes) return;
     const nodes = SinopticoEditor.getNodes();
     const clients = nodes.filter(n => (n.Tipo || '').toLowerCase() === 'cliente');
-    const prodParents = nodes.filter(n => ['pieza final','producto'].includes((n.Tipo||'').toLowerCase()) || (n.Tipo||'').toLowerCase() === 'cliente');
     const subParentsList = nodes.filter(n => ['pieza final','producto','subensamble'].includes((n.Tipo||'').toLowerCase()));
 
     function populate(sel, list) {
@@ -35,6 +34,12 @@ document.addEventListener('DOMContentLoaded', () => {
     populate(prodClient, clients);
     populate(subParent, subParentsList);
     populate(insParent, subParentsList);
+
+    const hasProducts = subParentsList.length > 0;
+    const sBtn = sForm.querySelector('button[type="submit"]');
+    const iBtn = iForm.querySelector('button[type="submit"]');
+    if (sBtn) sBtn.disabled = !hasProducts;
+    if (iBtn) iBtn.disabled = !hasProducts;
   }
 
   function askChildren(parentId) {
@@ -68,9 +73,8 @@ document.addEventListener('DOMContentLoaded', () => {
     e.preventDefault();
     const parent = prodClient.value;
     const desc = document.getElementById('prodDesc').value.trim();
-    const seq = document.getElementById('prodSeq').value.trim();
     if (!desc) return;
-    const id = SinopticoEditor.addNode({ ParentID: parent, Tipo: 'Pieza final', Secuencia: seq, Descripción: desc });
+    const id = SinopticoEditor.addNode({ ParentID: parent, Tipo: 'Pieza final', Descripción: desc });
     pForm.reset();
     fillOptions();
     if (window.mostrarMensaje)
@@ -82,9 +86,12 @@ document.addEventListener('DOMContentLoaded', () => {
     e.preventDefault();
     const parent = subParent.value;
     const desc = document.getElementById('subDesc').value.trim();
-    const seq = document.getElementById('subSeq').value.trim();
+    if (!parent) {
+      if (window.mostrarMensaje) window.mostrarMensaje('Seleccione un padre', 'warning');
+      return;
+    }
     if (!desc) return;
-    const id = SinopticoEditor.addNode({ ParentID: parent, Tipo: 'Subensamble', Secuencia: seq, Descripción: desc });
+    const id = SinopticoEditor.addNode({ ParentID: parent, Tipo: 'Subensamble', Descripción: desc });
     sForm.reset();
     fillOptions();
     if (window.mostrarMensaje)
@@ -96,10 +103,13 @@ document.addEventListener('DOMContentLoaded', () => {
     e.preventDefault();
     const parent = insParent.value;
     const desc = document.getElementById('insDesc').value.trim();
-    const seq = document.getElementById('insSeq').value.trim();
     const code = document.getElementById('insCode').value.trim();
+    if (!parent) {
+      if (window.mostrarMensaje) window.mostrarMensaje('Seleccione un padre', 'warning');
+      return;
+    }
     if (!desc) return;
-    SinopticoEditor.addNode({ ParentID: parent, Tipo: 'Insumo', Secuencia: seq, Descripción: desc, Código: code });
+    SinopticoEditor.addNode({ ParentID: parent, Tipo: 'Insumo', Descripción: desc, Código: code });
     iForm.reset();
     fillOptions();
     if (window.mostrarMensaje)

--- a/sinoptico.html
+++ b/sinoptico.html
@@ -21,8 +21,7 @@
     <button id="toggleTheme">🌙</button>
   </nav>
   <h1>Sinóptico de Producto Barack</h1>
-  <button id="sinopticoEditBtn" class="edit-button">Editar</button>
-  <div id="sinopticoAdmin" class="sinoptico-admin">
+  <div id="sinopticoAdmin" class="sinoptico-admin hidden">
     <select id="newParent"></select>
     <select id="newTipo">
       <option value="Producto">Producto</option>
@@ -129,76 +128,5 @@
   <script src="auth.js"></script>
   <script src="theme.js" defer></script>
   <script src="renderer.js" defer></script>
-  <script>
-    document.addEventListener('DOMContentLoaded', () => {
-      const editBtn = document.getElementById('sinopticoEditBtn');
-      const admin = document.getElementById('sinopticoAdmin');
-      function update() {
-        const logged = sessionStorage.getItem('isAdmin') === 'true';
-        const editing = sessionStorage.getItem('sinopticoEdit') === 'true';
-        editBtn.style.display = logged ? 'inline-block' : 'none';
-        admin.classList.toggle('hidden', !(logged && editing));
-        editBtn.textContent = editing ? 'Salir de edición' : 'Editar';
-      }
-      editBtn.addEventListener('click', () => {
-        const editing = sessionStorage.getItem('sinopticoEdit') === 'true';
-        if (editing) sessionStorage.removeItem('sinopticoEdit');
-        else sessionStorage.setItem('sinopticoEdit', 'true');
-        update();
-        document.dispatchEvent(new CustomEvent('sinoptico-mode'));
-      });
-      const parentSel = document.getElementById('newParent');
-      const tipoSel = document.getElementById('newTipo');
-      const seqInput = document.getElementById('newSecuencia');
-      const descInput = document.getElementById('newDesc');
-      const delSel = document.getElementById('deleteNode');
-
-      function fillOptions() {
-        if (!window.SinopticoEditor || !window.SinopticoEditor.getNodes) return;
-        const nodes = window.SinopticoEditor.getNodes();
-        parentSel.innerHTML = '<option value="">(raíz)</option>';
-        delSel.innerHTML = '<option value="">Seleccione nodo...</option>';
-        nodes.forEach(n => {
-          const txt = `${n.ID} - ${(n['Descripción'] || '').toString()}`;
-          const opt1 = document.createElement('option');
-          opt1.value = n.ID;
-          opt1.textContent = txt;
-          parentSel.appendChild(opt1);
-          const opt2 = document.createElement('option');
-          opt2.value = n.ID;
-          opt2.textContent = txt;
-          delSel.appendChild(opt2);
-        });
-      }
-
-      document.getElementById('addRow').addEventListener('click', () => {
-        const desc = descInput.value.trim();
-        if (!desc) return;
-        if (window.SinopticoEditor) {
-          window.SinopticoEditor.addNode({
-            ParentID: parentSel.value,
-            Tipo: tipoSel.value,
-            Secuencia: seqInput.value,
-            Descripción: desc
-          });
-          descInput.value = '';
-          seqInput.value = '';
-          fillOptions();
-        }
-      });
-
-      document.getElementById('deleteTree').addEventListener('click', () => {
-        const id = delSel.value;
-        if (id && window.SinopticoEditor) {
-          window.SinopticoEditor.deleteSubtree(id);
-          fillOptions();
-        }
-      });
-
-      document.addEventListener('sinoptico-mode', fillOptions);
-      fillOptions();
-      update();
-    });
-  </script>
 </body>
 </html>

--- a/sinoptico_edit.html
+++ b/sinoptico_edit.html
@@ -27,7 +27,6 @@
     <form id="productForm" class="node-form">
       <h2>Agregar producto</h2>
       <select id="prodClient"></select>
-      <input type="text" id="prodSeq" placeholder="Secuencia" />
       <input type="text" id="prodDesc" placeholder="Descripción" required />
       <button type="submit">Agregar</button>
     </form>
@@ -35,7 +34,6 @@
     <form id="subForm" class="node-form">
       <h2>Agregar subensamble</h2>
       <select id="subParent"></select>
-      <input type="text" id="subSeq" placeholder="Secuencia" />
       <input type="text" id="subDesc" placeholder="Descripción" required />
       <button type="submit">Agregar</button>
     </form>
@@ -43,7 +41,6 @@
     <form id="insForm" class="node-form">
       <h2>Agregar insumo</h2>
       <select id="insParent"></select>
-      <input type="text" id="insSeq" placeholder="Secuencia" />
       <input type="text" id="insDesc" placeholder="Descripción" required />
       <input type="text" id="insCode" placeholder="Código" />
       <button type="submit">Agregar</button>


### PR DESCRIPTION
## Summary
- hide editing UI in `sinoptico.html`
- sort nodes by description when building table
- guard event listeners if page elements are missing
- load table data even without DOM present
- simplify `sinoptico_edit.html` forms and validate parent selection

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684b265742f8832fa3f76ace014433d7