### PR TITLE
Add setup script for Node tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,10 +50,10 @@ The page loads [SheetJS](https://sheetjs.com/) and [Fuse.js](https://fusejs.io/)
 
 ## Node testing
 
-Running the project in a browser is enough to use the page. Optionally you can run an automated test that executes `maestro.js` under Node using JSDOM. The tests rely on `jsdom-global`, `jsdom` and `fuse.js`, which `npm install` will download for you. **Make sure to run `npm install` once before executing the tests**:
+Running the project in a browser is enough to use the page. Optionally you can run an automated test that executes `maestro.js` under Node using JSDOM. The tests rely on `jsdom-global`, `jsdom` and `fuse.js`. **Run `scripts/setup.sh` once before executing the tests to download these dependencies**:
 
 ```bash
-npm install
+scripts/setup.sh
 ```
 
 Then run:

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+# Install Node dependencies used for testing
+npm install


### PR DESCRIPTION
## Summary
- add `scripts/setup.sh` to install dev dependencies
- document using the new script before running tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c1fe94618832f9ff3068e9eadcd77