### PR TITLE
Add history snapshot utilities and viewer

### DIFF
--- a/amfe_proceso_ultra.html
+++ b/amfe_proceso_ultra.html
@@ -60,6 +60,7 @@
   <div id="toast" class="toast" style="display:none"></div>
   <script src="theme.js" defer></script>
   <script src="smooth-nav.js" defer></script>
+  <script src="history_utils.js"></script>
   <script src="amfe_proceso_ultra.js"></script>
 </body>
 </html>

--- a/amfe_proceso_ultra.js
+++ b/amfe_proceso_ultra.js
@@ -30,6 +30,9 @@
 
   function save(){
     localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+    if (typeof addHistoryEntry === 'function') {
+      try { addHistoryEntry('amfeUltraHistory', data); } catch(e){}
+    }
   }
 
   function initHeader(){

--- a/history_utils.js
+++ b/history_utils.js
@@ -1,0 +1,27 @@
+(function(global){
+  function loadHistory(key){
+    if (typeof localStorage === 'undefined') return [];
+    try {
+      const arr = JSON.parse(localStorage.getItem(key));
+      return Array.isArray(arr) ? arr : [];
+    } catch(e){
+      return [];
+    }
+  }
+
+  function addHistoryEntry(key, data){
+    if (typeof localStorage === 'undefined') return;
+    const history = loadHistory(key);
+    const copy = JSON.parse(JSON.stringify(data));
+    history.push({ timestamp: new Date().toISOString(), data: copy });
+    try {
+      localStorage.setItem(key, JSON.stringify(history));
+    } catch(e){}
+  }
+
+  global.loadHistory = loadHistory;
+  global.addHistoryEntry = addHistoryEntry;
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { loadHistory, addHistoryEntry };
+  }
+})(typeof globalThis !== 'undefined' ? globalThis : window);

--- a/history_viewer.html
+++ b/history_viewer.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Historiales</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <nav class="main-nav">
+    <a href="index.html">Inicio</a>
+    <a href="sinoptico.html">Sinóptico</a>
+    <a href="listado_maestro.html">Listado maestro</a>
+    <a href="insumos.html">Insumos</a>
+    <button id="toggleTheme">🌙</button>
+  </nav>
+  <h1>Historiales</h1>
+  <div id="historyContainer"></div>
+  <script src="auth.js"></script>
+  <script src="history_utils.js"></script>
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      const cont = document.getElementById('historyContainer');
+      if (sessionStorage.getItem('isAdmin') !== 'true') {
+        cont.textContent = 'Acceso restringido';
+        return;
+      }
+      const keys = Object.keys(localStorage).filter(k => k.endsWith('History'));
+      if (!keys.length) {
+        cont.textContent = 'No hay historiales disponibles';
+        return;
+      }
+      keys.forEach(k => {
+        const section = document.createElement('section');
+        const h2 = document.createElement('h2');
+        h2.textContent = k;
+        section.appendChild(h2);
+        const history = loadHistory(k);
+        history.forEach((entry, idx) => {
+          const wrap = document.createElement('div');
+          const label = document.createElement('span');
+          label.textContent = entry.timestamp;
+          const dl = document.createElement('button');
+          dl.textContent = 'Descargar';
+          dl.addEventListener('click', () => {
+            const blob = new Blob([JSON.stringify(entry.data, null, 2)], {type:'application/json'});
+            const url = URL.createObjectURL(blob);
+            const a = document.createElement('a');
+            a.href = url;
+            a.download = k + '_' + idx + '.json';
+            a.click();
+            URL.revokeObjectURL(url);
+          });
+          wrap.appendChild(label);
+          wrap.appendChild(dl);
+          section.appendChild(wrap);
+        });
+        cont.appendChild(section);
+      });
+    });
+  </script>
+  <script src="theme.js" defer></script>
+  <script src="smooth-nav.js" defer></script>
+</body>
+</html>

--- a/insumos.html
+++ b/insumos.html
@@ -51,9 +51,10 @@
       update();
     });
   </script>
