### PR TITLE
Implement visual builder and code fields

### DIFF
--- a/admin_menu.html
+++ b/admin_menu.html
@@ -20,6 +20,7 @@
     <button id="menuCrear" onclick="location.href='sinoptico_crear.html'">Crear</button>
     <button id="menuEliminar" onclick="location.href='sinoptico_eliminar.html'">Eliminar</button>
     <button id="menuModificar" onclick="location.href='sinoptico_modificar.html'">Modificar</button>
+    <button id="menuBuilder" onclick="location.href='product_builder.html'">Constructor</button>
   </div>
   <script src="auth.js"></script>
   <script src="theme.js" defer></script>

--- a/product_builder.html
+++ b/product_builder.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Constructor de producto</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <nav class="main-nav">
+    <a href="index.html">Inicio</a>
+    <a href="sinoptico.html">Sinóptico</a>
+    <a href="admin_menu.html" aria-current="page">Editar sinóptico</a>
+    <button id="toggleTheme">🌙</button>
+  </nav>
+  <h1>Constructor de producto</h1>
+  <div class="editor-container">
+    <input type="text" id="builderDesc" placeholder="Descripción del producto" required>
+    <input type="text" id="builderCode" placeholder="Código del producto">
+    <div class="builder-lists">
+      <section>
+        <h2>Subproductos</h2>
+        <div id="availableSubs"></div>
+      </section>
+      <section>
+        <h2>Insumos</h2>
+        <div id="availableIns"></div>
+      </section>
+    </div>
+    <h2>Seleccionados</h2>
+    <ul id="selectedList"></ul>
+    <button id="saveProduct">Guardar producto</button>
+  </div>
+  <a href="admin_menu.html" class="home-button">Volver</a>
+  <script src="auth.js"></script>
+  <script src="theme.js" defer></script>
+  <script src="smooth-nav.js" defer></script>
+  <script src="renderer.js"></script>
+  <script src="product_builder.js"></script>
+</body>
+</html>

--- a/product_builder.js
+++ b/product_builder.js
@@ -1,0 +1,67 @@
+document.addEventListener('DOMContentLoaded', () => {
+  if (sessionStorage.getItem('isAdmin') !== 'true') {
+    alert('Debe iniciar sesión para editar');
+    location.href = 'login.html';
+    return;
+  }
+
+  const subsDiv = document.getElementById('availableSubs');
+  const insDiv = document.getElementById('availableIns');
+  const selectedList = document.getElementById('selectedList');
+  let selected = [];
+
+  function renderLists() {
+    if (!window.SinopticoEditor || !SinopticoEditor.getNodes) return;
+    const nodes = SinopticoEditor.getNodes();
+    const subs = nodes.filter(n => (n.Tipo || '').toLowerCase() === 'subensamble');
+    const ins = nodes.filter(n => (n.Tipo || '').toLowerCase() === 'insumo');
+    subsDiv.innerHTML = '';
+    insDiv.innerHTML = '';
+    subs.forEach(s => {
+      const btn = document.createElement('button');
+      btn.textContent = `${s['Descripción'] || ''} - ${s['Código'] || ''}`;
+      btn.addEventListener('click', () => addItem({ Tipo: s.Tipo, Descripción: s['Descripción'], Código: s['Código'] }));
+      subsDiv.appendChild(btn);
+    });
+    ins.forEach(i => {
+      const btn = document.createElement('button');
+      btn.textContent = `${i['Descripción'] || ''} - ${i['Código'] || ''}`;
+      btn.addEventListener('click', () => addItem({ Tipo: i.Tipo, Descripción: i['Descripción'], Código: i['Código'] }));
+      insDiv.appendChild(btn);
+    });
+  }
+
+  function renderSelected() {
+    selectedList.innerHTML = '';
+    selected.forEach((item, idx) => {
+      const li = document.createElement('li');
+      li.textContent = `${item.Descripción || ''} - ${item.Código || ''}`;
+      const rm = document.createElement('button');
+      rm.textContent = '×';
+      rm.addEventListener('click', () => { selected.splice(idx, 1); renderSelected(); });
+      li.appendChild(rm);
+      selectedList.appendChild(li);
+    });
+  }
+
+  function addItem(item) {
+    selected.push(item);
+    renderSelected();
+  }
+
+  document.getElementById('saveProduct').addEventListener('click', () => {
+    const desc = document.getElementById('builderDesc').value.trim();
+    const code = document.getElementById('builderCode').value.trim();
+    if (!desc) return;
+    SinopticoEditor.addNode({ Tipo: 'Pieza final', Descripción: desc, Código: code }, selected);
+    selected = [];
+    document.getElementById('builderDesc').value = '';
+    document.getElementById('builderCode').value = '';
+    renderSelected();
+    alert('Producto creado');
+  });
+
+  document.addEventListener('sinoptico-mode', renderLists);
+  setTimeout(renderLists, 300);
+});
+

