### PR TITLE
Update visual constructor and add tree arrows

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1139,11 +1139,22 @@ select {
   position: absolute;
   top: 50%;
   left: 100%;
-  width: 20px;
+  width: 14px;
   border-top: 2px solid #ccc;
 }
+.flow-diagram li > .tree-node::before {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: calc(100% + 14px);
+  border-width: 4px 0 4px 6px;
+  border-style: solid;
+  border-color: transparent transparent transparent #ccc;
+  transform: translateY(-50%);
+}
 
-.flow-diagram li:last-child > .tree-node::after {
+.flow-diagram li:last-child > .tree-node::after,
+.flow-diagram li:last-child > .tree-node::before {
   display: none;
 }
 

--- a/visual_constructor.html
+++ b/visual_constructor.html
@@ -33,10 +33,6 @@
     <section id="step2" class="wizard-step hidden">
       <h2>Paso 2: Agregar Subproductos</h2>
       <div id="productCard" class="builder-card"></div>
-      <button id="toStep3">Siguiente</button>
-    </section>
-    <section id="step3" class="wizard-step hidden">
-      <h2>Paso 3: Agregar Insumos</h2>
       <div id="summaryTree" class="tree-preview flow-diagram"></div>
       <button id="saveAll">Guardar Producto</button>
     </section>

--- a/visual_constructor.js
+++ b/visual_constructor.js
@@ -8,7 +8,6 @@ document.addEventListener('DOMContentLoaded', () => {
   const progressBar = document.getElementById('progressBar');
   const step1 = document.getElementById('step1');
   const step2 = document.getElementById('step2');
-  const step3 = document.getElementById('step3');
   const productCard = document.getElementById('productCard');
   const summaryTree = document.getElementById('summaryTree');
   const saveBtn = document.getElementById('saveAll');
@@ -42,8 +41,8 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   function updateProgress(step) {
-    progressBar.style.width = step * 33 + '%';
-    [step1, step2, step3].forEach((s,i) => {
+    progressBar.style.width = step * 50 + '%';
+    [step1, step2].forEach((s,i) => {
       if (i === step-1) {
         s.classList.remove('hidden');
         s.classList.add('active');
@@ -240,10 +239,6 @@ document.addEventListener('DOMContentLoaded', () => {
     updateProgress(2);
   });
 
-  document.getElementById('toStep3').addEventListener('click', () => {
-    updateSummary();
-    updateProgress(3);
-  });
 
   saveBtn.addEventListener('click', () => {
     updateSummary();


### PR DESCRIPTION
## Summary
- simplify the visual constructor by removing the last step
- adjust progress logic to two steps
- add arrow markers in flow diagram trees

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c3e4b0a80832fa9c62884d6481f65