### PR TITLE
Add JSON export/import controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ no external dependencies. All header fields and the list of processes persist in
 - **Editing modes** – once logged in you can edit the master list and the sinóptico using their respective **Editar** buttons. The product view is maintained through the interface at `admin_menu.html`.
 - **Excel export** – visible rows can be saved as `sinoptico.xlsx`. The file
   downloads to your browser's default folder.
+- **JSON export/import** – use **Export JSON** to save the hierarchy and **Import JSON** to load a previously saved `.json` file.
 - **Dynamic categories** – the master list starts empty and new document sections appear automatically when items are added.
 - **Client grouping** – rows with a value in the `Cliente` column are grouped under that client in the product tree.
 - **Smooth animations** – buttons and rows fade and scale for a more polished experience.

--- a/renderer.js
+++ b/renderer.js
@@ -541,6 +541,62 @@
       });
 
       /* ==================================================
+         Exportar/Importar JSON
+      ================================================== */
+      const btnExportJson = document.getElementById('btnExportJson');
+      if (btnExportJson) btnExportJson.addEventListener('click', exportJson);
+
+      const btnImportJson = document.getElementById('btnImportJson');
+      const inputImportJson = document.getElementById('inputImportJson');
+      if (btnImportJson && inputImportJson) {
+        btnImportJson.addEventListener('click', () => inputImportJson.click());
+        inputImportJson.addEventListener('change', e => {
+          const file = e.target.files[0];
+          if (file) importJsonFile(file);
+          inputImportJson.value = '';
+        });
+      }
+
+      function exportJson() {
+        try {
+          const blob = new Blob([
+            JSON.stringify(sinopticoData, null, 2)
+          ], { type: 'application/json' });
+          const url = URL.createObjectURL(blob);
+          const a = document.createElement('a');
+          a.href = url;
+          a.download = 'sinoptico.json';
+          a.style.display = 'none';
+          document.body.appendChild(a);
+          a.click();
+          document.body.removeChild(a);
+          URL.revokeObjectURL(url);
+        } catch (e) {
+          console.error('Error exporting JSON', e);
+        }
+      }
+
+      function importJsonFile(file) {
+        if (typeof FileReader === 'undefined') return;
+        const reader = new FileReader();
+        reader.onload = () => {
+          try {
+            const data = JSON.parse(reader.result);
+            if (Array.isArray(data)) {
+              sinopticoData = data;
+              saveSinoptico();
+              loadData();
+            } else {
+              throw new Error('Formato inválido');
+            }
+          } catch (e) {
+            console.error('Error importing JSON', e);
+          }
+        };
+        reader.readAsText(file);
+      }
+
+      /* ==================================================
          5) Cargar CSV y construir la tabla jerárquica
          + Recarga automática cada 30 segundos
       ================================================== */

--- a/sinoptico.html
+++ b/sinoptico.html
@@ -88,6 +88,9 @@
     <button id="btnRefrescar" aria-label="Recargar datos">Refrescar</button>
     <!-- Botón para exportar la tabla visible a Excel -->
     <button id="btnExcel" aria-label="Exportar la tabla visible a Excel">Exportar a Excel</button>
+    <button id="btnExportJson" aria-label="Exportar datos a JSON">Exportar JSON</button>
+    <input type="file" id="inputImportJson" accept=".json" style="display:none" />
+    <button id="btnImportJson" aria-label="Importar datos desde JSON">Importar JSON</button>
   </div>
     <table id="sinoptico">
       <thead>


### PR DESCRIPTION
## Summary
- add Export JSON and Import JSON buttons
- implement export/import helpers in renderer.js
- update README with new feature

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c5d98b800832f9a2d638680ad684e