### PR TITLE
Display admin panel when session persists

### DIFF
--- a/login.html
+++ b/login.html
@@ -52,20 +52,19 @@
       const logoutBtn = document.getElementById('logoutBtn');
       const backHomeBtn = document.getElementById('backHome');
       auth.restoreSession();
-      if (sessionStorage.getItem('isAdmin') === 'true') {
-        location.href = 'index.html';
-        return;
-      }
       function updatePanel() {
-        panel.style.display = sessionStorage.getItem('isAdmin') === 'true' ? 'block' : 'none';
+        const isAdmin = sessionStorage.getItem('isAdmin') === 'true';
+        panel.style.display = isAdmin ? 'block' : 'none';
+        form.style.display = isAdmin ? 'none' : 'flex';
       }
+      updatePanel();
       form.addEventListener('submit', e => {
         e.preventDefault();
         const u = document.getElementById('username').value.trim();
         const p = document.getElementById('password').value.trim();
         const remember = document.getElementById('rememberMe').checked;
         if (auth.login(u, p, remember)) {
-          location.href = 'index.html';
+          updatePanel();
         } else {
           alert('Credenciales inválidas');
         }


### PR DESCRIPTION
## Summary
- prevent redirect away from `login.html` when a stored admin session exists
- show or hide the admin panel and form based on `sessionStorage.isAdmin`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c5f72c5d8832f8689b7a873a84e32