### PR TITLE
Implement separate creation page

### DIFF
--- a/sinoptico-create.js
+++ b/sinoptico-create.js
@@ -1,0 +1,173 @@
+document.addEventListener('DOMContentLoaded', () => {
+  if (sessionStorage.getItem('isAdmin') !== 'true') {
+    alert('Debe iniciar sesión para editar');
+    location.href = 'login.html';
+    return;
+  }
+
+  sessionStorage.setItem('sinopticoEdit', 'true');
+  document.dispatchEvent(new Event('sinoptico-mode'));
+
+  const level = document.getElementById('levelSelect');
+  const clientForm = document.getElementById('clientForm');
+  const productForm = document.getElementById('productForm');
+  const subForm = document.getElementById('subForm');
+  const insForm = document.getElementById('insForm');
+  const prodClient = document.getElementById('prodClient');
+  const subParent = document.getElementById('subParent');
+  const insParent = document.getElementById('insParent');
+  const childContainer = document.getElementById('childContainer');
+
+  function hideAll() {
+    [clientForm, productForm, subForm, insForm].forEach(f => f.classList.add('hidden'));
+  }
+
+  level.addEventListener('change', () => {
+    hideAll();
+    switch (level.value) {
+      case 'Cliente':
+        clientForm.classList.remove('hidden');
+        break;
+      case 'Producto':
+        productForm.classList.remove('hidden');
+        fillOptions();
+        break;
+      case 'Subproducto':
+        subForm.classList.remove('hidden');
+        fillOptions();
+        break;
+      case 'Insumo':
+        insForm.classList.remove('hidden');
+        fillOptions();
+        break;
+    }
+  });
+
+  document.querySelectorAll('.cancelBtn').forEach(btn => {
+    btn.addEventListener('click', () => {
+      hideAll();
+      level.value = '';
+    });
+  });
+
+  function fillOptions() {
+    if (!window.SinopticoEditor || !SinopticoEditor.getNodes) return;
+    const nodes = SinopticoEditor.getNodes();
+    const clients = nodes.filter(n => (n.Tipo || '').toLowerCase() === 'cliente');
+    const parents = nodes.filter(n => ['pieza final','producto','subensamble'].includes((n.Tipo||'').toLowerCase()));
+
+    prodClient.innerHTML = '';
+    clients.forEach(n => {
+      const opt = document.createElement('option');
+      opt.value = n.ID;
+      opt.textContent = n['Descripción'] || '';
+      prodClient.appendChild(opt);
+    });
+
+    [subParent, insParent].forEach(sel => {
+      if (!sel) return;
+      sel.innerHTML = '';
+      parents.forEach(n => {
+        const opt = document.createElement('option');
+        opt.value = n.ID;
+        opt.textContent = `${n.ID} - ${n['Descripción'] || ''}`;
+        sel.appendChild(opt);
+      });
+    });
+  }
+
+  clientForm.addEventListener('submit', e => {
+    e.preventDefault();
+    const desc = document.getElementById('clientDesc').value.trim();
+    if (!desc) return;
+    SinopticoEditor.addNode({ Tipo: 'Cliente', Descripción: desc, Cliente: desc });
+    clientForm.reset();
+    hideAll();
+    level.value = '';
+  });
+
+  productForm.addEventListener('submit', e => {
+    e.preventDefault();
+    const parent = prodClient.value;
+    const desc = document.getElementById('prodDesc').value.trim();
+    if (!desc) return;
+    const id = SinopticoEditor.addNode({ ParentID: parent, Tipo: 'Pieza final', Descripción: desc });
+    productForm.reset();
+    if (confirm('¿Va a incluir subproductos o insumos?')) {
+      level.value = 'Subproducto';
+      level.dispatchEvent(new Event('change'));
+      subParent.value = id;
+    } else {
+      hideAll();
+      level.value = '';
+    }
+  });
+
+  let lastSubId = null;
+
+  subForm.addEventListener('submit', e => {
+    e.preventDefault();
+    const parent = subParent.value;
+    const desc = document.getElementById('subDesc').value.trim();
+    if (!desc) return;
+    lastSubId = SinopticoEditor.addNode({ ParentID: parent, Tipo: 'Subensamble', Descripción: desc });
+    subForm.reset();
+    fillOptions();
+  });
+
+  document.getElementById('addChildSub').addEventListener('click', () => {
+    if (!lastSubId) return;
+    createSubChildForm(lastSubId);
+  });
+
+  document.getElementById('addChildIns').addEventListener('click', () => {
+    if (!lastSubId) return;
+    createInsChildForm(lastSubId);
+  });
+
+  function createSubChildForm(pid) {
+    const form = document.createElement('form');
+    form.className = 'node-form child-form';
+    form.innerHTML = `
+      <input type="text" placeholder="Descripción" required>
+      <div class="form-actions">
+        <button type="submit">Guardar</button>
+        <button type="button" class="cancelBtn">Cancelar</button>
+      </div>`;
+    childContainer.appendChild(form);
+    form.querySelector('.cancelBtn').addEventListener('click', () => form.remove());
+    form.addEventListener('submit', ev => {
+      ev.preventDefault();
+      const desc = form.querySelector('input').value.trim();
+      if (!desc) return;
+      SinopticoEditor.addNode({ ParentID: pid, Tipo: 'Subensamble', Descripción: desc });
+      form.remove();
+    });
+  }
+
+  function createInsChildForm(pid) {
+    const form = document.createElement('form');
+    form.className = 'node-form child-form';
+    form.innerHTML = `
+      <input type="text" placeholder="Descripción" required>
+      <input type="text" placeholder="Código">
+      <div class="form-actions">
+        <button type="submit">Guardar</button>
+        <button type="button" class="cancelBtn">Cancelar</button>
+      </div>`;
+    childContainer.appendChild(form);
+    form.querySelector('.cancelBtn').addEventListener('click', () => form.remove());
+    form.addEventListener('submit', ev => {
+      ev.preventDefault();
+      const inputs = form.querySelectorAll('input');
+      const desc = inputs[0].value.trim();
+      const code = inputs[1].value.trim();
+      if (!desc) return;
+      SinopticoEditor.addNode({ ParentID: pid, Tipo: 'Insumo', Descripción: desc, Código: code });
+      form.remove();
+    });
+  }
+
+  document.addEventListener('sinoptico-mode', fillOptions);
+  setTimeout(fillOptions, 300);
+});

