### PR TITLE
Enable quick product creation

### DIFF
--- a/sinoptico-create.js
+++ b/sinoptico-create.js
@@ -16,8 +16,17 @@ document.addEventListener('DOMContentLoaded', () => {
   const prodClient = document.getElementById('prodClient');
   const subParent = document.getElementById('subParent');
   const insParent = document.getElementById('insParent');
+  const addProductBtn = document.getElementById('addProductBtn');
   const childContainer = document.getElementById('childContainer');
   const preview = document.getElementById('treePreview');
+
+  let addAnotherProduct = false;
+  if (addProductBtn) {
+    addProductBtn.addEventListener('click', () => {
+      addAnotherProduct = true;
+      productForm.classList.remove('hidden');
+    });
+  }
 
   function renderTree() {
     if (!preview || !window.SinopticoEditor || !SinopticoEditor.getNodes) return;
@@ -129,7 +138,13 @@ document.addEventListener('DOMContentLoaded', () => {
     const id = SinopticoEditor.addNode({ ParentID: parent, Tipo: 'Pieza final', Descripción: desc });
     renderTree();
     productForm.reset();
-    if (confirm('¿Va a incluir subproductos o insumos?')) {
+    const addMore = addAnotherProduct || (e.submitter && e.submitter.id === 'addProductBtn');
+    addAnotherProduct = false;
+    if (addMore) {
+      productForm.classList.remove('hidden');
+      level.value = 'Producto';
+      fillOptions();
+    } else if (confirm('¿Va a incluir subproductos o insumos?')) {
       level.value = 'Subproducto';
       level.dispatchEvent(new Event('change'));
       subParent.value = id;

--- a/sinoptico_crear.html
+++ b/sinoptico_crear.html
@@ -39,6 +39,7 @@
     <input type="text" id="prodDesc" placeholder="Descripción" required>
     <div class="form-actions">
       <button type="submit">Guardar</button>
+      <button type="submit" id="addProductBtn" title="Agregar otro producto">➕</button>
       <button type="button" class="cancelBtn">Cancelar</button>
     </div>
   </form>

--- a/styles.css
+++ b/styles.css
@@ -965,6 +965,17 @@ select {
   border-radius: 4px;
   cursor: pointer;
 }
+.node-form #addProductBtn {
+  width: 32px;
+  padding: 4px;
+  font-size: 1.2rem;
+  line-height: 1;
+  border-radius: 50%;
+  background-color: var(--color-accent);
+}
+.node-form #addProductBtn:hover {
+  background-color: var(--color-accent-hover);
+}
 .node-form button:hover {
   background-color: var(--color-primary-hover);
 }


### PR DESCRIPTION
## Summary
- add a `➕` button to create more products without using the dropdown
- keep product form visible when the new button is used
- style the new icon-sized button

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684b851190ac832f92c5f6a793dd2fc3