### PR TITLE
Prevent auth test from modifying user file

### DIFF
--- a/test-auth.js
+++ b/test-auth.js
@@ -7,15 +7,38 @@ global.localStorage = window.localStorage;
 const fs = require('fs');
 const path = require('path');
 const userFile = path.join(__dirname, 'no-borrar', 'users.json');
+
+// load the users file once and work on a memory copy
+let memoryUsers = [];
 if (fs.existsSync(userFile)) {
   try {
-    const existing = JSON.parse(fs.readFileSync(userFile, 'utf8'));
-    const filtered = existing.filter(u => u.username !== 'user1');
-    if (filtered.length !== existing.length)
-      fs.writeFileSync(userFile, JSON.stringify(filtered, null, 2));
-    localStorage.setItem('users', JSON.stringify(filtered));
-  } catch (e) {}
+    memoryUsers = JSON.parse(fs.readFileSync(userFile, 'utf8'));
+  } catch (e) {
+    memoryUsers = [];
+  }
 }
+memoryUsers = memoryUsers.filter(u => u.username !== 'user1');
+localStorage.setItem('users', JSON.stringify(memoryUsers));
+
+// intercept reads/writes so auth.js doesn't touch the real file
+const originalRead = fs.readFileSync;
+const originalWrite = fs.writeFileSync;
+fs.readFileSync = function (p, enc) {
+  if (path.resolve(p) === path.resolve(userFile)) {
+    return JSON.stringify(memoryUsers, null, 2);
+  }
+  return originalRead.call(fs, p, enc);
+};
+fs.writeFileSync = function (p, data) {
+  if (path.resolve(p) === path.resolve(userFile)) {
+    try {
+      memoryUsers = JSON.parse(data);
+    } catch (e) {}
+    localStorage.setItem('users', JSON.stringify(memoryUsers));
+    return;
+  }
+  return originalWrite.call(fs, p, data);
+};
 
 const auth = require('./auth.js');
 
@@ -29,12 +52,11 @@ if (sessionStorage.getItem('currentUser') !== 'user1') throw new Error('session 
 auth.logout();
 if (sessionStorage.getItem('currentUser')) throw new Error('logout failed');
 auth.changePassword('user1','new');
+
 if (!auth.login('user1','new')) throw new Error('password change failed');
 
-// cleanup the test user so repeated runs remain idempotent
-const users = JSON.parse(fs.readFileSync(userFile, 'utf8'));
-const remaining = users.filter(u => u.username !== 'user1');
-fs.writeFileSync(userFile, JSON.stringify(remaining, null, 2));
-localStorage.setItem('users', JSON.stringify(remaining));
+// restore fs operations
+fs.readFileSync = originalRead;
+fs.writeFileSync = originalWrite;
 
 console.log('auth tests passed');


### PR DESCRIPTION
## Summary
- patch `test-auth.js` so it operates on an in-memory copy of `no-borrar/users.json`
- intercept fs operations during the test to avoid touching the file

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684c350ccacc832faa5b108bf8059cf8