### PR TITLE
Fix AMFE link and update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,19 +4,19 @@ This project displays a hierarchical product table built with plain HTML, CSS an
 
 ## Launching the site
 
-Because some browsers block local file reads, it is recommended to serve the files from a small local web server. If Python is installed you can run:
+Because some browsers block local file reads, serve the folder from any static web server. For quick testing you can run:
 
 ```bash
 python3 -m http.server
 ```
 
-Open [http://localhost:8000/index.html](http://localhost:8000/index.html) in a modern browser to access the main menu.
+Open http://localhost:8000/index.html in a modern browser. All data, including the AMFE tables, is kept in your browser's localStorage.
 
 ## Login and user accounts
 
 Use the **Log in** link or open `login.html` directly to access the sign‑in page. The project includes four default accounts: **PAULO**, **LEO**, **FACUNDO** and **PABLO**, all with password `1234`. After logging in an admin panel becomes visible where you can create new users or update existing passwords.
 
-Account information is stored in the browser's `localStorage` or in `no-borrar/users.json` when running under Node/Electron. Delete that file or clear the `users` entry from `localStorage` to reset all accounts.
+Account information is stored in the browser's `localStorage`. Clear the `users` entry to reset all accounts.
 
 Editing the master list and the sinóptico now requires being logged in.
 
@@ -24,7 +24,7 @@ Editing the master list and the sinóptico now requires being logged in.
 
 The **master document list** lets you organise engineering documents by category. Open `listado_maestro.html` in your browser and click **Editar** to toggle edit mode. You must be logged in to modify the table. While in edit mode you can add new rows or change existing numbers and details.
 
-The list is normally stored in your browser's `localStorage`. When running in an environment that exposes `window.require` (for example Electron), the table is also loaded from and saved to `no-borrar/no borrar - listado maestro.json`. This JSON file lives in the `no-borrar` folder alongside the generated Excel and CSV files, ensuring the master list persists between sessions.
+The list is stored in your browser's `localStorage`; the no-borrar folder is no longer used.
 
 ## Features
 
@@ -40,8 +40,9 @@ The list is normally stored in your browser's `localStorage`. When running in an
 - **Smooth animations** – buttons and rows fade and scale for a more polished experience.
 - **Insumo lookup** – the insumos table includes a search box with fuzzy matching.
 - **Cross-linking** – clicking an insumo in the sinóptico opens the list filtered to that entry.
+- **AMFE persistence** – the AMFE pages store their data in `localStorage`.
 
-When running the app through Node/Electron the hierarchy is stored in `no-borrar/sinoptico.json`. Browsers fall back to `localStorage`.
+The product hierarchy is stored in `localStorage`.
 
 ## Dependencies and browser requirements
 

--- a/index.html
+++ b/index.html
@@ -24,7 +24,7 @@
               <p class="tagline">Soluciones integrales para la industria automotriz</p>
               <a class="btn-link" href="sinoptico.html">Ver Sinóptico de Producto</a>
               <a class="btn-link" href="listado_maestro.html">Listado maestro</a>
-              <a class="btn-link" href="amfe_proceso.html">AMFE de proceso</a>
+              <a class="btn-link" href="amfe_proceso_interactivo.html">AMFE de proceso</a>
           </section>
       </header>
       <main class="intro">


### PR DESCRIPTION
## Summary
- update the AMFE menu link to amfe_proceso_interactivo.html
- clarify that the site can run from any static web server
- remove Node/Electron references and mention that AMFE data is saved in `localStorage`

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c1ec13fcc832fb942aec4a23a807e