### PR TITLE
Trigger sinoptico-loaded event for builder

### DIFF
--- a/product_builder.js
+++ b/product_builder.js
@@ -150,6 +150,6 @@ document.addEventListener('DOMContentLoaded', () => {
   document.getElementById('builderCode').addEventListener('input', renderPreview);
 
   document.addEventListener('sinoptico-mode', () => { renderLists(); renderPreview(); });
-  setTimeout(() => { renderLists(); renderPreview(); }, 300);
+  document.addEventListener('sinoptico-loaded', () => { renderLists(); renderPreview(); });
 });
 

--- a/renderer.js
+++ b/renderer.js
@@ -691,6 +691,9 @@
         if (sinopticoElem) {
           procesarDatos(sinopticoData, expandedIds);
         }
+        Promise.resolve().then(() => {
+          document.dispatchEvent(new CustomEvent('sinoptico-loaded'));
+        });
       }
 
       // Llamo inmediatamente a loadData()


### PR DESCRIPTION
## Summary
- emit `sinoptico-loaded` when loadData finishes
- refresh product builder lists when the event fires and drop the timer

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c2e0f1ef0832faef524834d458694