### PR TITLE
Implement click overlay for tree nodes

### DIFF
--- a/sinoptico-create.js
+++ b/sinoptico-create.js
@@ -20,6 +20,8 @@ document.addEventListener('DOMContentLoaded', () => {
   const childContainer = document.getElementById('childContainer');
   const preview = document.getElementById('treePreview');
 
+  let optionsDiv = null;
+
   let addAnotherProduct = false;
   if (addProductBtn) {
     addProductBtn.addEventListener('click', () => {
@@ -28,8 +30,51 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   }
 
+  function createOptionsDiv() {
+    if (optionsDiv) return;
+    optionsDiv = document.createElement('div');
+    optionsDiv.className = 'node-options hidden';
+    optionsDiv.innerHTML = `
+      <button type="button" id="optAddSub">Agregar subproducto</button>
+      <button type="button" id="optAddIns">Agregar insumo</button>
+    `;
+    optionsDiv.addEventListener('click', ev => ev.stopPropagation());
+    document.body.appendChild(optionsDiv);
+  }
+
+  function hideOptions() {
+    if (optionsDiv) optionsDiv.classList.add('hidden');
+  }
+
+  function showOptions(id, anchor) {
+    createOptionsDiv();
+    const rect = anchor.getBoundingClientRect();
+    optionsDiv.style.top = `${rect.bottom + window.scrollY}px`;
+    optionsDiv.style.left = `${rect.left + window.scrollX}px`;
+    optionsDiv.classList.remove('hidden');
+    optionsDiv.querySelector('#optAddSub').onclick = () => {
+      openSubForm(id);
+      hideOptions();
+    };
+    optionsDiv.querySelector('#optAddIns').onclick = () => {
+      openInsForm(id);
+      hideOptions();
+    };
+  }
+
+  document.addEventListener('click', e => {
+    if (optionsDiv && !optionsDiv.contains(e.target)) {
+      hideOptions();
+    }
+  });
+
+  document.addEventListener('keydown', e => {
+    if (e.key === 'Escape') hideOptions();
+  });
+
   function renderTree() {
     if (!preview || !window.SinopticoEditor || !SinopticoEditor.getNodes) return;
+    hideOptions();
     const nodes = SinopticoEditor.getNodes();
     const map = {};
     nodes.forEach(n => (map[n.ID] = Object.assign({ children: [] }, n)));
@@ -48,24 +93,16 @@ document.addEventListener('DOMContentLoaded', () => {
       const li = document.createElement('li');
       const container = document.createElement('div');
       container.className = 'tree-node';
+      container.dataset.id = node.ID;
       const label = document.createElement('span');
       label.textContent = node['Descripción'] || node.ID;
       container.appendChild(label);
 
       if ((node.Tipo || '').toLowerCase() !== 'insumo') {
-        const addSub = document.createElement('button');
-        addSub.textContent = '+S';
-        addSub.className = 'add-child-btn';
-        addSub.title = 'Agregar subproducto';
-        addSub.addEventListener('click', () => openSubForm(node.ID));
-        container.appendChild(addSub);
-
-        const addIns = document.createElement('button');
-        addIns.textContent = '+I';
-        addIns.className = 'add-child-btn';
-        addIns.title = 'Agregar insumo';
-        addIns.addEventListener('click', () => openInsForm(node.ID));
-        container.appendChild(addIns);
+        container.addEventListener('click', ev => {
+          ev.stopPropagation();
+          showOptions(container.dataset.id, container);
+        });
       }
 
       li.appendChild(container);
@@ -80,6 +117,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   function hideAll() {
     [clientForm, productForm, subForm, insForm].forEach(f => f.classList.add('hidden'));
+    hideOptions();
   }
 
   function openSubForm(pid) {
@@ -123,6 +161,7 @@ document.addEventListener('DOMContentLoaded', () => {
     btn.addEventListener('click', () => {
       hideAll();
       level.value = '';
+      hideOptions();
     });
   });
 
@@ -198,6 +237,20 @@ document.addEventListener('DOMContentLoaded', () => {
     renderTree();
     subForm.reset();
     fillOptions();
+    hideOptions();
+  });
+
+  insForm.addEventListener('submit', e => {
+    e.preventDefault();
+    const parent = insParent.value;
+    const desc = document.getElementById('insDesc').value.trim();
+    const code = document.getElementById('insCode').value.trim();
+    if (!desc) return;
+    SinopticoEditor.addNode({ ParentID: parent, Tipo: 'Insumo', Descripción: desc, Código: code });
+    renderTree();
+    insForm.reset();
+    fillOptions();
+    hideOptions();
   });
 
   document.getElementById('addChildSub').addEventListener('click', () => {
@@ -227,6 +280,7 @@ document.addEventListener('DOMContentLoaded', () => {
       if (!desc) return;
       SinopticoEditor.addNode({ ParentID: pid, Tipo: 'Subensamble', Descripción: desc });
       renderTree();
+      fillOptions();
       form.remove();
     });
   }
@@ -251,6 +305,7 @@ document.addEventListener('DOMContentLoaded', () => {
       if (!desc) return;
       SinopticoEditor.addNode({ ParentID: pid, Tipo: 'Insumo', Descripción: desc, Código: code });
       renderTree();
+      fillOptions();
       form.remove();
     });
   }

--- a/styles.css
+++ b/styles.css
@@ -1075,3 +1075,27 @@ select {
 .add-child-btn:hover {
   background-color: var(--color-primary-hover);
 }
+
+.node-options {
+  position: absolute;
+  background-color: var(--color-light);
+  border: 1px solid #bbb;
+  border-radius: 4px;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.2);
+  padding: 4px;
+  z-index: 50;
+}
+
+.node-options button {
+  display: block;
+  width: 100%;
+  padding: 4px 8px;
+  background: none;
+  border: none;
+  text-align: left;
+  cursor: pointer;
+}
+
+.node-options button:hover {
+  background-color: #eee;
+}


### PR DESCRIPTION
## Summary
- allow clicking on tree nodes to show options overlay
- drop `+S` and `+I` buttons from tree view
- style `.node-options` menu
- ensure forms update overlay state and refresh tree
- close overlay on ESC and when tree rerenders

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684c064e868c832f8de26fbe200c8037