### PR TITLE
Add search UI for editing view

### DIFF
--- a/renderer.js
+++ b/renderer.js
@@ -135,6 +135,13 @@
           if (item.text) keywords.push(item.text.toString().trim());
         });
 
+        const isEdit = sessionStorage.getItem('sinopticoEdit') === 'true';
+
+        if (isEdit && keywords.length === 0) {
+          todasFilas.forEach(tr => (tr.style.display = 'none'));
+          return;
+        }
+
         if (keywords.length === 0) {
           // Mostrar/ocultar según nivel, sin filtro de texto
           todasFilas.forEach(tr => {

--- a/sinoptico_edit.html
+++ b/sinoptico_edit.html
@@ -24,9 +24,48 @@
     <button id="menuModificar">Modificar</button>
   </div>
 
-
   <div class="tabla-contenedor">
-    <table id="sinoptico">
+
+  <div class="filtro-contenedor" id="filtrosSinoptico">
+    <div class="filtros-texto">
+      <label for="filtroInsumo">🔍 Buscar Insumo:</label>
+      <div class="search-wrap">
+        <input type="text" id="filtroInsumo" placeholder="Ej: Hilo 120, Corte 1.." />
+        <button id="clearSearch" aria-label="Limpiar búsqueda">×</button>
+        <ul id="sinopticoSuggestions" class="suggestions-list"></ul>
+      </div>
+      <div id="selectedItems" class="chips"></div>
+
+      <div class="filtro-opciones">
+        <input type="checkbox" id="chkIncluirAncestros" checked />
+        <label for="chkIncluirAncestros">Incluir jerarquía (padres)</label>
+      </div>
+      <div class="filtro-opciones">
+        <input type="checkbox" id="chkMostrarNivel0" checked />
+        <label for="chkMostrarNivel0">Mostrar Nivel 0</label>
+      </div>
+      <div class="filtro-opciones">
+        <input type="checkbox" id="chkMostrarNivel1" checked />
+        <label for="chkMostrarNivel1">Mostrar Producto (nivel 1)</label>
+      </div>
+      <div class="filtro-opciones">
+        <input type="checkbox" id="chkMostrarNivel2" checked />
+        <label for="chkMostrarNivel2">Mostrar Subensamble (nivel 2)</label>
+      </div>
+      <div class="filtro-opciones">
+        <input type="checkbox" id="chkMostrarNivel3" checked />
+        <label for="chkMostrarNivel3">Mostrar Insumo (nivel 3)</label>
+      </div>
+    </div>
+
+    <button id="expandirTodo" aria-label="Expandir todas las filas">Expandir Todo</button>
+    <button id="colapsarTodo" aria-label="Colapsar todas las filas">Colapsar Todo</button>
+    <button id="btnRefrescar" aria-label="Recargar datos">Refrescar</button>
+    <button id="btnExcel" aria-label="Exportar la tabla visible a Excel">Exportar a Excel</button>
+  </div>
+
+
+  <table id="sinoptico">
       <thead>
         <tr>
           <th>Item</th>

--- a/styles.css
+++ b/styles.css
@@ -983,14 +983,16 @@ select {
 }
 
 .editor-menu button {
-  padding: 8px 16px;
-  background-color: var(--color-primary);
+  padding: 10px 18px;
+  background: linear-gradient(135deg, var(--color-accent), var(--color-primary));
   color: var(--color-light);
   border: none;
-  border-radius: 4px;
+  border-radius: 6px;
   cursor: pointer;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+  transition: transform 0.2s;
 }
 
 .editor-menu button:hover {
-  background-color: var(--color-primary-hover);
+  transform: scale(1.05);
 }


### PR DESCRIPTION
## Summary
- add fuzzy search interface to `sinoptico_edit.html`
- tweak editor buttons with gradient and hover scale
- hide rows when editing view has no search filter

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684b7622baa0832fa14154b25677f9f8