### PR TITLE
Add Montserrat flow diagram style

### DIFF
--- a/sinoptico_crear.html
+++ b/sinoptico_crear.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Crear elemento</title>
+  <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;600&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="styles.css">
 </head>
 <body>
@@ -65,7 +66,7 @@
       <button type="button" class="cancelBtn">Cancelar</button>
     </div>
   </form>
-  <div id="treePreview" class="tree-preview"></div>
+  <div id="treePreview" class="tree-preview flow-diagram"></div>
   <a href="admin_menu.html" class="home-button">Volver al listado</a>
   <script src="auth.js"></script>
   <script src="theme.js" defer></script>

--- a/styles.css
+++ b/styles.css
@@ -1093,3 +1093,66 @@ select {
   background-color: var(--color-primary-hover);
 }
 
+/* ========= Flow diagram enhancements ========= */
+.flow-diagram {
+  font-family: 'Montserrat', sans-serif;
+}
+
+.flow-diagram .tree-list,
+.flow-diagram .tree-list ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  align-items: center;
+}
+
+.flow-diagram .tree-list ul {
+  margin-left: 40px;
+  position: relative;
+}
+
+.flow-diagram .tree-node {
+  position: relative;
+  padding: 8px 12px;
+  margin: 8px;
+  border-radius: 8px;
+  background: linear-gradient(135deg, #ffffff, #f0f0ff);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  animation: fadeIn 0.3s ease forwards;
+  opacity: 0;
+}
+
+.flow-diagram li > .tree-node::after {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 100%;
+  width: 20px;
+  border-top: 2px solid #ccc;
+}
+
+.flow-diagram li:last-child > .tree-node::after {
+  display: none;
+}
+
+.flow-diagram li > ul::before {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: -20px;
+  width: 20px;
+  border-top: 2px solid #ccc;
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(-5px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+


### PR DESCRIPTION
## Summary
- import Montserrat in sinoptico_crear
- preview flow in a left-to-right layout
- style cards with gradient, rounded edges and fade-in animation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c11002a00832fae019469f32027e7