### PR TITLE
Add sequence field to process AMFE

### DIFF
--- a/amfe_proceso_ultra.js
+++ b/amfe_proceso_ultra.js
@@ -1,4 +1,5 @@
 (function(){
+  const STORAGE_KEY = 'amfeUltraData';
   const isAdmin = sessionStorage.getItem('isAdmin') === 'true';
   const data = {
     header: {
@@ -14,13 +15,30 @@
     processes: []
   };
 
+  try {
+    const stored = JSON.parse(localStorage.getItem(STORAGE_KEY));
+    if (stored && typeof stored === 'object') {
+      if (stored.header) Object.assign(data.header, stored.header);
+      if (Array.isArray(stored.processes)) data.processes = stored.processes;
+    }
+  } catch (e) {}
+
+  data.processes.forEach((p, i) => {
+    if (typeof p.secuencia === 'undefined') p.secuencia = i + 1;
+    if (!Array.isArray(p.modos)) p.modos = [];
+  });
+
+  function save(){
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+  }
+
   function initHeader(){
     ['organizacion','planta','fecha','responsable','cliente','conf','modelo'].forEach(key=>{
       const el=document.getElementById('hdr-'+key);
       if(!el) return;
       el.value=data.header[key]||'';
       el.readOnly=!isAdmin;
-      el.addEventListener('input',()=>{ data.header[key]=el.value; });
+      el.addEventListener('input',()=>{ data.header[key]=el.value; save(); });
     });
     renderTeam();
   }
@@ -34,7 +52,7 @@
       if(isAdmin){
         const del=document.createElement('button');
         del.textContent='×';
-        del.onclick=()=>{ data.header.equipo.splice(idx,1); renderTeam(); };
+        del.onclick=()=>{ data.header.equipo.splice(idx,1); save(); renderTeam(); };
         span.appendChild(del);
       }
       list.appendChild(span);
@@ -45,7 +63,7 @@
       document.getElementById('teamAdd').onclick=()=>{
         const inp=document.getElementById('teamInput');
         const name=inp.value.trim();
-        if(name){ data.header.equipo.push(name); inp.value=''; renderTeam(); }
+        if(name){ data.header.equipo.push(name); inp.value=''; save(); renderTeam(); }
       };
     } else {
       controls.style.display='none';
@@ -61,9 +79,10 @@
 
   function validateFields(container){
     let valid=true;
-    container.querySelectorAll('.process-fields span').forEach(s=>{
-      if(!s.textContent.trim()){ s.classList.add('invalid'); valid=false; }
-      else s.classList.remove('invalid');
+    container.querySelectorAll('.process-fields span, .process-fields input').forEach(el=>{
+      const val = el.tagName==='INPUT' ? el.value : el.textContent;
+      if(!val.toString().trim()){ el.classList.add('invalid'); valid=false; }
+      else el.classList.remove('invalid');
     });
     return valid;
   }
@@ -82,21 +101,35 @@
       if(isAdmin){
         const btnWrap=document.createElement('span');
         const edit=document.createElement('button'); edit.textContent='✎';
-        edit.onclick=()=>{ const n=prompt('Nombre del proceso', title.textContent); if(n){ proc.titulo=n; title.textContent=n; } };
+        edit.onclick=()=>{ const n=prompt('Nombre del proceso', title.textContent); if(n){ proc.titulo=n; title.textContent=n; save(); } };
         const dup=document.createElement('button'); dup.textContent='📄';
-        dup.onclick=()=>{ const copy=JSON.parse(JSON.stringify(proc)); data.processes.splice(pIdx+1,0,copy); renderProcesses(); };
+        dup.onclick=()=>{ const copy=JSON.parse(JSON.stringify(proc)); data.processes.splice(pIdx+1,0,copy); save(); renderProcesses(); };
         const del=document.createElement('button'); del.textContent='🗑️';
-        del.onclick=()=>{ if(confirm('¿Eliminar proceso?')){ data.processes.splice(pIdx,1); renderProcesses(); } };
+        del.onclick=()=>{ if(confirm('¿Eliminar proceso?')){ data.processes.splice(pIdx,1); save(); renderProcesses(); } };
         btnWrap.append(edit,dup,del);
         summary.appendChild(btnWrap);
       }
       details.appendChild(summary);
       const fields=document.createElement('div');
       fields.className='process-fields';
-      ['estacion','descripcion','materiales','requerimientos'].forEach(f=>{
-        const span=fieldSpan(proc[f]);
-        span.onblur=()=>{ proc[f]=span.textContent.trim(); validateFields(details); };
-        fields.appendChild(span);
+      ['secuencia','estacion','descripcion','materiales','requerimientos'].forEach(f=>{
+        if(f==='secuencia'){
+          if(isAdmin){
+            const inp=document.createElement('input');
+            inp.type='number';
+            inp.value=proc.secuencia||'';
+            inp.oninput=()=>{ proc.secuencia=parseInt(inp.value,10)||0; save(); };
+            fields.appendChild(inp);
+          } else {
+            const span=document.createElement('span');
+            span.textContent=proc.secuencia||'';
+            fields.appendChild(span);
+          }
+        } else {
+          const span=fieldSpan(proc[f]);
+          span.onblur=()=>{ proc[f]=span.textContent.trim(); validateFields(details); save(); };
+          fields.appendChild(span);
+        }
       });
       details.appendChild(fields);
       const wrap=document.createElement('div');
@@ -123,6 +156,7 @@
                 m.rpn=s*o*d;
                 tr.children[7].textContent=m.rpn||'';
               }
+              save();
             };
           }
           tr.appendChild(td);
@@ -130,7 +164,7 @@
         const tdDel=document.createElement('td');
         if(isAdmin){
           const del=document.createElement('button'); del.textContent='🗑️';
-          del.onclick=()=>{ proc.modos.splice(rIdx,1); renderProcesses(); };
+          del.onclick=()=>{ proc.modos.splice(rIdx,1); save(); renderProcesses(); };
           tdDel.appendChild(del);
         }
         tr.appendChild(tdDel);
@@ -143,6 +177,7 @@
           const clone={};
           Object.keys({efInt:'',efCli:'',efUsu:'',causa:'',s:'',o:'',d:'',rpn:'',prev:'',det:'',resp:'',fecha:'',estado:'',obs:''}).forEach(k=>clone[k]='');
           proc.modos.push(clone);
+          save();
           renderProcesses();
         };
         details.appendChild(addBtn);
@@ -157,7 +192,8 @@
   }
 
   document.getElementById('addProcess').addEventListener('click',()=>{
-    data.processes.push({titulo:'',estacion:'',descripcion:'',materiales:'',requerimientos:'',modos:[{efInt:'',efCli:'',efUsu:'',causa:'',s:'',o:'',d:'',rpn:'',prev:'',det:'',resp:'',fecha:'',estado:'',obs:''}]});
+    data.processes.push({secuencia:data.processes.length+1,titulo:'',estacion:'',descripcion:'',materiales:'',requerimientos:'',modos:[{efInt:'',efCli:'',efUsu:'',causa:'',s:'',o:'',d:'',rpn:'',prev:'',det:'',resp:'',fecha:'',estado:'',obs:''}]});
+    save();
     renderProcesses();
   });
 
@@ -178,6 +214,7 @@
     document.querySelectorAll('.process-section').forEach(sec=>{ if(!validateFields(sec)) valid=false; });
     if(!valid) return alert('Complete los campos marcados');
     const payload=collectData();
+    save();
     fetch('/api/amfe',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(payload)})
       .then(r=>{ if(!r.ok) throw new Error(); })
       .then(()=>showToast('AMFE guardado correctamente'))


### PR DESCRIPTION
## Summary
- persist AMFE data in `localStorage`
- add new `secuencia` number field to each process
- show editable sequence input for admins
- store edits automatically while working

## Testing
- `scripts/setup.sh`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c47306cbc832f8b0993c32b916c94