### PR TITLE
Improve navigation and sinoptico spacing

### DIFF
--- a/renderer.js
+++ b/renderer.js
@@ -934,7 +934,7 @@
           const spanTextPadre = tdPadre.querySelector('.item-text');
           if (spanTextPadre) anchoText = spanTextPadre.offsetWidth;
 
-          const margenExtra = 4; // sólo 4px en lugar de 8px
+          const margenExtra = 12; // mayor separación para cada nivel
           const indentActual = indentPadre + anchoToggle + anchoArrow + anchoText + margenExtra;
           indentCache[id] = indentActual;
           return indentActual;

--- a/smooth-nav.js
+++ b/smooth-nav.js
@@ -13,7 +13,7 @@ window.addEventListener('DOMContentLoaded', () => {
       const href = a.href;
       setTimeout(() => {
         window.location.href = href;
-      }, 200);
+      }, 100);
     });
   });
 });

--- a/styles.css
+++ b/styles.css
@@ -55,7 +55,7 @@ body {
   background-color: var(--color-bg);
   color: var(--color-text);
   opacity: 0;
-  transition: opacity 0.3s ease-in-out;
+  transition: opacity 0.15s ease-in-out;
 }
 
 body.page-loaded {
@@ -298,9 +298,9 @@ body.dark-mode .fila-oper {
 .arrow-nivel-5,
 .arrow-nivel-6 {
   display: inline-block;
-  width: 14px;       /* reducido a 14px en lugar de 16px */
+  width: 20px;       /* espacio fijo un poco mayor */
   text-align: center;
-  margin-right: 2px; /* reducido a 2px en lugar de 4px */
+  margin-right: 4px; /* separación más evidente */
   font-weight: bold;
 }
 .arrow-nivel-1 {


### PR DESCRIPTION
## Summary
- shorten opacity transition for pages
- speed up smooth navigation script
- widen arrow spacing for tree levels
- add more indent spacing between levels in the renderer

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c1017ee3c832fa7a19d3f5033500b