### PR TITLE
Restore add buttons and center sinoptico tree

### DIFF
--- a/sinoptico-create.js
+++ b/sinoptico-create.js
@@ -20,8 +20,6 @@ document.addEventListener('DOMContentLoaded', () => {
   const childContainer = document.getElementById('childContainer');
   const preview = document.getElementById('treePreview');
 
-  let optionsDiv = null;
-
   let addAnotherProduct = false;
   if (addProductBtn) {
     addProductBtn.addEventListener('click', () => {
@@ -30,43 +28,7 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   }
 
-  function createOptionsDiv() {
-    if (optionsDiv) return;
-    optionsDiv = document.createElement('div');
-    optionsDiv.className = 'node-options hidden';
-    optionsDiv.innerHTML = `
-      <button type="button" id="optAddSub">Agregar subproducto</button>
-      <button type="button" id="optAddIns">Agregar insumo</button>
-    `;
-    optionsDiv.addEventListener('click', ev => ev.stopPropagation());
-    document.body.appendChild(optionsDiv);
-  }
 
-  function hideOptions() {
-    if (optionsDiv) optionsDiv.classList.add('hidden');
-  }
-
-  function showOptions(id, anchor) {
-    createOptionsDiv();
-    const rect = anchor.getBoundingClientRect();
-    optionsDiv.style.top = `${rect.bottom + window.scrollY}px`;
-    optionsDiv.style.left = `${rect.left + window.scrollX}px`;
-    optionsDiv.classList.remove('hidden');
-    optionsDiv.querySelector('#optAddSub').onclick = () => {
-      openSubForm(id);
-      hideOptions();
-    };
-    optionsDiv.querySelector('#optAddIns').onclick = () => {
-      openInsForm(id);
-      hideOptions();
-    };
-  }
-
-  document.addEventListener('click', e => {
-    if (optionsDiv && !optionsDiv.contains(e.target)) {
-      hideOptions();
-    }
-  });
 
   function renderTree() {
     if (!preview || !window.SinopticoEditor || !SinopticoEditor.getNodes) return;
@@ -93,10 +55,19 @@ document.addEventListener('DOMContentLoaded', () => {
       container.appendChild(label);
 
       if ((node.Tipo || '').toLowerCase() !== 'insumo') {
-        container.addEventListener('click', ev => {
-          ev.stopPropagation();
-          showOptions(node.ID, container);
-        });
+        const addSub = document.createElement('button');
+        addSub.textContent = '+S';
+        addSub.className = 'add-child-btn';
+        addSub.title = 'Agregar subproducto';
+        addSub.addEventListener('click', () => openSubForm(node.ID));
+        container.appendChild(addSub);
+
+        const addIns = document.createElement('button');
+        addIns.textContent = '+I';
+        addIns.className = 'add-child-btn';
+        addIns.title = 'Agregar insumo';
+        addIns.addEventListener('click', () => openInsForm(node.ID));
+        container.appendChild(addIns);
       }
 
       li.appendChild(container);
@@ -111,7 +82,6 @@ document.addEventListener('DOMContentLoaded', () => {
 
   function hideAll() {
     [clientForm, productForm, subForm, insForm].forEach(f => f.classList.add('hidden'));
-    hideOptions();
   }
 
   function openSubForm(pid) {
@@ -155,7 +125,6 @@ document.addEventListener('DOMContentLoaded', () => {
     btn.addEventListener('click', () => {
       hideAll();
       level.value = '';
-      hideOptions();
     });
   });
 
@@ -231,7 +200,6 @@ document.addEventListener('DOMContentLoaded', () => {
     renderTree();
     subForm.reset();
     fillOptions();
-    hideOptions();
   });
 
   insForm.addEventListener('submit', e => {
@@ -244,7 +212,6 @@ document.addEventListener('DOMContentLoaded', () => {
     renderTree();
     insForm.reset();
     fillOptions();
-    hideOptions();
   });
 
   document.getElementById('addChildSub').addEventListener('click', () => {

--- a/styles.css
+++ b/styles.css
@@ -1051,7 +1051,8 @@ select {
 
 /* ========= Tree preview ========= */
 .tree-preview {
-  margin: 20px;
+  margin: 20px auto;
+  width: fit-content;
 }
 
 .tree-list,
@@ -1092,26 +1093,3 @@ select {
   background-color: var(--color-primary-hover);
 }
 
-.node-options {
-  position: absolute;
-  background-color: var(--color-light);
-  border: 1px solid #bbb;
-  border-radius: 4px;
-  box-shadow: 0 2px 4px rgba(0,0,0,0.2);
-  padding: 4px;
-  z-index: 50;
-}
-
-.node-options button {
-  display: block;
-  width: 100%;
-  padding: 4px 8px;
-  background: none;
-  border: none;
-  text-align: left;
-  cursor: pointer;
-}
-
-.node-options button:hover {
-  background-color: #eee;
-}


### PR DESCRIPTION
## Summary
- show `+S` and `+I` buttons again for each tree node
- remove overlay logic and styling
- center the tree preview in the page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c0dd0c4b4832f94603899a99ebbc7