-  <script src="theme.js" defer></script>
-  <script src="smooth-nav.js" defer></script>
-  <script src="https://cdn.jsdelivr.net/npm/fuse.js@6/dist/fuse.min.js"></script>
-  <script src="insumos.js" defer></script>
+    <script src="theme.js" defer></script>
+    <script src="smooth-nav.js" defer></script>
+    <script src="https://cdn.jsdelivr.net/npm/fuse.js@6/dist/fuse.min.js"></script>
+    <script src="history_utils.js"></script>
+    <script src="insumos.js" defer></script>
 </body>
 </html>

--- a/insumos.js
+++ b/insumos.js
@@ -47,6 +47,9 @@ document.addEventListener('DOMContentLoaded', () => {
 
   function save() {
     localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+    if (typeof addHistoryEntry === 'function') {
+      try { addHistoryEntry('insumosHistory', data); } catch(e){}
+    }
     if (fs && jsonPath) {
       try {
         fs.writeFileSync(jsonPath, JSON.stringify(data, null, 2), 'utf8');

--- a/listado_maestro.html
+++ b/listado_maestro.html
@@ -64,10 +64,11 @@
 
       updateButton();
     });
-  </script>
-  <script src="theme.js" defer></script>
-  <script src="smooth-nav.js" defer></script>
-  <script src="https://cdn.jsdelivr.net/npm/fuse.js@6.6.2/dist/fuse.min.js"></script>
-  <script src="maestro.js"></script>
+    </script>
+    <script src="theme.js" defer></script>
+    <script src="smooth-nav.js" defer></script>
+    <script src="https://cdn.jsdelivr.net/npm/fuse.js@6.6.2/dist/fuse.min.js"></script>
+    <script src="history_utils.js"></script>
+    <script src="maestro.js"></script>
 </body>
 </html>

--- a/maestro.js
+++ b/maestro.js
@@ -155,6 +155,9 @@ document.addEventListener('DOMContentLoaded', () => {
 
   function save() {
     localStorage.setItem(STORAGE_KEY, JSON.stringify(docs));
+    if (typeof addHistoryEntry === 'function') {
+      try { addHistoryEntry('maestroHistory', docs); } catch(e){}
+    }
   }
 
   function render() {

--- a/renderer.js
+++ b/renderer.js
@@ -1004,6 +1004,9 @@
 
       function saveSinoptico() {
         localStorage.setItem('sinopticoData', JSON.stringify(sinopticoData));
+        if (typeof addHistoryEntry === 'function') {
+          try { addHistoryEntry('sinopticoHistory', sinopticoData); } catch(e){}
+        }
         if (fs && jsonFile) {
           try {
             fs.writeFileSync(

--- a/sinoptico.html
+++ b/sinoptico.html
@@ -113,6 +113,7 @@
   <a href="index.html" class="home-button">Inicio</a>
 
   <script src="auth.js"></script>
+  <script src="history_utils.js"></script>
   <script src="theme.js" defer></script>
   <script src="smooth-nav.js" defer></script>
   <script>sessionStorage.setItem('sinopticoEdit','false');</script>

--- a/test-insumos.js
+++ b/test-insumos.js
@@ -1,5 +1,6 @@
 const jsdom = require('jsdom-global');
 jsdom('', { url: 'http://localhost' });
+require('./history_utils.js');
 
 // expose storages
 global.sessionStorage = window.sessionStorage;

--- a/test-maestro.js
+++ b/test-maestro.js
@@ -1,5 +1,6 @@
 const jsdom = require('jsdom-global');
 jsdom('', { url: 'http://localhost' });
+require('./history_utils.js');
 global.sessionStorage = window.sessionStorage;
 global.localStorage = window.localStorage;
 

--- a/test-renderer.js
+++ b/test-renderer.js
@@ -2,6 +2,8 @@ const jsdom = require('jsdom-global');
 const Fuse = require('fuse.js');
 jsdom('', { url: 'http://localhost' });
 
+require('./history_utils.js');
+
 // expose storage
 global.sessionStorage = window.sessionStorage;
 global.localStorage = window.localStorage;


### PR DESCRIPTION
## Summary
- store sinoptico, AMFE, maestro and insumos snapshots with timestamps
- add generic `history_utils.js` helpers
- load helpers on pages that edit data
- include new read-only `history_viewer.html`
- update tests to load the helper module

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c4c4607ec832fb8d96aa90dc51825