### PR TITLE
Mejora carteles de edición de sinóptico

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ The page loads [SheetJS](https://sheetjs.com/) and [Fuse.js](https://fusejs.io/)
 
 ## Node testing
 
-Running the project in a browser is enough to use the page. Optionally you can run an automated test that executes `maestro.js` under Node using JSDOM. The tests rely on `jsdom-global`, `jsdom` and `fuse.js`, which `npm install` will download for you. Install the dev dependencies once with:
+Running the project in a browser is enough to use the page. Optionally you can run an automated test that executes `maestro.js` under Node using JSDOM. The tests rely on `jsdom-global`, `jsdom` and `fuse.js`, which `npm install` will download for you. **Make sure to run `npm install` once before executing the tests**:
 
 ```bash
 npm install

--- a/sinoptico-edit.js
+++ b/sinoptico-edit.js
@@ -53,7 +53,8 @@ document.addEventListener('DOMContentLoaded', () => {
         SinopticoEditor.addNode({ ParentID: parentId, Tipo: 'Insumo', Descripción: desc });
       } else {
         const id = SinopticoEditor.addNode({ ParentID: parentId, Tipo: 'Subensamble', Descripción: desc });
-        if (confirm('¿Agregar hijos para ' + desc + '?')) askChildren(id);
+        if (confirm('¿Desea agregar subelementos a "' + desc + '"? (Aceptar=Sí / Cancelar=No)'))
+          askChildren(id);
       }
     }
   }
@@ -77,9 +78,14 @@ document.addEventListener('DOMContentLoaded', () => {
     const id = SinopticoEditor.addNode({ ParentID: parent, Tipo: 'Pieza final', Descripción: desc });
     pForm.reset();
     fillOptions();
-    if (window.mostrarMensaje)
-      window.mostrarMensaje('Producto agregado exitosamente!', 'success');
-    if (confirm('¿Desea agregar subelementos al producto?')) askChildren(id);
+    if (confirm('¿Desea agregar subproductos? (Aceptar=Sí / Cancelar=No)')) {
+      askChildren(id);
+      if (window.mostrarMensaje)
+        window.mostrarMensaje('Producto y subproductos agregados!', 'success');
+    } else {
+      if (window.mostrarMensaje)
+        window.mostrarMensaje('Producto agregado exitosamente!', 'success');
+    }
   });
 
   sForm.addEventListener('submit', e => {
@@ -94,9 +100,14 @@ document.addEventListener('DOMContentLoaded', () => {
     const id = SinopticoEditor.addNode({ ParentID: parent, Tipo: 'Subensamble', Descripción: desc });
     sForm.reset();
     fillOptions();
-    if (window.mostrarMensaje)
-      window.mostrarMensaje('Subensamble agregado exitosamente!', 'success');
-    if (confirm('¿Agregar subelementos a este subensamble?')) askChildren(id);
+    if (confirm('¿Agregar subelementos a este subensamble? (Aceptar=Sí / Cancelar=No)')) {
+      askChildren(id);
+      if (window.mostrarMensaje)
+        window.mostrarMensaje('Subensamble y subelementos agregados!', 'success');
+    } else {
+      if (window.mostrarMensaje)
+        window.mostrarMensaje('Subensamble agregado exitosamente!', 'success');
+    }
   });
 
   iForm.addEventListener('submit', e => {


### PR DESCRIPTION
## Summary
- show custom confirmation messages when adding subproducts
- display success notices only after user chooses not to add more items
- clarify prompts when adding nested nodes
- document that `npm install` must run before `npm test`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684b28ff80d4832f81f032f0512427e0