### PR TITLE
Add admin menu page

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The list is normally stored in your browser's `localStorage`. When running in an
 - **Filtering** – search for text and control which hierarchy levels are visible.
 - **Expand/Collapse** – the tree of products can be expanded node by node or all at once.
 - **Manual refresh** – click the **Refrescar** button in `sinoptico.html` to reload data on demand.
-- **Editing modes** – once logged in you can edit the master list and the sinóptico using their respective **Editar** buttons. The product view is maintained through the interface at `sinoptico_edit.html`.
+- **Editing modes** – once logged in you can edit the master list and the sinóptico using their respective **Editar** buttons. The product view is maintained through the interface at `admin_menu.html`.
 - **Excel export** – visible rows can be saved as `sinoptico.xlsx`. The file
   downloads to your browser's default folder.
 - **Dynamic categories** – the master list starts empty and new document sections appear automatically when items are added.

--- a/admin_menu.html
+++ b/admin_menu.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Menú de administración</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <nav class="main-nav">
+    <a href="index.html">Inicio</a>
+    <a href="sinoptico.html">Sinóptico</a>
+    <a href="admin_menu.html" aria-current="page">Editar sinóptico</a>
+    <a href="listado_maestro.html">Listado maestro</a>
+    <button id="toggleTheme">🌙</button>
+  </nav>
+  <h1>Menú de administración del sinóptico</h1>
+  <div class="admin-menu">
+    <button id="menuCrear" onclick="location.href='sinoptico_crear.html'">Crear</button>
+    <button id="menuEliminar" onclick="location.href='sinoptico_eliminar.html'">Eliminar</button>
+    <button id="menuModificar" onclick="location.href='sinoptico_modificar.html'">Modificar</button>
+  </div>
+  <script src="auth.js"></script>
+  <script src="theme.js" defer></script>
+  <script src="tree-editor.js"></script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
       <nav class="main-nav">
           <a href="index.html" aria-current="page">Inicio</a>
           <a href="sinoptico.html">Sinóptico</a>
-          <a href="sinoptico_edit.html" id="editSinLink" style="display:none">Editar sinóptico</a>
+          <a href="admin_menu.html" id="editSinLink" style="display:none">Editar sinóptico</a>
           <a href="listado_maestro.html">Listado maestro</a>
           <a href="login.html" id="loginLink">Log in</a>
           <button id="toggleTheme">🌙</button>

--- a/sinoptico_crear.html
+++ b/sinoptico_crear.html
@@ -64,7 +64,7 @@
       <button type="button" class="cancelBtn">Cancelar</button>
     </div>
   </form>
-  <a href="sinoptico_edit.html" class="home-button">Volver al listado</a>
+  <a href="admin_menu.html" class="home-button">Volver al listado</a>
   <script src="auth.js"></script>
   <script src="theme.js" defer></script>
   <script src="renderer.js"></script>

--- a/sinoptico_eliminar.html
+++ b/sinoptico_eliminar.html
@@ -32,7 +32,7 @@
       <ul id="resultsInsumo"></ul>
     </div>
   </section>
-  <a href="sinoptico_edit.html" class="home-button">Volver</a>
+  <a href="admin_menu.html" class="home-button">Volver</a>
   <script src="auth.js"></script>
   <script src="theme.js" defer></script>
   <script src="renderer.js"></script>

--- a/sinoptico_modificar.html
+++ b/sinoptico_modificar.html
@@ -27,7 +27,7 @@
     </thead>
     <tbody></tbody>
   </table>
-  <a href="sinoptico_edit.html" class="home-button">Volver</a>
+  <a href="admin_menu.html" class="home-button">Volver</a>
   <script src="auth.js"></script>
   <script src="theme.js" defer></script>
   <script src="renderer.js"></script>

--- a/styles.css
+++ b/styles.css
@@ -996,3 +996,28 @@ select {
 .editor-menu button:hover {
   transform: scale(1.05);
 }
+
+/* Admin menu buttons */
+.admin-menu {
+  width: 80%;
+  margin: 40px auto;
+  display: flex;
+  justify-content: center;
+  gap: 20px;
+}
+
+.admin-menu button {
+  padding: 16px 24px;
+  font-size: 1.2rem;
+  background: linear-gradient(135deg, var(--color-accent), var(--color-primary));
+  color: var(--color-light);
+  border: none;
+  border-radius: 8px;
+  cursor: pointer;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+  transition: transform 0.2s;
+}
+
+.admin-menu button:hover {
+  transform: scale(1.05);
+}


### PR DESCRIPTION
## Summary
- create new **admin_menu.html** with navigation and buttons
- style new menu with `.admin-menu` rule
- adjust index navigation link
- update "Volver" links on edit pages
- mention admin menu in README

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684b7bfd92d8832f9aee251611a6c444