### PR TITLE
Fix product tree preview and client linking

### DIFF
--- a/renderer.js
+++ b/renderer.js
@@ -574,29 +574,39 @@
         const clientes = {};
         datosOriginal.forEach(fila => {
           const cli = (fila.Cliente || '').toString().trim();
-          if (cli && !clientes[cli]) {
-            const id = `cli-${Object.keys(clientes).length + 1}`;
-            clientes[cli] = { id, nombre: cli };
+          const tipo = (fila.Tipo || '').toString().trim().toLowerCase();
+          if (!cli) return;
+          if (!clientes[cli]) {
+            clientes[cli] = {
+              id: tipo === 'cliente' ? fila.ID : `cli-${Object.keys(clientes).length + 1}`,
+              nombre: cli,
+              existente: tipo === 'cliente'
+            };
+          } else if (tipo === 'cliente') {
+            clientes[cli].id = fila.ID;
+            clientes[cli].existente = true;
           }
         });
 
         // 2) Crear filas virtuales para cada cliente detectado
-        const filasClientes = Object.values(clientes).map(cli => ({
-          ID: cli.id,
-          ParentID: '',
-          Tipo: 'Cliente',
-          Secuencia: '',
-          Descripción: cli.nombre,
-          Cliente: cli.nombre,
-          Vehículo: '',
-          RefInterno: '',
-          versión: '',
-          Imagen: '',
-          Consumo: '',
-          Unidad: '',
-          Sourcing: '',
-          Código: ''
-        }));
+        const filasClientes = Object.values(clientes)
+          .filter(cli => !cli.existente)
+          .map(cli => ({
+            ID: cli.id,
+            ParentID: '',
+            Tipo: 'Cliente',
+            Secuencia: '',
+            Descripción: cli.nombre,
+            Cliente: cli.nombre,
+            Vehículo: '',
+            RefInterno: '',
+            versión: '',
+            Imagen: '',
+            Consumo: '',
+            Unidad: '',
+            Sourcing: '',
+            Código: ''
+          }));
 
         // 3) Reasignar las piezas finales para que cuelguen del cliente
         const datos = datosOriginal.map(row => {

--- a/styles.css
+++ b/styles.css
@@ -1115,7 +1115,8 @@ select {
   margin: 0;
   padding: 0;
   display: flex;
-  align-items: center;
+  flex-direction: column;
+  align-items: flex-start;
 }
 
 .flow-diagram .tree-list ul {
@@ -1132,6 +1133,8 @@ select {
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
   animation: fadeIn 0.3s ease forwards;
   opacity: 0;
+  white-space: normal;
+  word-break: break-word;
 }
 
 .flow-diagram li > .tree-node::after {


### PR DESCRIPTION
## Summary
- keep product tree preview vertical and allow node text to wrap
- avoid duplicate client nodes when loading sinoptico data

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c40f456e0832f808d3c030a7f0d57