### PR TITLE
Update login auto-redirect

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Open http://localhost:8000/index.html in a modern browser. All data, including t
 ## Login and user accounts
 
 Use the **Log in** link or open `login.html` directly to access the sign‑in page. The project includes four default accounts: **PAULO**, **LEO**, **FACUNDO** and **PABLO**, all with password `1234`. After logging in an admin panel becomes visible where you can create new users or update existing passwords.
+If the page detects `sessionStorage.isAdmin` is already set to `true`, it skips the form and redirects straight to `index.html`.
 
 Account information is now stored as SHA‑256 hashes in the browser's `localStorage`. Tick **Recordarme** on the login form to keep the session between visits. Clear the `users` entry to reset all accounts.
 

--- a/login.html
+++ b/login.html
@@ -50,6 +50,10 @@
       const panel = document.getElementById('adminPanel');
       const logoutBtn = document.getElementById('logoutBtn');
       auth.restoreSession();
+      if (sessionStorage.getItem('isAdmin') === 'true') {
+        location.href = 'index.html';
+        return;
+      }
       function updatePanel() {
         panel.style.display = sessionStorage.getItem('isAdmin') === 'true' ? 'block' : 'none';
       }


### PR DESCRIPTION
## Summary
- redirect to `index.html` from the login page when `sessionStorage.isAdmin` is already `true`
- note this login page behavior in the docs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c5aa12bd8832fa725e47ba42bcf8e