### PR TITLE
Remove tagline from homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,13 +20,9 @@
           <section class="hero">
               <img src="images/LOGO BARACK.png" alt="Logo Barack" class="logo">
               <h1>Ingeniería Barack</h1>
-              <p class="tagline">Soluciones integrales para la industria automotriz</p>
               <a class="btn-link" href="sinoptico.html">Ver Sinóptico de Producto</a>
               <a class="btn-link" href="listado_maestro.html">Listado maestro</a>
-<<<<<< codex/eliminar-archivos-y-confirmar-referencias
-=======
               <a class="btn-link" href="amfe_proceso_ultra.html">AMFE de proceso</a>
->>>>>> main
         </section>
       </header>
       <main class="intro">

--- a/styles.css
+++ b/styles.css
@@ -738,6 +738,7 @@ body.amfe-page:not(.dark-mode) .logo {
 .hero h1 {
   font-size: 3rem;
   color: var(--color-light);
+  margin-bottom: 1.5rem;
 }
 .intro {
   background-color: var(--color-light);


### PR DESCRIPTION
## Summary
- clean up merge markers in `index.html`
- remove the homepage tagline so only the buttons remain
- adjust hero heading spacing with a new margin in `styles.css`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c4c546ef0832f97cfa055cb1478dd