### PR TITLE
Add sinoptico-data-changed event and live updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,17 @@ The list is stored in your browser's `localStorage`; the no-borrar folder is no 
 - **Cross-linking** – clicking an insumo in the sinóptico opens the list filtered to that entry.
 - **Insumo editing** – administrators can agregar, modificar o eliminar insumos desde `insumos.html`.
 - **AMFE persistence** – the AMFE pages store their data in `localStorage`.
+- **Data change event** – pages dispatch a `sinoptico-data-changed` event after
+  updating the product tree so other modules can refresh their views.
 
 The product hierarchy is stored in `localStorage`.
+
+## Listening for data changes
+
+Whenever `SinopticoEditor.addNode`, `updateNode` or `deleteSubtree` modifies the
+hierarchy it stores the updated array and dispatches the
+`sinoptico-data-changed` event. Scripts can listen for this event on
+`document` and call `SinopticoEditor.getNodes()` to refresh their UI.
 
 ## Dependencies and browser requirements
 

--- a/product_builder.js
+++ b/product_builder.js
@@ -150,6 +150,7 @@ document.addEventListener('DOMContentLoaded', () => {
   document.getElementById('builderCode').addEventListener('input', renderPreview);
 
   document.addEventListener('sinoptico-mode', () => { renderLists(); renderPreview(); });
+  document.addEventListener('sinoptico-data-changed', () => { renderLists(); renderPreview(); });
   setTimeout(() => { renderLists(); renderPreview(); }, 300);
 });
 

--- a/renderer.js
+++ b/renderer.js
@@ -1018,6 +1018,7 @@
           }
           saveSinoptico();
           loadData();
+          document.dispatchEvent(new CustomEvent('sinoptico-data-changed'));
           return row.ID;
         },
         deleteSubtree(id) {
@@ -1029,6 +1030,7 @@
           sinopticoData = sinopticoData.filter(r => !ids.has(r.ID));
           saveSinoptico();
           loadData();
+          document.dispatchEvent(new CustomEvent('sinoptico-data-changed'));
         },
         updateNode(id, attrs) {
           const node = sinopticoData.find(r => r.ID === id);
@@ -1039,6 +1041,7 @@
           }
           saveSinoptico();
           loadData();
+          document.dispatchEvent(new CustomEvent('sinoptico-data-changed'));
         },
         getNodes() {
           return sinopticoData.slice();

--- a/sinoptico-create.js
+++ b/sinoptico-create.js
@@ -317,6 +317,9 @@ document.addEventListener('DOMContentLoaded', () => {
   document.addEventListener('sinoptico-mode', () => {
     fillOptions();
   });
+  document.addEventListener('sinoptico-data-changed', () => {
+    fillOptions();
+  });
   setTimeout(() => {
     fillOptions();
   }, 300);

--- a/sinoptico-delete.js
+++ b/sinoptico-delete.js
@@ -50,6 +50,11 @@ document.addEventListener('DOMContentLoaded', () => {
   sIns.addEventListener('input', () => buildList(rIns, search('insumo', sIns.value)));
 
   document.dispatchEvent(new Event('sinoptico-mode'));
+  document.addEventListener('sinoptico-data-changed', () => {
+    buildList(rClient, search('cliente', sClient.value));
+    buildList(rProd, search('producto', sProd.value));
+    buildList(rIns, search('insumo', sIns.value));
+  });
   setTimeout(() => {
     buildList(rClient, []);
     buildList(rProd, []);

--- a/sinoptico-edit.js
+++ b/sinoptico-edit.js
@@ -126,5 +126,6 @@ document.addEventListener('DOMContentLoaded', () => {
   });
 
   document.addEventListener('sinoptico-mode', fillOptions);
+  document.addEventListener('sinoptico-data-changed', fillOptions);
   setTimeout(fillOptions, 300);
 });

--- a/sinoptico-modify.js
+++ b/sinoptico-modify.js
@@ -31,5 +31,6 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   document.addEventListener('sinoptico-mode', render);
+  document.addEventListener('sinoptico-data-changed', render);
   setTimeout(render, 300);
 });


### PR DESCRIPTION
## Summary
- dispatch `sinoptico-data-changed` whenever the hierarchy is modified
- refresh UI components in product builder and editor pages on the new event
- document the event in the README for integrators

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c2e0affd4832fbf3d3847aa745499