### PR TITLE
Enhance dark mode and navigation transitions

### DIFF
--- a/admin_menu.html
+++ b/admin_menu.html
@@ -22,6 +22,7 @@
   </div>
   <script src="auth.js"></script>
   <script src="theme.js" defer></script>
+  <script src="smooth-nav.js" defer></script>
   <script src="tree-editor.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -34,6 +34,7 @@
       </main>
       <script src="auth.js"></script>
       <script src="theme.js" defer></script>
+      <script src="smooth-nav.js" defer></script>
       <script>
         document.addEventListener('DOMContentLoaded', () => {
           document.querySelector('main').classList.add('fade-in');

--- a/listado_maestro.html
+++ b/listado_maestro.html
@@ -65,6 +65,7 @@
     });
   </script>
   <script src="theme.js" defer></script>
+  <script src="smooth-nav.js" defer></script>
   <script src="https://cdn.jsdelivr.net/npm/fuse.js@6.6.2/dist/fuse.min.js"></script>
   <script src="maestro.js"></script>
 </body>

--- a/login.html
+++ b/login.html
@@ -40,6 +40,7 @@
 
   <script src="auth.js"></script>
   <script src="theme.js" defer></script>
+  <script src="smooth-nav.js" defer></script>
   <script>
     document.addEventListener('DOMContentLoaded', () => {
       const form = document.getElementById('loginForm');

--- a/sinoptico.html
+++ b/sinoptico.html
@@ -127,6 +127,7 @@
 
   <script src="auth.js"></script>
   <script src="theme.js" defer></script>
+  <script src="smooth-nav.js" defer></script>
   <script src="renderer.js" defer></script>
 </body>
 </html>

--- a/sinoptico_crear.html
+++ b/sinoptico_crear.html
@@ -69,6 +69,7 @@
   <a href="admin_menu.html" class="home-button">Volver al listado</a>
   <script src="auth.js"></script>
   <script src="theme.js" defer></script>
+  <script src="smooth-nav.js" defer></script>
   <script src="renderer.js"></script>
   <script src="sinoptico-create.js"></script>
 </body>

--- a/sinoptico_edit.html
+++ b/sinoptico_edit.html
@@ -89,6 +89,7 @@
 
   <script src="auth.js"></script>
   <script src="theme.js" defer></script>
+  <script src="smooth-nav.js" defer></script>
   <script src="renderer.js" defer></script>
   <script src="tree-editor.js" defer></script>
 </body>

--- a/sinoptico_eliminar.html
+++ b/sinoptico_eliminar.html
@@ -35,6 +35,7 @@
   <a href="admin_menu.html" class="home-button">Volver</a>
   <script src="auth.js"></script>
   <script src="theme.js" defer></script>
+  <script src="smooth-nav.js" defer></script>
   <script src="renderer.js"></script>
   <script src="sinoptico-delete.js"></script>
 </body>

--- a/sinoptico_modificar.html
+++ b/sinoptico_modificar.html
@@ -30,6 +30,7 @@
   <a href="admin_menu.html" class="home-button">Volver</a>
   <script src="auth.js"></script>
   <script src="theme.js" defer></script>
+  <script src="smooth-nav.js" defer></script>
   <script src="renderer.js"></script>
   <script src="sinoptico-modify.js"></script>
 </body>

--- a/smooth-nav.js
+++ b/smooth-nav.js
@@ -1,0 +1,19 @@
+// Add smooth page transitions
+window.addEventListener('DOMContentLoaded', () => {
+  document.body.classList.add('page-loaded');
+  document.querySelectorAll('a[href]').forEach(a => {
+    const url = a.getAttribute('href');
+    if (a.target === '_blank' || !url || url.startsWith('#') || url.startsWith('mailto:')) return;
+    a.addEventListener('click', evt => {
+      // only intercept left click without modifier keys
+      if (evt.button !== 0 || evt.metaKey || evt.ctrlKey || evt.shiftKey || evt.altKey) return;
+      evt.preventDefault();
+      document.body.classList.add('fade-out');
+      document.body.classList.remove('page-loaded');
+      const href = a.href;
+      setTimeout(() => {
+        window.location.href = href;
+      }, 200);
+    });
+  });
+});

--- a/styles.css
+++ b/styles.css
@@ -18,11 +18,13 @@
 }
 
 body.dark-mode {
-  --color-bg: #111;
+  --color-bg: #121212;
   --color-text: #e0e0e0;
-  --color-primary: #003366; /* tonos más oscuros para encabezados y botones */
-  --color-accent: #005a9c;  /* azul intenso para elementos destacados */
-  --color-surface-dark: #222;
+  --color-primary: #1e88e5;
+  --color-primary-hover: #1565c0;
+  --color-accent: #42a5f5;
+  --color-accent-hover: #2196f3;
+  --color-surface-dark: #1e1e1e;
 }
 
 /* mantener la hero de la página de inicio con sus colores originales */
@@ -52,6 +54,16 @@ body {
   padding: 60px 0 0 0;
   background-color: var(--color-bg);
   color: var(--color-text);
+  opacity: 0;
+  transition: opacity 0.3s ease-in-out;
+}
+
+body.page-loaded {
+  opacity: 1;
+}
+
+body.fade-out {
+  opacity: 0;
 }
 
 body.home {
@@ -570,6 +582,10 @@ body.dark-mode .fila-oper {
 
 .suggestions-list li:hover {
   background-color: #eee;
+}
+
+body.dark-mode .suggestions-list li:hover {
+  background-color: #333;
 }
 
 .filter-banner {

--- a/theme.js
+++ b/theme.js
@@ -2,7 +2,8 @@
 window.addEventListener('DOMContentLoaded', () => {
   const btn = document.getElementById('toggleTheme');
   if (!btn) return;
-  if (localStorage.getItem('theme') === 'dark') {
+  const saved = localStorage.getItem('theme');
+  if (saved === 'dark' || (!saved && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
     document.body.classList.add('dark-mode');
   }
   btn.addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- modernize the dark theme colors
- support automatic dark mode detection
- add page fade transitions via new `smooth-nav.js`
- include smooth navigation script on all HTML pages

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c0ae520f0832fa067364d8062d67a