### PR TITLE
Handle empty sinoptico lists

### DIFF
--- a/product_builder.js
+++ b/product_builder.js
@@ -17,17 +17,23 @@ document.addEventListener('DOMContentLoaded', () => {
 
   // Renderiza botones de subensambles e insumos disponibles
   function renderLists() {
+    subsDiv.innerHTML = '';
+    insDiv.innerHTML = '';
     if (!window.SinopticoEditor || !SinopticoEditor.getNodes) return;
     const nodes = SinopticoEditor.getNodes();
-    const subs  = nodes.filter(n => (n.Tipo || '').toLowerCase() === 'subensamble');
-    const ins   = nodes.filter(n => (n.Tipo || '').toLowerCase() === 'insumo');
-    subsDiv.innerHTML = '';
-    insDiv.innerHTML  = '';
+    if (!Array.isArray(nodes) || nodes.length === 0 ||
+        !nodes.some(n => (n.Tipo || '').toLowerCase() === 'cliente')) {
+      subsDiv.textContent = 'Sinóptico vacío';
+      return;
+    }
+    const subs = nodes.filter(n => (n.Tipo || '').toLowerCase() === 'subensamble');
+    const ins  = nodes.filter(n => (n.Tipo || '').toLowerCase() === 'insumo');
     subs.forEach(s => {
       const btn = document.createElement('button');
       btn.textContent = `${s['Descripción'] || ''} - ${s['Código'] || ''}`;
       btn.addEventListener('click', () => addItem({
-        ID: s.ID, Tipo: s.Tipo,
+        ID: s.ID,
+        Tipo: s.Tipo,
         Descripción: s['Descripción'],
         Código: s['Código']
       }));
@@ -37,7 +43,8 @@ document.addEventListener('DOMContentLoaded', () => {
       const btn = document.createElement('button');
       btn.textContent = `${i['Descripción'] || ''} - ${i['Código'] || ''}`;
       btn.addEventListener('click', () => addItem({
-        ID: i.ID, Tipo: i.Tipo,
+        ID: i.ID,
+        Tipo: i.Tipo,
         Descripción: i['Descripción'],
         Código: i['Código']
       }));

--- a/sinoptico-create.js
+++ b/sinoptico-create.js
@@ -317,6 +317,9 @@ document.addEventListener('DOMContentLoaded', () => {
   document.addEventListener('sinoptico-mode', () => {
     fillOptions();
   });
+  document.addEventListener('sinoptico-loaded', () => {
+    fillOptions();
+  });
   document.addEventListener('sinoptico-data-changed', () => {
     fillOptions();
   });

--- a/sinoptico-delete.js
+++ b/sinoptico-delete.js
@@ -50,6 +50,11 @@ document.addEventListener('DOMContentLoaded', () => {
   sIns.addEventListener('input', () => buildList(rIns, search('insumo', sIns.value)));
 
   document.dispatchEvent(new Event('sinoptico-mode'));
+  document.addEventListener('sinoptico-loaded', () => {
+    buildList(rClient, search('cliente', sClient.value));
+    buildList(rProd, search('producto', sProd.value));
+    buildList(rIns, search('insumo', sIns.value));
+  });
   document.addEventListener('sinoptico-data-changed', () => {
     buildList(rClient, search('cliente', sClient.value));
     buildList(rProd, search('producto', sProd.value));

--- a/sinoptico-edit.js
+++ b/sinoptico-edit.js
@@ -126,6 +126,7 @@ document.addEventListener('DOMContentLoaded', () => {
   });
 
   document.addEventListener('sinoptico-mode', fillOptions);
+  document.addEventListener('sinoptico-loaded', fillOptions);
   document.addEventListener('sinoptico-data-changed', fillOptions);
   setTimeout(fillOptions, 300);
 });

--- a/sinoptico-modify.js
+++ b/sinoptico-modify.js
@@ -31,6 +31,7 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   document.addEventListener('sinoptico-mode', render);
+  document.addEventListener('sinoptico-loaded', render);
   document.addEventListener('sinoptico-data-changed', render);
   setTimeout(render, 300);
 });

--- a/visual_constructor.js
+++ b/visual_constructor.js
@@ -277,6 +277,7 @@ document.addEventListener('DOMContentLoaded', () => {
   });
 
   document.addEventListener('sinoptico-mode', fillClientOptions);
+  document.addEventListener('sinoptico-loaded', fillClientOptions);
   document.addEventListener('sinoptico-data-changed', fillClientOptions);
   setTimeout(fillClientOptions, 300);
 });


### PR DESCRIPTION
## Summary
- guard against missing sinoptico data when listing subassemblies in `product_builder.js`
- update option refresh logic in the sinoptico editors when data loads

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c4c675a70832f9bfed63f208cb464