--- a/sinoptico_crear.html
+++ b/sinoptico_crear.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Crear elemento</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <nav class="main-nav">
+    <a href="index.html">Inicio</a>
+    <a href="sinoptico.html">Sinóptico</a>
+    <a href="sinoptico_edit.html">Editar sinóptico</a>
+    <button id="toggleTheme">🌙</button>
+  </nav>
+  <h1>Crear elemento del sinóptico</h1>
+  <div id="mensaje"></div>
+  <div class="editor-container">
+    <label for="levelSelect">Tipo de elemento</label>
+    <select id="levelSelect">
+      <option value="">Seleccione</option>
+      <option value="Cliente">Cliente</option>
+      <option value="Producto">Producto</option>
+      <option value="Subproducto">Subproducto</option>
+      <option value="Insumo">Insumo</option>
+    </select>
+  </div>
+  <form id="clientForm" class="node-form hidden">
+    <h2>Nuevo cliente</h2>
+    <input type="text" id="clientDesc" placeholder="Nombre" required>
+    <div class="form-actions">
+      <button type="submit">Guardar</button>
+      <button type="button" class="cancelBtn">Cancelar</button>
+    </div>
+  </form>
+  <form id="productForm" class="node-form hidden">
+    <h2>Nuevo producto</h2>
+    <select id="prodClient"></select>
+    <input type="text" id="prodDesc" placeholder="Descripción" required>
+    <div class="form-actions">
+      <button type="submit">Guardar</button>
+      <button type="button" class="cancelBtn">Cancelar</button>
+    </div>
+  </form>
+  <form id="subForm" class="node-form hidden">
+    <h2>Nuevo subproducto</h2>
+    <select id="subParent"></select>
+    <input type="text" id="subDesc" placeholder="Descripción" required>
+    <div class="form-actions">
+      <button type="submit">Guardar</button>
+      <button type="button" id="addChildSub">Agregar subproducto hijo</button>
+      <button type="button" id="addChildIns">Agregar insumo</button>
+      <button type="button" class="cancelBtn">Cancelar</button>
+    </div>
+    <div id="childContainer"></div>
+  </form>
+  <form id="insForm" class="node-form hidden">
+    <h2>Nuevo insumo</h2>
+    <select id="insParent"></select>
+    <input type="text" id="insDesc" placeholder="Descripción" required>
+    <input type="text" id="insCode" placeholder="Código">
+    <div class="form-actions">
+      <button type="submit">Guardar</button>
+      <button type="button" class="cancelBtn">Cancelar</button>
+    </div>
+  </form>
+  <a href="sinoptico_edit.html" class="home-button">Volver al listado</a>
+  <script src="auth.js"></script>
+  <script src="theme.js" defer></script>
+  <script src="renderer.js"></script>
+  <script src="sinoptico-create.js"></script>
+</body>
+</html>

--- a/sinoptico_edit.html
+++ b/sinoptico_edit.html
@@ -24,30 +24,6 @@
     <button id="menuModificar">Modificar</button>
   </div>
 
