### PR TITLE
Hide admin panel until login

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -930,6 +930,7 @@ select {
   flex-direction: column;
   gap: 8px;
 }
+.admin-panel { display: none; }
 .admin-row {
   display: flex;
   gap: 6px;


### PR DESCRIPTION
## Summary
- hide the `.admin-panel` element by default so `updatePanel()` can reveal it for admins

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c500641a8832fb4231fb8eae8a242