### PR TITLE
Add hierarchical tree with nested layout

### DIFF
--- a/sinoptico-create.js
+++ b/sinoptico-create.js
@@ -25,35 +25,68 @@ document.addEventListener('DOMContentLoaded', () => {
     const map = {};
     nodes.forEach(n => (map[n.ID] = Object.assign({ children: [] }, n)));
     nodes.forEach(n => {
-      if (n.ParentID && map[n.ParentID]) {
-        map[n.ParentID].children.push(map[n.ID]);
-      }
+      if (n.ParentID && map[n.ParentID]) map[n.ParentID].children.push(map[n.ID]);
     });
     const roots = nodes.filter(n => !n.ParentID).map(n => map[n.ID]);
-    const levels = [];
-    function traverse(node, depth) {
-      levels[depth] = levels[depth] || [];
-      levels[depth].push(node);
-      node.children.forEach(c => traverse(c, depth + 1));
-    }
-    roots.forEach(r => traverse(r, 0));
 
     preview.innerHTML = '';
-    levels.forEach(lv => {
-      const lvDiv = document.createElement('div');
-      lvDiv.className = 'tree-level';
-      lv.forEach(n => {
-        const nd = document.createElement('div');
-        nd.className = 'tree-node';
-        nd.textContent = n['Descripción'] || n.ID;
-        lvDiv.appendChild(nd);
-      });
-      preview.appendChild(lvDiv);
-    });
+    const rootList = document.createElement('ul');
+    rootList.className = 'tree-list';
+    roots.forEach(r => rootList.appendChild(buildItem(r)));
+    preview.appendChild(rootList);
+
+    function buildItem(node) {
+      const li = document.createElement('li');
+      const container = document.createElement('div');
+      container.className = 'tree-node';
+      const label = document.createElement('span');
+      label.textContent = node['Descripción'] || node.ID;
+      container.appendChild(label);
+
+      if ((node.Tipo || '').toLowerCase() !== 'insumo') {
+        const addSub = document.createElement('button');
+        addSub.textContent = '+S';
+        addSub.className = 'add-child-btn';
+        addSub.title = 'Agregar subproducto';
+        addSub.addEventListener('click', () => openSubForm(node.ID));
+        container.appendChild(addSub);
+
+        const addIns = document.createElement('button');
+        addIns.textContent = '+I';
+        addIns.className = 'add-child-btn';
+        addIns.title = 'Agregar insumo';
+        addIns.addEventListener('click', () => openInsForm(node.ID));
+        container.appendChild(addIns);
+      }
+
+      li.appendChild(container);
+      if (node.children && node.children.length) {
+        const ul = document.createElement('ul');
+        node.children.forEach(c => ul.appendChild(buildItem(c)));
+        li.appendChild(ul);
+      }
+      return li;
+    }
   }
 
   function hideAll() {
     [clientForm, productForm, subForm, insForm].forEach(f => f.classList.add('hidden'));
+  }
+
+  function openSubForm(pid) {
+    hideAll();
+    level.value = 'Subproducto';
+    subForm.classList.remove('hidden');
+    fillOptions();
+    if (pid) subParent.value = pid;
+  }
+
+  function openInsForm(pid) {
+    hideAll();
+    level.value = 'Insumo';
+    insForm.classList.remove('hidden');
+    fillOptions();
+    if (pid) insParent.value = pid;
   }
 
   level.addEventListener('change', () => {

--- a/styles.css
+++ b/styles.css
@@ -1024,22 +1024,43 @@ select {
 
 /* ========= Tree preview ========= */
 .tree-preview {
-  margin: 20px auto;
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
+  margin: 20px;
 }
 
-.tree-level {
-  display: flex;
-  justify-content: center;
-  gap: 12px;
+.tree-list,
+.tree-list ul {
+  list-style: none;
+  margin: 0;
+  padding-left: 20px;
+}
+
+.tree-list ul {
+  border-left: 1px dashed #ccc;
+  margin-left: 12px;
 }
 
 .tree-node {
-  padding: 6px 12px;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 8px;
   border: 1px solid #bbb;
   border-radius: 4px;
   background-color: var(--color-light);
   white-space: nowrap;
+}
+
+.add-child-btn {
+  margin-left: 4px;
+  padding: 0 4px;
+  font-size: 0.8rem;
+  background-color: var(--color-primary);
+  color: var(--color-light);
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.add-child-btn:hover {
+  background-color: var(--color-primary-hover);
 }


### PR DESCRIPTION
## Summary
- render the tree in `sinoptico-create.js` as nested lists instead of horizontal levels
- add small buttons for adding subproducts or insumos directly from the preview
- provide helpers to open forms with the parent already selected
- style `.tree-preview` for the new vertical layout

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684b8774941c832f905c1eac5de2807f