### PR TITLE
Fix AMFE logo visibility

### DIFF
--- a/amfe_proceso_interactivo.html
+++ b/amfe_proceso_interactivo.html
@@ -33,7 +33,7 @@
   <h1 style="text-align:center">AMFE de Proceso</h1>
   <section class="header-grid" id="amfeHeader">
     <div style="grid-column:1/-1;text-align:center">
-      <img src="images/LOGO BARACK.png" alt="Logo" style="height:80px">
+      <img src="images/LOGO BARACK.png" alt="Logo" class="logo" style="height:80px">
     </div>
     <label>Organización<input></label>
     <label>Planta<input></label>

--- a/styles.css
+++ b/styles.css
@@ -711,6 +711,11 @@ header {
   max-width: 250px;
   height: auto;
 }
+body:not(.dark-mode) .logo {
+  background-color: var(--color-primary);
+  padding: 4px;
+  border-radius: 4px;
+}
 
 .hero {
   min-height: 85vh;


### PR DESCRIPTION
## Summary
- give logos a blue background in light mode so the image is visible
- add logo class to AMFE process interactive page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c20f5e754832f873fc598055cbecb