### PR TITLE
Update README for ultralight AMFE page

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@ The **master document list** lets you organise engineering documents by category
 
 The list is stored solely in your browser's `localStorage`.
 
-## Using `amfe_proceso_mejorado.html`
+## Using `amfe_proceso_ultra.html`
 
-Open `amfe_proceso_mejorado.html` in a browser to work with an enhanced process AMFE. Log in to add processes or failure modes and edit the tables inline. All data is kept in `localStorage`.
+Open `amfe_proceso_ultra.html` in a browser to use the ultralight process AMFE. It saves everything to `localStorage` and has no external dependencies. Log in to add processes or failure modes and edit the tables inline.
 
 
 ## Features
@@ -47,7 +47,7 @@ Open `amfe_proceso_mejorado.html` in a browser to work with an enhanced process 
 - **Cross-linking** – clicking an insumo in the sinóptico opens the list filtered to that entry.
 - **Insumo editing** – administrators can agregar, modificar o eliminar insumos desde `insumos.html`.
 - **AMFE persistence** – the AMFE pages store their data in `localStorage`.
-- **Improved process AMFE** – `amfe_proceso_mejorado.html` adds per-process sections with DataTable filtering and inline editing. Data is saved to `localStorage`.
+- **Ultralight process AMFE** – `amfe_proceso_ultra.html` saves everything to `localStorage` and has no external dependencies.
 - **Data change event** – pages dispatch a `sinoptico-data-changed` event after
   updating the product tree so other modules can refresh their views.
 


### PR DESCRIPTION
## Summary
- update references to amfe_proceso_ultra.html
- describe that this ultralight version stores data in `localStorage` and requires no external libraries

## Testing
- `scripts/setup.sh`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c43c3ec7c832fa0b16d5f2caf8649