### PR TITLE
Implement click overlay for tree nodes

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1075,3 +1075,27 @@ select {
 .add-child-btn:hover {
   background-color: var(--color-primary-hover);
 }
+
+.node-options {
+  position: absolute;
+  background-color: var(--color-light);
+  border: 1px solid #bbb;
+  border-radius: 4px;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.2);
+  padding: 4px;
+  z-index: 50;
+}
+
+.node-options button {
+  display: block;
+  width: 100%;
+  padding: 4px 8px;
+  background: none;
+  border: none;
+  text-align: left;
+  cursor: pointer;
+}
+
+.node-options button:hover {
+  background-color: #eee;
+}


### PR DESCRIPTION
## Summary
- allow clicking on tree nodes to show options overlay
- drop `+S` and `+I` buttons from tree view
- style `.node-options` menu
- ensure forms update overlay state and refresh tree

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c064e868c832f8de26fbe200c8037