### PR TITLE
Add ultralight process AMFE editor

### DIFF
--- a/amfe_proceso_ultra.html
+++ b/amfe_proceso_ultra.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>AMFE de Proceso Ultraligero</title>
+  <link rel="stylesheet" href="styles.css">
+  <style>
+    body { font-family: var(--font-base); margin:0; }
+    .header-grid { position:sticky; top:0; z-index:100; background:#fff; padding:10px; margin:0; display:grid; grid-template-columns:repeat(auto-fit,minmax(200px,1fr)); gap:10px; box-shadow:0 2px 4px rgba(0,0,0,0.1); }
+    .header-grid label { display:flex; flex-direction:column; font-weight:600; }
+    .team-list span { background:#0066cc; color:#fff; padding:2px 6px; margin:2px; border-radius:4px; display:inline-block; transition:box-shadow .2s; }
+    .team-list button { margin-left:4px; }
+    .process-section { margin:20px; border-radius:8px; background:#fff; box-shadow:0 2px 4px rgba(0,0,0,0.1); }
+    .process-section summary { cursor:pointer; padding:10px; background:linear-gradient(#4b6cb7,#182848); color:#fff; border-radius:8px 8px 0 0; display:flex; justify-content:space-between; align-items:center; }
+    .process-fields { display:grid; grid-template-columns:repeat(auto-fit,minmax(150px,1fr)); gap:10px; padding:10px; }
+    .process-fields span { border:1px solid #ccc; padding:4px; border-radius:4px; min-height:22px; }
+    .process-fields .invalid { border-color:red; }
+    .table-wrapper { overflow-x:auto; padding:10px; }
+    table.fmea-table { border-collapse:collapse; width:100%; }
+    table.fmea-table th, table.fmea-table td { border:1px solid #ccc; padding:4px; }
+    table.fmea-table th { background:#0d1b3d; color:#fff; position:sticky; top:0; }
+    table.fmea-table tbody tr:nth-child(even) { background:#f0f4ff; }
+    button { border:none; padding:6px 12px; background:#0d1b3d; color:#fff; border-radius:4px; cursor:pointer; transition:box-shadow .2s; }
+    button:hover { box-shadow:0 2px 4px rgba(0,0,0,0.2); }
+    button.hidden { display:none; }
+    [contenteditable]:focus { outline:2px solid var(--color-accent); }
+    .add-mode-btn { margin-top:10px; }
+    #saveAmfe { position:fixed; bottom:20px; right:20px; }
+  </style>
+</head>
+<body class="amfe-page">
+  <nav class="main-nav">
+    <a href="index.html">Inicio</a>
+    <a href="sinoptico.html">Sinóptico</a>
+    <a href="listado_maestro.html">Listado maestro</a>
+    <button id="toggleTheme">🌙</button>
+  </nav>
+  <section class="header-grid" id="amfeHeader">
+    <label>Organización<input id="hdr-organizacion"></label>
+    <label>Planta<input id="hdr-planta"></label>
+    <label>Fecha de Inicio<input id="hdr-fecha" type="date"></label>
+    <label>Responsable de Diseño<input id="hdr-responsable"></label>
+    <label>Cliente<input id="hdr-cliente"></label>
+    <label>Confidencialidad<input id="hdr-conf"></label>
+    <label>Modelo/Año<input id="hdr-modelo"></label>
+    <label>Equipo
+      <div class="team-list" id="teamList"></div>
+      <div id="teamControls">
+        <input id="teamInput" placeholder="Nombre">
+        <button id="teamAdd">+</button>
+      </div>
+    </label>
+  </section>
+  <div id="processContainer"></div>
+  <button id="addProcess">+ Proceso</button>
+  <button id="saveAmfe">Guardar AMFE</button>
+  <div id="toast" class="toast" style="display:none"></div>
+  <script src="theme.js" defer></script>
+  <script src="smooth-nav.js" defer></script>
+  <script src="amfe_proceso_ultra.js"></script>
+</body>
+</html>

--- a/amfe_proceso_ultra.js
+++ b/amfe_proceso_ultra.js
@@ -1,0 +1,215 @@
+(function(){
+  const STORAGE_KEY = 'amfeProcesoUltra';
+  const isAdmin = sessionStorage.getItem('isAdmin') === 'true';
+  let data = {
+    header: {
+      organizacion: '',
+      planta: '',
+      fecha: '',
+      responsable: '',
+      cliente: '',
+      confidencialidad: '',
+      modelo: '',
+      equipo: []
+    },
+    processes: []
+  };
+
+  function loadData(){
+    const saved = localStorage.getItem(STORAGE_KEY);
+    if(saved){
+      try{ data = JSON.parse(saved); }catch(e){}
+    }
+  }
+
+  function saveData(){
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+  }
+
+  function initHeader(){
+    ['organizacion','planta','fecha','responsable','cliente','conf','modelo'].forEach(key=>{
+      const el=document.getElementById('hdr-'+key);
+      if(!el) return;
+      el.value=data.header[key]||'';
+      el.readOnly=!isAdmin;
+      el.addEventListener('input',()=>{ data.header[key]=el.value; saveData(); });
+    });
+    renderTeam();
+  }
+
+  function renderTeam(){
+    const list=document.getElementById('teamList');
+    list.innerHTML='';
+    data.header.equipo.forEach((name,idx)=>{
+      const span=document.createElement('span');
+      span.textContent=name;
+      if(isAdmin){
+        const del=document.createElement('button');
+        del.textContent='×';
+        del.onclick=()=>{ data.header.equipo.splice(idx,1); saveData(); renderTeam(); };
+        span.appendChild(del);
+      }
+      list.appendChild(span);
+    });
+    const controls=document.getElementById('teamControls');
+    if(isAdmin){
+      controls.style.display='block';
+      document.getElementById('teamAdd').onclick=()=>{
+        const inp=document.getElementById('teamInput');
+        const name=inp.value.trim();
+        if(name){ data.header.equipo.push(name); inp.value=''; saveData(); renderTeam(); }
+      };
+    } else {
+      controls.style.display='none';
+    }
+  }
+
+  function fieldSpan(text){
+    const span=document.createElement('span');
+    span.textContent=text||'';
+    span.contentEditable=isAdmin;
+    return span;
+  }
+
+  function validateFields(container){
+    let valid=true;
+    container.querySelectorAll('.process-fields span').forEach(s=>{
+      if(!s.textContent.trim()){ s.classList.add('invalid'); valid=false; }
+      else s.classList.remove('invalid');
+    });
+    return valid;
+  }
+
+  function renderProcesses(){
+    const cont=document.getElementById('processContainer');
+    cont.innerHTML='';
+    data.processes.forEach((proc,pIdx)=>{
+      const details=document.createElement('details');
+      details.className='process-section';
+      details.open=true;
+      const summary=document.createElement('summary');
+      const title=document.createElement('span');
+      title.textContent=proc.titulo||`Proceso ${pIdx+1}`;
+      summary.appendChild(title);
+      if(isAdmin){
+        const btnWrap=document.createElement('span');
+        const edit=document.createElement('button'); edit.textContent='✎';
+        edit.onclick=()=>{ const n=prompt('Nombre del proceso', title.textContent); if(n){ proc.titulo=n; title.textContent=n; saveData(); } };
+        const dup=document.createElement('button'); dup.textContent='📄';
+        dup.onclick=()=>{ const copy=JSON.parse(JSON.stringify(proc)); data.processes.splice(pIdx+1,0,copy); saveData(); renderProcesses(); };
+        const del=document.createElement('button'); del.textContent='🗑️';
+        del.onclick=()=>{ if(confirm('¿Eliminar proceso?')){ data.processes.splice(pIdx,1); saveData(); renderProcesses(); } };
+        btnWrap.append(edit,dup,del);
+        summary.appendChild(btnWrap);
+      }
+      details.appendChild(summary);
+      const fields=document.createElement('div');
+      fields.className='process-fields';
+      ['estacion','descripcion','materiales','requerimientos'].forEach(f=>{
+        const span=fieldSpan(proc[f]);
+        span.onblur=()=>{ proc[f]=span.textContent.trim(); validateFields(details); saveData(); };
+        fields.appendChild(span);
+      });
+      details.appendChild(fields);
+      const wrap=document.createElement('div');
+      wrap.className='table-wrapper';
+      const table=document.createElement('table');
+      table.className='fmea-table';
+      table.innerHTML='<thead><tr><th>Efecto planta interna</th><th>Efecto planta cliente</th><th>Efecto usuario final</th><th>Causa</th><th>S</th><th>O</th><th>D</th><th>RPN</th><th>Acción preventiva</th><th>Acción detectiva</th><th>Responsable</th><th>Fecha objetivo</th><th>Estado</th><th>Observaciones</th><th></th></tr></thead><tbody></tbody>';
+      wrap.appendChild(table);
+      details.appendChild(wrap);
+      proc.modos.forEach((m,rIdx)=>{
+        const tr=document.createElement('tr');
+        const fields=['efInt','efCli','efUsu','causa','s','o','d','rpn','prev','det','resp','fecha','estado','obs'];
+        fields.forEach((fld,idx)=>{
+          const td=document.createElement('td');
+          if(fld==='rpn'){ td.textContent=m.rpn||''; }
+          else {
+            td.contentEditable=isAdmin;
+            td.textContent=m[fld]||'';
+            td.onblur=()=>{
+              m[fld]=td.textContent.trim();
+              if(['s','o','d'].includes(fld)){
+                m[fld]=Number(m[fld])||0;
+                const s=Number(m.s)||0,o=Number(m.o)||0,d=Number(m.d)||0;
+                m.rpn=s*o*d;
+                tr.children[7].textContent=m.rpn||'';
+              }
+              saveData();
+            };
+          }
+          tr.appendChild(td);
+        });
+        const tdDel=document.createElement('td');
+        if(isAdmin){
+          const del=document.createElement('button'); del.textContent='🗑️';
+          del.onclick=()=>{ proc.modos.splice(rIdx,1); saveData(); renderProcesses(); };
+          tdDel.appendChild(del);
+        }
+        tr.appendChild(tdDel);
+        table.querySelector('tbody').appendChild(tr);
+      });
+      if(isAdmin){
+        const addBtn=document.createElement('button'); addBtn.textContent='+ Modo de Falla'; addBtn.className='add-mode-btn';
+        addBtn.onclick=()=>{
+          const base=proc.modos[proc.modos.length-1]||{};
+          const clone={};
+          Object.keys({efInt:'',efCli:'',efUsu:'',causa:'',s:'',o:'',d:'',rpn:'',prev:'',det:'',resp:'',fecha:'',estado:'',obs:''}).forEach(k=>clone[k]='');
+          proc.modos.push(clone);
+          saveData();
+          renderProcesses();
+        };
+        details.appendChild(addBtn);
+      }
+      cont.appendChild(details);
+    });
+    if(isAdmin){
+      document.getElementById('addProcess').style.display='block';
+    } else {
+      document.getElementById('addProcess').style.display='none';
+    }
+  }
+
+  document.getElementById('addProcess').addEventListener('click',()=>{
+    data.processes.push({titulo:'',estacion:'',descripcion:'',materiales:'',requerimientos:'',modos:[{efInt:'',efCli:'',efUsu:'',causa:'',s:'',o:'',d:'',rpn:'',prev:'',det:'',resp:'',fecha:'',estado:'',obs:''}]});
+    saveData();
+    renderProcesses();
+  });
+
+  function collectData(){
+    return JSON.parse(JSON.stringify(data));
+  }
+
+  function showToast(msg){
+    const t=document.getElementById('toast');
+    t.textContent=msg;
+    t.style.display='block';
+    setTimeout(()=>{t.style.display='none';},2500);
+  }
+
+  document.getElementById('saveAmfe').addEventListener('click',()=>{
+    if(!isAdmin) return;
+    let valid=true;
+    document.querySelectorAll('.process-section').forEach(sec=>{ if(!validateFields(sec)) valid=false; });
+    if(!valid) return alert('Complete los campos marcados');
+    saveData();
+    showToast('AMFE guardado');
+  });
+
+  document.addEventListener('DOMContentLoaded',()=>{
+    loadData();
+    initHeader();
+    renderProcesses();
+    if(!isAdmin){
+      document.getElementById('saveAmfe').style.display='none';
+    }
+  });
+
+  window.addEventListener('storage',e=>{
+    if(e.key===STORAGE_KEY){
+      loadData();
+      initHeader();
+      renderProcesses();
+    }
+  });
+})();


### PR DESCRIPTION
## Summary
- provide new AMFE de Proceso page built with plain JS
- implement AMFE interaction logic without dependencies
- persist data locally instead of posting to /api

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684c3a253a10832fa3bdbba57a92141e