### PR TITLE
Add Insumos page with navigation entry

### DIFF
--- a/admin_menu.html
+++ b/admin_menu.html
@@ -12,6 +12,7 @@
     <a href="sinoptico.html">Sinóptico</a>
     <a href="admin_menu.html" aria-current="page">Editar sinóptico</a>
     <a href="listado_maestro.html">Listado maestro</a>
+    <a href="insumos.html">Insumos</a>
     <button id="toggleTheme">🌙</button>
   </nav>
   <h1>Menú de administración del sinóptico</h1>

--- a/index.html
+++ b/index.html
@@ -13,6 +13,7 @@
           <a href="sinoptico.html">Sinóptico</a>
           <a href="admin_menu.html" id="editSinLink" style="display:none">Editar sinóptico</a>
           <a href="listado_maestro.html">Listado maestro</a>
+          <a href="insumos.html">Insumos</a>
           <a href="login.html" id="loginLink">Log in</a>
           <button id="toggleTheme">🌙</button>
       </nav>

--- a/insumos.html
+++ b/insumos.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Base de datos de Insumos</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <nav class="main-nav">
+    <a href="index.html">Inicio</a>
+    <a href="sinoptico.html">Sinóptico</a>
+    <a href="listado_maestro.html">Listado maestro</a>
+    <a href="insumos.html" aria-current="page">Insumos</a>
+    <button id="toggleTheme">🌙</button>
+  </nav>
+  <h1>Insumos</h1>
+  <div id="insumos" class="maestro-container"></div>
+
+  <script src="auth.js"></script>
+  <script src="theme.js" defer></script>
+  <script src="smooth-nav.js" defer></script>
+  <script src="insumos.js" defer></script>
+</body>
+</html>

--- a/insumos.js
+++ b/insumos.js
@@ -1,0 +1,66 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const cont = document.getElementById('insumos');
+  const STORAGE_KEY = 'insumosData';
+  let fs = null;
+  let path = null;
+  let jsonPath = null;
+  if (typeof window !== 'undefined' && typeof window.require === 'function') {
+    try {
+      fs = window.require('fs');
+      path = window.require('path');
+      jsonPath = path.join(__dirname, 'insumos.json');
+    } catch (e) {
+      fs = null;
+    }
+  }
+  let data = [];
+  if (fs && jsonPath && fs.existsSync(jsonPath)) {
+    try {
+      data = JSON.parse(fs.readFileSync(jsonPath, 'utf8')) || [];
+    } catch (e) {
+      data = [];
+    }
+  } else {
+    data = JSON.parse(localStorage.getItem(STORAGE_KEY)) || [];
+  }
+
+  function save() {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+    if (fs && jsonPath) {
+      try {
+        fs.writeFileSync(jsonPath, JSON.stringify(data, null, 2), 'utf8');
+      } catch (e) {
+        console.error('Error writing insumos JSON', e);
+      }
+    }
+  }
+
+  function render() {
+    cont.textContent = '';
+    const table = document.createElement('table');
+    table.className = 'insumos-table';
+    const thead = document.createElement('thead');
+    const hr = document.createElement('tr');
+    ['ID','Nombre','Descripción','Especificaciones'].forEach(t => {
+      const th = document.createElement('th');
+      th.textContent = t;
+      hr.appendChild(th);
+    });
+    thead.appendChild(hr);
+    table.appendChild(thead);
+    const tbody = document.createElement('tbody');
+    data.forEach(item => {
+      const tr = document.createElement('tr');
+      [item.id, item.nombre, item.descripcion, item.especificaciones].forEach(v => {
+        const td = document.createElement('td');
+        td.textContent = v || '';
+        tr.appendChild(td);
+      });
+      tbody.appendChild(tr);
+    });
+    table.appendChild(tbody);
+    cont.appendChild(table);
+  }
+
+  render();
+});

--- a/insumos.json
+++ b/insumos.json
@@ -1,0 +1,8 @@
+[
+  {
+    "id": 1,
+    "nombre": "Insumo de ejemplo",
+    "descripcion": "Descripción de ejemplo",
+    "especificaciones": "Especificaciones básicas"
+  }
+]