--- a/sinoptico-create.js
+++ b/sinoptico-create.js
@@ -21,10 +21,12 @@ document.addEventListener('DOMContentLoaded', () => {
   const subSearch = document.getElementById('subSearch');
   const subSuggestions = document.getElementById('subSuggestions');
   const subDescInput = document.getElementById('subDesc');
+  const subCodeInput = document.getElementById('subCode');
   const insSearch = document.getElementById('insSearch');
   const insSuggestions = document.getElementById('insSuggestions');
   const insDescInput = document.getElementById('insDesc');
   const insCodeInput = document.getElementById('insCode');
+  const prodCodeInput = document.getElementById('prodCode');
 
   let subFuse = null;
   let insFuse = null;
@@ -126,8 +128,8 @@ document.addEventListener('DOMContentLoaded', () => {
     const nodes = SinopticoEditor.getNodes();
     const subs = nodes.filter(n => (n.Tipo || '').toLowerCase() === 'subensamble');
     const ins = nodes.filter(n => (n.Tipo || '').toLowerCase() === 'insumo');
-    subFuse = new Fuse(subs, { keys: ['Descripción', 'Código', 'ID'], threshold: 0.3 });
-    insFuse = new Fuse(ins, { keys: ['Descripción', 'Código', 'ID'], threshold: 0.3 });
+    subFuse = new Fuse(subs, { keys: ['Descripción', 'Código', 'ID'], threshold: 0.2 });
+    insFuse = new Fuse(ins, { keys: ['Descripción', 'Código', 'ID'], threshold: 0.2 });
   }
 
   function attachSearch(input, list, fuseGetter, onPick, clearSel) {
@@ -145,7 +147,9 @@ document.addEventListener('DOMContentLoaded', () => {
       results.forEach(r => {
         const li = document.createElement('li');
         const item = r.item;
-        li.textContent = item['Descripción'] || item.ID;
+        const desc = item['Descripción'] || item.ID;
+        const codeTxt = item['Código'] ? ` - ${item['Código']}` : '';
+        li.textContent = `${desc}${codeTxt}`;
         li.addEventListener('mousedown', () => {
           onPick(item);
           list.innerHTML = '';
@@ -195,8 +199,9 @@ document.addEventListener('DOMContentLoaded', () => {
     e.preventDefault();
     const parent = prodClient.value;
     const desc = document.getElementById('prodDesc').value.trim();
+    const code = prodCodeInput ? prodCodeInput.value.trim() : '';
     if (!desc) return;
-    const id = SinopticoEditor.addNode({ ParentID: parent, Tipo: 'Pieza final', Descripción: desc });
+    const id = SinopticoEditor.addNode({ ParentID: parent, Tipo: 'Pieza final', Descripción: desc, Código: code });
     productForm.reset();
     const addMore = addAnotherProduct || (e.submitter && e.submitter.id === 'addProductBtn');
     addAnotherProduct = false;
@@ -220,13 +225,14 @@ document.addEventListener('DOMContentLoaded', () => {
     e.preventDefault();
     const parent = subParent.value;
     const desc = subDescInput.value.trim();
+    const code = subCodeInput ? subCodeInput.value.trim() : '';
     if (!desc && !selectedSubId) return;
     let data;
     if (selectedSubId) {
       const node = SinopticoEditor.getNodes().find(n => n.ID === selectedSubId);
-      data = { ParentID: parent, Tipo: node ? node.Tipo : 'Subensamble', Descripción: node ? node['Descripción'] : desc };
+      data = { ParentID: parent, Tipo: node ? node.Tipo : 'Subensamble', Descripción: node ? node['Descripción'] : desc, Código: node ? node['Código'] : code };
     } else {
-      data = { ParentID: parent, Tipo: 'Subensamble', Descripción: desc };
+      data = { ParentID: parent, Tipo: 'Subensamble', Descripción: desc, Código: code };
     }
     lastSubId = SinopticoEditor.addNode(data);
     selectedSubId = null;

--- a/sinoptico-modify.js
+++ b/sinoptico-modify.js
@@ -18,10 +18,11 @@ document.addEventListener('DOMContentLoaded', () => {
       btn.textContent = 'Editar';
       btn.addEventListener('click', () => {
         const desc = prompt('Nueva descripción', n['Descripción'] || '');
-        if (desc !== null) {
-          window.SinopticoEditor.updateNode(n.ID, { Descripción: desc });
-          render();
-        }
+        if (desc === null) return;
+        const code = prompt('Nuevo código', n['Código'] || '');
+        if (code === null) return;
+        window.SinopticoEditor.updateNode(n.ID, { Descripción: desc, Código: code });
+        render();
       });
       td.appendChild(btn);
       tr.appendChild(td);

--- a/sinoptico_crear.html
+++ b/sinoptico_crear.html
@@ -35,22 +35,24 @@
       <button type="button" class="cancelBtn">Cancelar</button>
     </div>
   </form>
-  <form id="productForm" class="node-form hidden">
-    <h2>Nuevo producto</h2>
-    <select id="prodClient"></select>
-    <input type="text" id="prodDesc" placeholder="Descripción" required>
+    <form id="productForm" class="node-form hidden">
+      <h2>Nuevo producto</h2>
+      <select id="prodClient"></select>
+      <input type="text" id="prodDesc" placeholder="Descripción" required>
+      <input type="text" id="prodCode" placeholder="Código">
     <div class="form-actions">
       <button type="submit">Guardar</button>
       <button type="submit" id="addProductBtn" title="Agregar otro producto">➕</button>
       <button type="button" class="cancelBtn">Cancelar</button>
     </div>
   </form>
-  <form id="subForm" class="node-form hidden">
-    <h2>Nuevo subproducto</h2>
-    <select id="subParent"></select>
-    <input type="text" id="subSearch" placeholder="Buscar existente">
-    <ul id="subSuggestions" class="suggestions-list"></ul>
-    <input type="text" id="subDesc" placeholder="Descripción" required>
+    <form id="subForm" class="node-form hidden">
+      <h2>Nuevo subproducto</h2>
+      <select id="subParent"></select>
+      <input type="text" id="subSearch" placeholder="Buscar existente">
+      <ul id="subSuggestions" class="suggestions-list"></ul>
+      <input type="text" id="subDesc" placeholder="Descripción" required>
+      <input type="text" id="subCode" placeholder="Código">
     <div class="form-actions">
       <button type="submit">Guardar</button>
       <button type="button" id="addChildSub">Agregar subproducto hijo</button>


### PR DESCRIPTION
## Summary
- allow entering product and subproduct codes in the create form
- capture those codes when adding nodes
- show code in search suggestions and tighten Fuse.js threshold
- enable editing codes in the modification table
- add a visual product builder page and link from admin menu

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c175f3128832f9255471c85e8ba85