### PR TITLE
Ensure loaded data is persisted

### DIFF
--- a/renderer.js
+++ b/renderer.js
@@ -714,6 +714,14 @@
           sinopticoData = stored ? JSON.parse(stored) : generarDatosIniciales();
         }
 
+        if (typeof localStorage !== 'undefined') {
+          try {
+            localStorage.setItem('sinopticoData', JSON.stringify(sinopticoData));
+          } catch (e) {
+            console.error('Error persisting sinopticoData', e);
+          }
+        }
+
         if (sinopticoElem) {
           procesarDatos(sinopticoData, expandedIds);
         }


### PR DESCRIPTION
## Summary
- persist `sinopticoData` to localStorage every time the table is loaded
- keep dispatching `sinoptico-data-changed` after modifications so other pages stay in sync

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c4c4cffec832f987e777ea8851381