--- a/listado_maestro.html
+++ b/listado_maestro.html
@@ -11,6 +11,7 @@
     <a href="index.html">Inicio</a>
     <a href="sinoptico.html">Sinóptico</a>
     <a href="listado_maestro.html" aria-current="page">Listado maestro</a>
+    <a href="insumos.html">Insumos</a>
     <button id="toggleTheme">🌙</button>
   </nav>
   <header class="maestro-header">

--- a/login.html
+++ b/login.html
@@ -11,6 +11,7 @@
     <a href="index.html">Inicio</a>
     <a href="sinoptico.html">Sinóptico</a>
     <a href="listado_maestro.html">Listado maestro</a>
+    <a href="insumos.html">Insumos</a>
     <button id="toggleTheme">🌙</button>
   </nav>
 

--- a/sinoptico.html
+++ b/sinoptico.html
@@ -18,6 +18,7 @@
     <a href="index.html">Inicio</a>
     <a href="sinoptico.html" aria-current="page">Sinóptico</a>
     <a href="listado_maestro.html">Listado maestro</a>
+    <a href="insumos.html">Insumos</a>
     <button id="toggleTheme">🌙</button>
   </nav>
   <h1>Sinóptico de Producto Barack</h1>

--- a/sinoptico_crear.html
+++ b/sinoptico_crear.html
@@ -12,6 +12,7 @@
     <a href="index.html">Inicio</a>
     <a href="sinoptico.html">Sinóptico</a>
     <a href="sinoptico_edit.html">Editar sinóptico</a>
+    <a href="insumos.html">Insumos</a>
     <button id="toggleTheme">🌙</button>
   </nav>
   <h1>Crear elemento del sinóptico</h1>

--- a/sinoptico_edit.html
+++ b/sinoptico_edit.html
@@ -12,6 +12,7 @@
     <a href="sinoptico.html">Sinóptico</a>
     <a href="sinoptico_edit.html" aria-current="page">Editar sinóptico</a>
     <a href="listado_maestro.html">Listado maestro</a>
+    <a href="insumos.html">Insumos</a>
     <button id="toggleTheme">🌙</button>
   </nav>
 

--- a/sinoptico_eliminar.html
+++ b/sinoptico_eliminar.html
@@ -11,6 +11,7 @@
     <a href="index.html">Inicio</a>
     <a href="sinoptico.html">Sinóptico</a>
     <a href="sinoptico_edit.html">Editar sinóptico</a>
+    <a href="insumos.html">Insumos</a>
     <button id="toggleTheme">🌙</button>
   </nav>
   <h1>Eliminar elementos</h1>

--- a/sinoptico_modificar.html
+++ b/sinoptico_modificar.html
@@ -11,6 +11,7 @@
     <a href="index.html">Inicio</a>
     <a href="sinoptico.html">Sinóptico</a>
     <a href="sinoptico_edit.html">Editar sinóptico</a>
+    <a href="insumos.html">Insumos</a>
     <button id="toggleTheme">🌙</button>
   </nav>
   <h1>Modificar detalles</h1>

--- a/styles.css
+++ b/styles.css
@@ -1156,3 +1156,26 @@ select {
   }
 }
 
+
+/* ==============================
+   INSUMOS
+   ============================== */
+.insumos-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 20px;
+  background-color: var(--color-light);
+  border-radius: 6px;
+  overflow: hidden;
+}
+
+.insumos-table th,
+.insumos-table td {
+  border: 1px solid #ccc;
+  padding: 8px;
+  text-align: left;
+}
+
+.insumos-table tbody tr:nth-child(even) {
+  background-color: #f7f7f7;
+}


### PR DESCRIPTION
## Summary
- add `insumos.html` with a simple table UI
- implement `insumos.js` to load the insumo database from JSON or localStorage
- include sample data file `insumos.json`
- add navigation link to the new page across the site
- style the table in `styles.css`

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c13374a8c832fa7b22ba55bcbad3b