### PR TITLE
Fix admin row layout

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -934,6 +934,11 @@ select {
 .admin-row {
   display: flex;
   gap: 6px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+.admin-row input {
+  flex: 1;
 }
 .login-form input,
 .admin-panel input {


### PR DESCRIPTION
## Summary
- align admin rows centrally and wrap when needed
- make admin text inputs flex so they're equal width

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c5aa26e68832fa963c07f979a987d