### PR TITLE
Enhance product wizard with client support

### DIFF
--- a/visual_constructor.html
+++ b/visual_constructor.html
@@ -24,6 +24,7 @@
       <div class="inline-form">
         <input type="text" id="prodDesc" placeholder="Descripción" required>
         <input type="text" id="prodCode" placeholder="Código">
+        <select id="prodClient"></select>
         <button id="toStep2">Siguiente</button>
       </div>
     </section>
@@ -42,6 +43,7 @@
   <script src="auth.js"></script>
   <script src="theme.js" defer></script>
   <script src="smooth-nav.js" defer></script>
+  <script src="renderer.js"></script>
   <script src="visual_constructor.js"></script>
 </body>
 </html>

--- a/visual_constructor.js
+++ b/visual_constructor.js
@@ -12,8 +12,25 @@ document.addEventListener('DOMContentLoaded', () => {
   const productCard = document.getElementById('productCard');
   const summaryTree = document.getElementById('summaryTree');
   const saveBtn = document.getElementById('saveAll');
+  const clientSelect = document.getElementById('prodClient');
 
   const root = { descripcion: '', codigo: '', subproductos: [] };
+
+  fillClientOptions();
+
+  function fillClientOptions() {
+    if (!clientSelect) return;
+    if (!window.SinopticoEditor || !SinopticoEditor.getNodes) return;
+    const nodes = SinopticoEditor.getNodes();
+    const clients = nodes.filter(n => (n.Tipo || '').toLowerCase() === 'cliente');
+    clientSelect.innerHTML = '';
+    clients.forEach(c => {
+      const opt = document.createElement('option');
+      opt.value = c.ID;
+      opt.textContent = c['Descripción'] || '';
+      clientSelect.appendChild(opt);
+    });
+  }
 
   function showToast(msg) {
     const div = document.createElement('div');
@@ -187,7 +204,9 @@ document.addEventListener('DOMContentLoaded', () => {
       }))
     };
     if (window.SinopticoEditor && SinopticoEditor.addNode) {
+      const parentId = clientSelect ? clientSelect.value : '';
       SinopticoEditor.addNode({
+        ParentID: parentId,
         Tipo: data.Tipo,
         Descripción: data.Descripción,
         Código: data.Código
@@ -205,4 +224,8 @@ document.addEventListener('DOMContentLoaded', () => {
       showToast('Error: SinopticoEditor no disponible');
     }
   });
+
+  document.addEventListener('sinoptico-mode', fillClientOptions);
+  document.addEventListener('sinoptico-data-changed', fillClientOptions);
+  setTimeout(fillClientOptions, 300);
 });


### PR DESCRIPTION
## Summary
- add client dropdown to the visual constructor
- populate the dropdown and save with `ParentID`
- include `renderer.js` so SinopticoEditor is available

## Testing
- `scripts/setup.sh`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c3367f694832faa7c8f6fdc6f0362