### PR TITLE
Implement search reuse for sinoptico creation

### DIFF
--- a/sinoptico_crear.html
+++ b/sinoptico_crear.html
@@ -47,6 +47,8 @@
   <form id="subForm" class="node-form hidden">
     <h2>Nuevo subproducto</h2>
     <select id="subParent"></select>
+    <input type="text" id="subSearch" placeholder="Buscar existente">
+    <ul id="subSuggestions" class="suggestions-list"></ul>
     <input type="text" id="subDesc" placeholder="Descripción" required>
     <div class="form-actions">
       <button type="submit">Guardar</button>
@@ -59,6 +61,8 @@
   <form id="insForm" class="node-form hidden">
     <h2>Nuevo insumo</h2>
     <select id="insParent"></select>
+    <input type="text" id="insSearch" placeholder="Buscar existente">
+    <ul id="insSuggestions" class="suggestions-list"></ul>
     <input type="text" id="insDesc" placeholder="Descripción" required>
     <input type="text" id="insCode" placeholder="Código">
     <div class="form-actions">
@@ -66,12 +70,12 @@
       <button type="button" class="cancelBtn">Cancelar</button>
     </div>
   </form>
-  <div id="treePreview" class="tree-preview flow-diagram"></div>
   <a href="admin_menu.html" class="home-button">Volver al listado</a>
   <script src="auth.js"></script>
   <script src="theme.js" defer></script>
   <script src="smooth-nav.js" defer></script>
   <script src="renderer.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/fuse.js@6/dist/fuse.min.js"></script>
   <script src="sinoptico-create.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- drop tree preview from creation page
- add search fields for subproductos and insumos with Fuse.js
- remove renderTree helper and related calls
- allow reusing existing nodes when saving new ones

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c137e19c8832f936a14945205cdb3