-  <div id="crearMenu" class="editor-container hidden">
-    <div class="node-form">
-      <button id="btnAddClient">Agregar cliente</button>
-      <button id="btnAddProduct">Agregar producto</button>
-      <button id="volverMenu">Volver</button>
-    </div>
-
-    <form id="clientForm" class="node-form hidden">
-      <h2>Nuevo cliente</h2>
-      <input type="text" id="clientDesc" placeholder="Nombre" required />
-      <button type="submit">Guardar</button>
-    </form>
-
-    <div id="productStep" class="hidden">
-      <button id="addProductBtn">+ Producto</button>
-    </div>
-
-    <form id="productForm" class="node-form hidden">
-      <h2>Nuevo producto</h2>
-      <select id="prodClient"></select>
-      <input type="text" id="prodDesc" placeholder="Descripción" required />
-      <button type="submit">Guardar</button>
-    </form>
-  </div>
 
   <div class="tabla-contenedor">
     <table id="sinoptico">

--- a/styles.css
+++ b/styles.css
@@ -969,6 +969,11 @@ select {
   background-color: var(--color-primary-hover);
 }
 
+.form-actions {
+  display: flex;
+  gap: 8px;
+}
+
 .editor-menu {
   width: 95%;
   margin: 20px auto;

--- a/tree-editor.js
+++ b/tree-editor.js
@@ -8,77 +8,10 @@ document.addEventListener('DOMContentLoaded', () => {
   sessionStorage.setItem('sinopticoEdit', 'true');
   document.dispatchEvent(new Event('sinoptico-mode'));
 
-  const mainMenu = document.getElementById('mainMenu');
-  const crearMenu = document.getElementById('crearMenu');
-  const clientForm = document.getElementById('clientForm');
-  const productForm = document.getElementById('productForm');
-  const productStep = document.getElementById('productStep');
-  const prodClient = document.getElementById('prodClient');
-
-  function show(el) { if (el) el.classList.remove('hidden'); }
-  function hide(el) { if (el) el.classList.add('hidden'); }
-
-  function backToMain() {
-    hide(crearMenu); hide(clientForm); hide(productForm); hide(productStep);
-    show(mainMenu);
-  }
-
-  document.getElementById('menuCrear').addEventListener('click', () => {
-    fillOptions();
-    hide(mainMenu);
-    show(crearMenu);
-  });
-  document.getElementById('volverMenu').addEventListener('click', backToMain);
-
-  document.getElementById('btnAddClient').addEventListener('click', () => {
-    hide(productStep); hide(productForm); show(clientForm);
-  });
-
-  document.getElementById('btnAddProduct').addEventListener('click', () => {
-    hide(clientForm); hide(productForm); show(productStep);
-  });
-
-  document.getElementById('addProductBtn').addEventListener('click', () => {
-    if (confirm('¿Vas a agregar insumos, subproductos o subensamble a este producto?')) {
-      hide(productStep);
-      show(productForm);
-    } else {
-      backToMain();
-    }
-  });
-
-  clientForm.addEventListener('submit', e => {
-    e.preventDefault();
-    const desc = document.getElementById('clientDesc').value.trim();
-    if (!desc) return;
-    SinopticoEditor.addNode({ Tipo: 'Cliente', Descripción: desc, Cliente: desc });
-    clientForm.reset();
-    backToMain();
-  });
-
-  productForm.addEventListener('submit', e => {
-    e.preventDefault();
-    const parent = prodClient.value;
-    const desc = document.getElementById('prodDesc').value.trim();
-    if (!desc) return;
-    SinopticoEditor.addNode({ ParentID: parent, Tipo: 'Pieza final', Descripción: desc });
-    productForm.reset();
-    backToMain();
-  });
-
-  function fillOptions() {
-    if (!window.SinopticoEditor || !SinopticoEditor.getNodes) return;
-    const nodes = SinopticoEditor.getNodes();
-    const clients = nodes.filter(n => (n.Tipo || '').toLowerCase() === 'cliente');
-    prodClient.innerHTML = '';
-    clients.forEach(n => {
-      const opt = document.createElement('option');
-      opt.value = n.ID;
-      opt.textContent = n['Descripción'] || '';
-      prodClient.appendChild(opt);
+  const crear = document.getElementById('menuCrear');
+  if (crear) {
+    crear.addEventListener('click', () => {
+      location.href = 'sinoptico_crear.html';
     });
   }
-
-  document.addEventListener('sinoptico-mode', fillOptions);
-  setTimeout(fillOptions, 300);
 });


### PR DESCRIPTION
## Summary
- split creation of tree elements into dedicated `sinoptico_crear.html`
- add script `sinoptico-create.js` for form logic and nested subproduct handling
- simplify `tree-editor.js` to act as a menu entry and redirect to the new page
- remove old creation forms from `sinoptico_edit.html`
- style adjustments for new form actions

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684b7161e7d8832f94e2f38df406b575