### PR TITLE
Add admin editing for insumos

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ The list is stored in your browser's `localStorage`; the no-borrar folder is no 
 - **Smooth animations** – buttons and rows fade and scale for a more polished experience.
 - **Insumo lookup** – the insumos table includes a search box with fuzzy matching.
 - **Cross-linking** – clicking an insumo in the sinóptico opens the list filtered to that entry.
+- **Insumo editing** – administrators can agregar, modificar o eliminar insumos desde `insumos.html`.
 - **AMFE persistence** – the AMFE pages store their data in `localStorage`.
 
 The product hierarchy is stored in `localStorage`.
@@ -50,7 +51,7 @@ The page loads [SheetJS](https://sheetjs.com/) and [Fuse.js](https://fusejs.io/)
 
 ## Node testing
 
-Running the project in a browser is enough to use the page. Optionally you can run an automated test that executes `maestro.js` under Node using JSDOM. The tests rely on `jsdom-global`, `jsdom` and `fuse.js`. **Run `scripts/setup.sh` once before executing the tests to download these dependencies**:
+Running the project in a browser is enough to use the page. Optionally you can run automated tests that execute the scripts under Node using JSDOM. The tests rely on `jsdom-global`, `jsdom` and `fuse.js`. **Run `scripts/setup.sh` once before executing the tests to download these dependencies**:
 
 ```bash
 scripts/setup.sh
@@ -62,7 +63,7 @@ Then run:
 npm test
 ```
 
-This creates a small DOM environment so the script can be executed without a real browser.
+This creates a small DOM environment so the scripts can be executed without a real browser. The tests also verify that the insumos editor persists new items.
 
 ## Fuzzy search flow
 

--- a/insumos.html
+++ b/insumos.html
@@ -14,15 +14,43 @@
     <a href="insumos.html" aria-current="page">Insumos</a>
     <button id="toggleTheme">🌙</button>
   </nav>
-  <h1>Insumos</h1>
+  <header class="maestro-header">
+    <h1>Insumos</h1>
+    <button id="editInsumosBtn" class="edit-button">Editar</button>
+  </header>
   <div class="search-wrap">
     <label for="insumoSearch">Buscar insumo</label>
     <input type="text" id="insumoSearch" placeholder="Nombre o descripción" />
     <button id="clearInsumoSearch" aria-label="Limpiar búsqueda">×</button>
   </div>
   <div id="insumos" class="maestro-container"></div>
+  <form id="insForm" class="insumos-form maestro-form">
+    <input type="text" id="inNombre" placeholder="Nombre" />
+    <input type="text" id="inDescripcion" placeholder="Descripción" />
+    <input type="text" id="inEspecificaciones" placeholder="Especificaciones" />
+    <button type="submit" id="saveItem">Guardar</button>
+  </form>
 
   <script src="auth.js"></script>
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      const btn = document.getElementById('editInsumosBtn');
+      function update() {
+        const editing = sessionStorage.getItem('insumosAdmin') === 'true';
+        btn.textContent = editing ? 'Salir de edición' : 'Editar';
+        btn.style.display = sessionStorage.getItem('isAdmin') === 'true' ? 'inline-block' : 'none';
+      }
+      btn.addEventListener('click', () => {
+        if (sessionStorage.getItem('isAdmin') !== 'true') return;
+        const editing = sessionStorage.getItem('insumosAdmin') === 'true';
+        if (editing) sessionStorage.removeItem('insumosAdmin');
+        else sessionStorage.setItem('insumosAdmin','true');
+        update();
+        document.dispatchEvent(new CustomEvent('insumos-mode'));
+      });
+      update();
+    });
+  </script>
   <script src="theme.js" defer></script>
   <script src="smooth-nav.js" defer></script>
   <script src="https://cdn.jsdelivr.net/npm/fuse.js@6/dist/fuse.min.js"></script>

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "",
   "scripts": {
-    "test": "node test-maestro.js && node test-renderer.js && node test-auth.js"
+    "test": "node test-maestro.js && node test-renderer.js && node test-auth.js && node test-insumos.js"
   },
   "devDependencies": {
     "fuse.js": "^7.1.0",

--- a/styles.css
+++ b/styles.css
@@ -1189,6 +1189,29 @@ select {
   background-color: #fff5a3;
 }
 
+.insumos-form {
+  display: flex;
+  gap: 8px;
+  margin-top: 10px;
+}
+.insumos-form input {
+  flex: 1;
+  padding: 6px;
+  border: 1px solid #bbb;
+  border-radius: 4px;
+}
+.insumos-form button {
+  padding: 6px 12px;
+  background-color: var(--color-primary);
+  color: var(--color-light);
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+.insumos-form button:hover {
+  background-color: var(--color-primary-hover);
+}
+
 #insumoSearch {
   max-width: 300px;
   display: block;

--- a/test-insumos.js
+++ b/test-insumos.js
@@ -1,0 +1,32 @@
+const jsdom = require('jsdom-global');
+jsdom('', { url: 'http://localhost' });
+
+// expose storages
+global.sessionStorage = window.sessionStorage;
+global.localStorage = window.localStorage;
+
+// minimal DOM elements expected by insumos.js
+document.body.innerHTML = `
+  <div id="insumos"></div>
+  <input id="insumoSearch" />
+  <button id="clearInsumoSearch"></button>
+  <form id="insForm" class="insumos-form">
+    <input id="inNombre" />
+    <input id="inDescripcion" />
+    <input id="inEspecificaciones" />
+    <button id="saveItem" type="submit"></button>
+  </form>
+`;
+
+sessionStorage.setItem('insumosAdmin','true');
+sessionStorage.setItem('isAdmin','true');
+
+require('./insumos.js');
+document.dispatchEvent(new Event('DOMContentLoaded'));
+
+window.InsumosEditor.createItem({ nombre: 'Test', descripcion: 'd', especificaciones: 'e' });
+
+const arr = JSON.parse(localStorage.getItem('insumosData') || '[]');
+if (!arr.find(i => i.nombre === 'Test')) throw new Error('item not persisted');
+
+console.log('insumos test passed');


### PR DESCRIPTION
## Summary
- allow admins to toggle edit mode on `insumos.html`
- provide a small edit form for adding/updating items
- implement create/update/delete logic in `insumos.js`
- expose InsumosEditor for tests and add a Node test
- style the new form and document the feature

## Testing
- `scripts/setup.sh`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c237755f8832f99fe9290d62adfe0