### PR TITLE
Show placeholders for empty AMFE process fields

### DIFF
--- a/amfe_proceso_ultra.html
+++ b/amfe_proceso_ultra.html
@@ -16,6 +16,7 @@
     .process-section summary { cursor:pointer; padding:10px; background:linear-gradient(#4b6cb7,#182848); color:#fff; border-radius:8px 8px 0 0; display:flex; justify-content:space-between; align-items:center; }
     .process-fields { display:grid; grid-template-columns:repeat(auto-fit,minmax(150px,1fr)); gap:10px; padding:10px; }
     .process-fields span { border:1px solid #ccc; padding:4px; border-radius:4px; min-height:22px; }
+    .process-fields span[data-placeholder]:empty::before { content: attr(data-placeholder); color:#999; }
     .process-fields .invalid { border-color:red; }
     .table-wrapper { overflow-x:auto; padding:10px; }
     table.fmea-table { border-collapse:collapse; width:100%; }

--- a/amfe_proceso_ultra.js
+++ b/amfe_proceso_ultra.js
@@ -15,6 +15,14 @@
     processes: []
   };
 
+  const PLACEHOLDERS = {
+    secuencia: 'Secuencia',
+    estacion: 'Estación',
+    descripcion: 'Descripción',
+    materiales: 'Materiales',
+    requerimientos: 'Requerimientos'
+  };
+
   function calcNivel(s,o,d){
     const r=s*o*d;
     if(!s||!o||!d) return '';
@@ -88,10 +96,11 @@
     }
   }
 
-  function fieldSpan(text){
+  function fieldSpan(text, placeholder){
     const span=document.createElement('span');
     span.textContent=text||'';
     span.contentEditable=isAdmin;
+    if(placeholder) span.dataset.placeholder=placeholder;
     return span;
   }
 
@@ -142,10 +151,11 @@
           } else {
             const span=document.createElement('span');
             span.textContent=proc.secuencia||'';
+            span.dataset.placeholder=PLACEHOLDERS[f];
             fields.appendChild(span);
           }
         } else {
-          const span=fieldSpan(proc[f]);
+          const span=fieldSpan(proc[f], PLACEHOLDERS[f]);
           span.onblur=()=>{ proc[f]=span.textContent.trim(); validateFields(details); save(); };
           fields.appendChild(span);
         }


### PR DESCRIPTION
## Summary
- add placeholder constants for AMFE process fields
- display placeholders in editable spans
- style spans to show placeholder text when empty

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c5290d3e4832f8a92f7ae21322551