### PR TITLE
Improve AMFE editing UI

### DIFF
--- a/admin_menu.html
+++ b/admin_menu.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Menú de administración</title>
+  <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;600&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="styles.css">
 </head>
 <body>

--- a/amfe.js
+++ b/amfe.js
@@ -58,9 +58,10 @@ document.addEventListener('DOMContentLoaded', () => {
       const tr = $('<tr>');
       fields.forEach(f => {
         const td = $('<td contenteditable="true">').text(row[f] || '');
+        td.on('focus', () => td.data('orig', td.text()));
         td.on('keydown', e => {
           if (e.key === 'Escape') {
-            document.execCommand('undo');
+            td.text(td.data('orig') || '');
             td.blur();
           }
           if (e.key === 'Enter') {

--- a/amfe_proceso.html
+++ b/amfe_proceso.html
@@ -9,7 +9,7 @@
   <link rel="stylesheet" href="https://cdn.datatables.net/1.13.7/css/jquery.dataTables.min.css">
   <link rel="stylesheet" href="https://cdn.datatables.net/buttons/2.4.1/css/buttons.dataTables.min.css">
   <style>
-    body { font-family: 'Montserrat', Arial, sans-serif; }
+    body { font-family: var(--font-base); }
     .dt-buttons button { background: linear-gradient(#4b6cb7, #182848); color: #fff; border: none; padding: 6px 12px; border-radius: 4px; }
     .dt-buttons button:hover { box-shadow: 0 2px 4px rgba(0,0,0,0.2); }
     #toolbar { display: flex; justify-content: space-between; align-items: center; width: 95%; margin: 20px auto; }

--- a/amfe_proceso_interactivo.html
+++ b/amfe_proceso_interactivo.html
@@ -9,7 +9,7 @@
   <link rel="stylesheet" href="https://cdn.datatables.net/1.13.7/css/jquery.dataTables.min.css">
   <link rel="stylesheet" href="https://cdn.datatables.net/buttons/2.4.1/css/buttons.dataTables.min.css">
   <style>
-    body { font-family: 'Montserrat', sans-serif; }
+    body { font-family: var(--font-base); }
     .header-grid { display:grid; grid-template-columns: repeat(auto-fit, minmax(200px,1fr)); gap:10px; margin:20px; }
     .header-grid label { display:flex; flex-direction:column; font-weight:600; }
     .process-section { margin:20px; border:1px solid #ccc; border-radius:6px; background:#fff; box-shadow:0 2px 4px rgba(0,0,0,0.1); }

--- a/amfe_proceso_mejorado.html
+++ b/amfe_proceso_mejorado.html
@@ -8,7 +8,7 @@
   <link rel="stylesheet" href="styles.css">
   <link rel="stylesheet" href="https://cdn.datatables.net/1.13.7/css/jquery.dataTables.min.css">
   <style>
-    body { font-family: 'Montserrat', sans-serif; }
+    body { font-family: var(--font-base); }
     .header-grid { display:grid; grid-template-columns:repeat(auto-fit,minmax(200px,1fr)); gap:10px; margin:20px; background:#fff; padding:10px; border-radius:8px; box-shadow:0 2px 4px rgba(0,0,0,0.1); }
     .header-grid label { display:flex; flex-direction:column; font-weight:600; }
     .readonly input { background:#f0f0f0; border:none; }

--- a/amfe_proceso_mejorado.js
+++ b/amfe_proceso_mejorado.js
@@ -1,18 +1,255 @@
 (function(){
-const STORAGE_KEY='amfeProcesoMejorado';
-let data={header:{organizacion:'',planta:'',fecha:'',responsable:'',cliente:'',confidencialidad:'',modelo:'',equipo:[]},processes:[]};
-function load(){const saved=localStorage.getItem(STORAGE_KEY);if(saved){try{data=JSON.parse(saved);}catch(e){}}}
-function save(){localStorage.setItem(STORAGE_KEY,JSON.stringify(data));}
-function logged(){return sessionStorage.getItem('currentUser');}
-function renderHeader(){['organizacion','planta','fecha','responsable','cliente','confidencialidad','modelo'].forEach(k=>{const el=document.getElementById('hdr-'+k);if(el){el.value=data.header[k]||'';}});
-const list=document.getElementById('teamList');list.innerHTML='';data.header.equipo.forEach((n,i)=>{const span=document.createElement('span');span.textContent=n;if(logged()){const del=document.createElement('button');del.textContent='🗑';del.onclick=()=>{data.header.equipo.splice(i,1);save();renderHeader();};span.appendChild(del);}list.appendChild(span);});
-const controls=document.getElementById('teamControls');if(logged()){controls.style.display='block';document.getElementById('teamAddBtn').onclick=()=>{const name=document.getElementById('teamAdd').value.trim();if(name){data.header.equipo.push(name);document.getElementById('teamAdd').value='';save();renderHeader();}};}else{controls.style.display='none';}}
-function render(){renderHeader();const cont=document.getElementById('processContainer');cont.innerHTML='';data.processes.forEach((proc,pIdx)=>{const details=document.createElement('details');details.className='process-section';details.open=true;const summary=document.createElement('summary');const title=document.createElement('span');title.textContent=proc.titulo||`Proceso ${pIdx+1}`;if(logged()){title.contentEditable='true';title.onkeydown=e=>{if(e.key==='Enter'){e.preventDefault();title.blur();}if(e.key==='Escape'){document.execCommand('undo');title.blur();}};title.onblur=()=>{proc.titulo=title.textContent.trim();save();};}
-summary.appendChild(title);if(logged()){const btns=document.createElement('span');const dup=document.createElement('button');dup.textContent='Duplicar';dup.onclick=()=>{const copy=JSON.parse(JSON.stringify(proc));data.processes.splice(pIdx+1,0,copy);save();render();};const del=document.createElement('button');del.textContent='🗑';del.onclick=()=>{if(confirm('¿Eliminar proceso?')){data.processes.splice(pIdx,1);save();render();}};btns.appendChild(dup);btns.appendChild(del);summary.appendChild(btns);}details.appendChild(summary);
-const fields=document.createElement('div');fields.className='process-fields';['estacion','descripcion','materiales','requerimientos'].forEach(f=>{const lab=document.createElement('label');lab.textContent=f.charAt(0).toUpperCase()+f.slice(1);if(logged()){const inp=document.createElement('input');inp.value=proc[f]||'';inp.onchange=()=>{proc[f]=inp.value.trim();if(!proc[f])inp.classList.add('invalid');else inp.classList.remove('invalid');save();};lab.appendChild(inp);}else{const span=document.createElement('span');span.textContent=proc[f]||'';lab.appendChild(span);}fields.appendChild(lab);});details.appendChild(fields);
-const wrap=document.createElement('div');wrap.className='table-wrapper';const table=document.createElement('table');table.id='tabla-'+pIdx;table.className='fmea-table display';table.innerHTML='<thead><tr><th>Efecto planta interna</th><th>Efecto planta cliente</th><th>Efecto usuario final</th><th>Causa</th><th>S</th><th>O</th><th>D</th><th>RPN</th><th>Acción preventiva</th><th>Acción detectiva</th><th>Responsable</th><th>Fecha objetivo</th><th>Estado</th><th>Observaciones</th><th></th></tr><tr class="filters"></tr></thead><tbody></tbody>';wrap.appendChild(table);details.appendChild(wrap);
-proc.modos.forEach((m,rIdx)=>{const tr=document.createElement('tr');['efInt','efCli','efUsu','causa','s','o','d','rpn','prev','det','resp','fecha','estado','obs'].forEach((fld,idx)=>{const td=document.createElement('td');if(logged()&&idx!==7){td.contentEditable='true';td.textContent=m[fld]||'';td.onkeydown=e=>{if(e.key==='Enter'){e.preventDefault();td.blur();}if(e.key==='Escape'){document.execCommand('undo');td.blur();}};td.onblur=()=>{m[fld]=td.textContent.trim();if(['s','o','d'].includes(fld)){const s=parseInt(m.s)||0,o=parseInt(m.o)||0,d=parseInt(m.d)||0;m.rpn=s*o*d;tr.children[7].textContent=m.rpn;}save();};}else{td.textContent=m[fld]||'';}tr.appendChild(td);});const tdDel=document.createElement('td');if(logged()){const del=document.createElement('button');del.textContent='🗑';del.onclick=()=>{proc.modos.splice(rIdx,1);save();render();};tdDel.appendChild(del);}tr.appendChild(tdDel);table.querySelector('tbody').appendChild(tr);});
-if(logged()){const addBtn=document.createElement('button');addBtn.textContent='+ Modo de Falla';addBtn.className='add-mode-btn';addBtn.onclick=()=>{proc.modos.push({});save();render();};details.appendChild(addBtn);}cont.appendChild(details);
-const dt=$(table).DataTable({paging:false,ordering:true,info:false,searching:false,scrollX:true,dom:'t'});const filterRow=table.querySelector('tr.filters');dt.columns().every(function(){const th=document.createElement('th');if(this.index()<14){const input=document.createElement('input');input.placeholder='Filtrar';input.style.width='100%';input.oninput=()=>{dt.column(this.index()).search(input.value).draw();};th.appendChild(input);}filterRow.appendChild(th);});});}
-window.addEventListener('DOMContentLoaded',()=>{load();render();document.getElementById('addProcess').onclick=()=>{if(!logged())return;data.processes.push({titulo:'',estacion:'',descripcion:'',materiales:'',requerimientos:'',modos:[]});save();render();};});
+const STORAGE_KEY = 'amfeProcesoMejorado';
+let data = {
+  header: {
+    organizacion: '',
+    planta: '',
+    fecha: '',
+    responsable: '',
+    cliente: '',
+    confidencialidad: '',
+    modelo: '',
+    equipo: []
+  },
+  processes: []
+};
+
+function load(){
+  const saved = localStorage.getItem(STORAGE_KEY);
+  if(saved){
+    try{ data = JSON.parse(saved); }catch(e){}
+  }
+}
+function save(){
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+}
+function logged(){
+  return sessionStorage.getItem('currentUser');
+}
+
+function renderHeader(){
+  ['organizacion','planta','fecha','responsable','cliente','confidencialidad','modelo'].forEach(k=>{
+    const el = document.getElementById('hdr-'+k);
+    if(el){ el.value = data.header[k] || ''; }
+  });
+  const list = document.getElementById('teamList');
+  list.innerHTML='';
+  data.header.equipo.forEach((n,i)=>{
+    const span = document.createElement('span');
+    span.textContent = n;
+    if(logged()){
+      const del=document.createElement('button');
+      del.textContent='🗑';
+      del.onclick=()=>{ data.header.equipo.splice(i,1); save(); renderHeader(); };
+      span.appendChild(del);
+    }
+    list.appendChild(span);
+  });
+  const controls = document.getElementById('teamControls');
+  if(logged()){
+    controls.style.display='block';
+    document.getElementById('teamAddBtn').onclick=()=>{
+      const name = document.getElementById('teamAdd').value.trim();
+      if(name){
+        data.header.equipo.push(name);
+        document.getElementById('teamAdd').value='';
+        save();
+        renderHeader();
+      }
+    };
+  } else {
+    controls.style.display='none';
+  }
+}
+
+function editableCell(text,onSave){
+  const td=document.createElement('td');
+  td.contentEditable='true';
+  td.textContent=text||'';
+  td.onfocus=()=>{ td.dataset.orig=td.textContent; };
+  td.onkeydown=e=>{
+    if(e.key==='Enter'){ e.preventDefault(); td.blur(); }
+    if(e.key==='Escape'){ td.textContent=td.dataset.orig||''; td.blur(); }
+  };
+  td.onblur=()=>{ onSave(td.textContent.trim()); };
+  return td;
+}
+
+function numberCell(value,onSave){
+  const td=document.createElement('td');
+  const inp=document.createElement('input');
+  inp.type='number';
+  inp.min='1';
+  inp.value=value||'';
+  if(!inp.value) inp.classList.add('invalid');
+  inp.onfocus=()=>{ inp.dataset.orig=inp.value; };
+  inp.onkeydown=e=>{
+    if(e.key==='Enter'){ e.preventDefault(); inp.blur(); }
+    if(e.key==='Escape'){ inp.value=inp.dataset.orig||''; inp.dispatchEvent(new Event('input')); inp.blur(); }
+  };
+  inp.oninput=()=>{
+    onSave(inp.value?inp.valueAsNumber:'');
+    if(!inp.value) inp.classList.add('invalid');
+    else inp.classList.remove('invalid');
+  };
+  td.appendChild(inp);
+  return td;
+}
+
+function estadoCell(value,onSave){
+  const td=document.createElement('td');
+  if(logged()){
+    const sel=document.createElement('select');
+    ['Abierto','Cerrado'].forEach(v=>{
+      const opt=document.createElement('option');
+      opt.value=v; opt.textContent=v; sel.appendChild(opt);
+    });
+    sel.value=value||'Abierto';
+    sel.onfocus=()=>{ sel.dataset.orig=sel.value; };
+    sel.onkeydown=e=>{ if(e.key==='Escape'){ sel.value=sel.dataset.orig; sel.blur(); } };
+    sel.onchange=()=>{ onSave(sel.value); };
+    td.appendChild(sel);
+  } else {
+    td.textContent=value||'';
+  }
+  return td;
+}
+
+function render(){
+  renderHeader();
+  const cont=document.getElementById('processContainer');
+  cont.innerHTML='';
+  data.processes.forEach((proc,pIdx)=>{
+    const details=document.createElement('details');
+    details.className='process-section';
+    details.open=true;
+    const summary=document.createElement('summary');
+    const title=document.createElement('span');
+    title.textContent=proc.titulo||`Proceso ${pIdx+1}`;
+    if(logged()){
+      title.contentEditable='true';
+      title.onfocus=()=>{ title.dataset.orig=title.textContent; };
+      title.onkeydown=e=>{
+        if(e.key==='Enter'){ e.preventDefault(); title.blur(); }
+        if(e.key==='Escape'){ title.textContent=title.dataset.orig||''; title.blur(); }
+      };
+      title.onblur=()=>{ proc.titulo=title.textContent.trim(); save(); };
+    }
+    summary.appendChild(title);
+    if(logged()){
+      const btns=document.createElement('span');
+      const dup=document.createElement('button');
+      dup.textContent='Duplicar';
+      dup.onclick=()=>{ const copy=JSON.parse(JSON.stringify(proc)); data.processes.splice(pIdx+1,0,copy); save(); render(); };
+      const del=document.createElement('button');
+      del.textContent='🗑';
+      del.onclick=()=>{ if(confirm('¿Eliminar proceso?')){ data.processes.splice(pIdx,1); save(); render(); } };
+      btns.appendChild(dup); btns.appendChild(del);
+      summary.appendChild(btns);
+    }
+    details.appendChild(summary);
+    const fields=document.createElement('div');
+    fields.className='process-fields';
+    ['estacion','descripcion','materiales','requerimientos'].forEach(f=>{
+      const lab=document.createElement('label');
+      lab.textContent=f.charAt(0).toUpperCase()+f.slice(1);
+      if(logged()){
+        const inp=document.createElement('input');
+        inp.value=proc[f]||'';
+        if(!inp.value) inp.classList.add('invalid');
+        inp.onfocus=()=>{ inp.dataset.orig=inp.value; };
+        inp.onkeydown=e=>{
+          if(e.key==='Enter'){ e.preventDefault(); inp.blur(); }
+          if(e.key==='Escape'){ inp.value=inp.dataset.orig||''; inp.dispatchEvent(new Event('input')); inp.blur(); }
+        };
+        inp.oninput=()=>{
+          proc[f]=inp.value.trim();
+          if(!proc[f]) inp.classList.add('invalid'); else inp.classList.remove('invalid');
+          save();
+        };
+        lab.appendChild(inp);
+      } else {
+        const span=document.createElement('span'); span.textContent=proc[f]||''; lab.appendChild(span);
+      }
+      fields.appendChild(lab);
+    });
+    details.appendChild(fields);
+    const wrap=document.createElement('div');
+    wrap.className='table-wrapper';
+    const table=document.createElement('table');
+    table.id='tabla-'+pIdx;
+    table.className='fmea-table display';
+    table.innerHTML='<thead><tr><th>Efecto planta interna</th><th>Efecto planta cliente</th><th>Efecto usuario final</th><th>Causa</th><th>S</th><th>O</th><th>D</th><th>RPN</th><th>Acción preventiva</th><th>Acción detectiva</th><th>Responsable</th><th>Fecha objetivo</th><th>Estado</th><th>Observaciones</th><th></th></tr><tr class="filters"></tr></thead><tbody></tbody>';
+    wrap.appendChild(table);
+    details.appendChild(wrap);
+    proc.modos.forEach((m,rIdx)=>{
+      const tr=document.createElement('tr');
+      ['efInt','efCli','efUsu','causa','s','o','d','rpn','prev','det','resp','fecha','estado','obs'].forEach((fld,idx)=>{
+        let td;
+        if(idx===7){
+          td=document.createElement('td');
+          td.textContent=m.rpn||'';
+        } else if(!logged()){
+          td=document.createElement('td');
+          td.textContent=m[fld]||'';
+        } else if(['s','o','d'].includes(fld)){
+          td=numberCell(m[fld],val=>{
+            m[fld]=val;
+            const s=Number(m.s)||0,o=Number(m.o)||0,d=Number(m.d)||0;
+            m.rpn=s*o*d;
+            tr.children[7].textContent=m.rpn||'';
+            save();
+          });
+        } else if(fld==='estado'){
+          td=estadoCell(m[fld],val=>{ m[fld]=val; save(); });
+        } else {
+          td=editableCell(m[fld],val=>{ m[fld]=val; save(); });
+        }
+        tr.appendChild(td);
+      });
+      const tdDel=document.createElement('td');
+      if(logged()){
+        const del=document.createElement('button');
+        del.textContent='🗑';
+        del.onclick=()=>{ proc.modos.splice(rIdx,1); save(); render(); };
+        tdDel.appendChild(del);
+      }
+      tr.appendChild(tdDel);
+      table.querySelector('tbody').appendChild(tr);
+    });
+    if(logged()){
+      const addBtn=document.createElement('button');
+      addBtn.textContent='+ Modo de Falla';
+      addBtn.className='add-mode-btn';
+      addBtn.onclick=()=>{ proc.modos.push({}); save(); render(); };
+      details.appendChild(addBtn);
+    }
+    cont.appendChild(details);
+
+    const dt=$(table).DataTable({paging:false,ordering:true,info:false,searching:false,scrollX:true,dom:'t'});
+    const filterRow=table.querySelector('tr.filters');
+    dt.columns().every(function(){
+      const th=document.createElement('th');
+      if(this.index()<14){
+        const input=document.createElement('input');
+        input.placeholder='Filtrar';
+        input.style.width='100%';
+        input.oninput=()=>{ dt.column(this.index()).search(input.value).draw(); };
+        th.appendChild(input);
+      }
+      filterRow.appendChild(th);
+    });
+  });
+}
+
+window.addEventListener('DOMContentLoaded',()=>{
+  load();
+  render();
+  document.getElementById('addProcess').onclick=()=>{
+    if(!logged()) return;
+    data.processes.push({titulo:'',estacion:'',descripcion:'',materiales:'',requerimientos:'',modos:[]});
+    save();
+    render();
+  };
+});
 })();

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Ingeniería Barack</title>
-    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;600&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="styles.css">
 </head>
   <body class="home">

--- a/insumos.html
+++ b/insumos.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Base de datos de Insumos</title>
+  <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;600&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="styles.css">
 </head>
 <body>

--- a/listado_maestro.html
+++ b/listado_maestro.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Listado maestro de ingeniería</title>
+  <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;600&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="styles.css" />
 </head>
 <body>

--- a/login.html
+++ b/login.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Iniciar sesión</title>
+  <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;600&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="styles.css">
 </head>
 <body>

--- a/product_builder.html
+++ b/product_builder.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Constructor de producto</title>
+  <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;600&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="styles.css">
 </head>
 <body>

--- a/sinoptico.html
+++ b/sinoptico.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Sinóptico de Producto Barack</title>
+  <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;600&display=swap" rel="stylesheet">
 
   <!-- Vinculamos el CSS externo -->
   <link rel="stylesheet" href="styles.css" />

--- a/sinoptico_edit.html
+++ b/sinoptico_edit.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Editor del Sinóptico</title>
+  <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;600&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="styles.css" />
 </head>
 <body>

--- a/sinoptico_eliminar.html
+++ b/sinoptico_eliminar.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Eliminar elementos</title>
+  <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;600&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="styles.css">
 </head>
 <body>

--- a/sinoptico_modificar.html
+++ b/sinoptico_modificar.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Modificar elementos</title>
+  <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;600&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="styles.css">
 </head>
 <body>

--- a/styles.css
+++ b/styles.css
@@ -9,7 +9,7 @@
   --color-accent: #0066cc;
   --color-accent-hover: #004c99;
   --color-light: #ffffff;
-  --font-base: 'Poppins', Arial, sans-serif;
+  --font-base: 'Montserrat', sans-serif;
 
   /* new mappings used later in the file */
   --primary-color: var(--color-primary);
@@ -91,6 +91,12 @@ h1 {
 
 .hidden {
   display: none !important;
+}
+
+/* highlight invalid form fields */
+.invalid {
+  border: 1px solid red !important;
+  background-color: #ffe5e5 !important;
 }
 
 /* ==============================
@@ -1100,7 +1106,7 @@ select {
 
 /* ========= Flow diagram enhancements ========= */
 .flow-diagram {
-  font-family: 'Montserrat', sans-serif;
+  font-family: var(--font-base);
 }
 
 .flow-diagram .tree-list,
@@ -1228,7 +1234,7 @@ select {
 /* ==============================
    CONSTRUCTOR VISUAL DE PRODUCTO
    ============================== */
-.wizard { max-width: 900px; margin: 20px auto; font-family: 'Montserrat', sans-serif; }
+.wizard { max-width: 900px; margin: 20px auto; font-family: var(--font-base); }
 .wizard .progress { height: 8px; background:#e0e0e0; border-radius:4px; overflow:hidden; margin-bottom:20px; }
 .wizard .progress #progressBar { height:100%; width:0; background:linear-gradient(90deg,#4b6cb7,#182848); transition:width 0.3s; }
 .wizard-step { display:none; }


### PR DESCRIPTION
## Summary
- add new `.invalid` style and use Montserrat as base font
- update all HTML pages to load Montserrat and rely on CSS variable
- replace undo logic in AMFE editors with custom restore handling
- make S/O/D numeric inputs compute RPN
- render Estado column as dropdown

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c27b91e3c832f97838d7a8c549186