### PR TITLE
Add AMFE Ultra persistence test

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "scripts": {
     "pretest": "sh scripts/setup.sh",
-    "test": "node test-maestro.js && node test-renderer.js && node test-auth.js && node test-insumos.js"
+    "test": "node test-maestro.js && node test-renderer.js && node test-auth.js && node test-insumos.js && node test-amfe-ultra.js"
   },
   "devDependencies": {
     "fuse.js": "^7.1.0",

--- a/test-amfe-ultra.js
+++ b/test-amfe-ultra.js
@@ -1,0 +1,28 @@
+const jsdom = require('jsdom-global');
+const fs = require('fs');
+const html = fs.readFileSync('amfe_proceso_ultra.html', 'utf8');
+jsdom(html, { url: 'http://localhost' });
+
+// expose storages
+global.sessionStorage = window.sessionStorage;
+global.localStorage = window.localStorage;
+
+// enable admin mode
+sessionStorage.setItem('isAdmin', 'true');
+
+require('./amfe_proceso_ultra.js');
+
+document.dispatchEvent(new Event('DOMContentLoaded'));
+
+document.getElementById('addProcess').click();
+
+const descSpan = document.querySelector('.process-section .process-fields span:nth-child(3)');
+descSpan.textContent = 'Test descripcion';
+descSpan.dispatchEvent(new Event('blur'));
+
+const stored = JSON.parse(localStorage.getItem('amfeUltraData') || '{}');
+if (!stored.processes || stored.processes[0].descripcion !== 'Test descripcion') {
+  throw new Error('changes not persisted');
+}
+
+console.log('amfe ultra test passed');


### PR DESCRIPTION
## Summary
- add a new test `test-amfe-ultra.js` that loads the AMFE Ultra page with jsdom, edits a process and checks persistence
- run this test as part of `npm test`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c52920f3c832f8fc678f3e3961705