### PR TITLE
Add admin user management

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Open http://localhost:8000/index.html in a modern browser. All data, including t
 
 ## Login and user accounts
 
-Use the **Log in** link or open `login.html` directly to access the sign‑in page. The project includes four default accounts: **PAULO**, **LEO**, **FACUNDO** and **PABLO**, all with password `1234`. After logging in an admin panel becomes visible where you can create new users or update existing passwords.
+Use the **Log in** link or open `login.html` directly to access the sign‑in page. The project includes four default accounts: **PAULO**, **LEO**, **FACUNDO** and **PABLO**, all with password `1234`. After logging in an admin panel becomes visible where you can create new users or update existing passwords. A dedicated management page is also available at `usuarios.html` for administrators.
 If the page detects `sessionStorage.isAdmin` is already set to `true`, it skips the form and redirects straight to `index.html`.
 
 Account information is now stored as SHA‑256 hashes in the browser's `localStorage`. Tick **Recordarme** on the login form to keep the session between visits. Clear the `users` entry to reset all accounts.

--- a/auth.js
+++ b/auth.js
@@ -17,10 +17,10 @@
     }
     if (!Array.isArray(list) || list.length === 0) {
       list = [
-        { username:'PAULO', hash: hash('1234') },
-        { username:'LEO', hash: hash('1234') },
-        { username:'FACUNDO', hash: hash('1234') },
-        { username:'PABLO', hash: hash('1234') }
+        { username:'PAULO', hash: hash('1234'), role:'admin' },
+        { username:'LEO', hash: hash('1234'), role:'admin' },
+        { username:'FACUNDO', hash: hash('1234'), role:'admin' },
+        { username:'PABLO', hash: hash('1234'), role:'admin' }
       ];
     } else {
       list = list.map(u => {
@@ -28,6 +28,7 @@
           u.hash = hash(u.password);
           delete u.password;
         }
+        if (!u.role) u.role = 'admin';
         return u;
       });
     }
@@ -48,7 +49,7 @@
     const u = users.find(x => x.username === username && x.hash === hashed);
     if (u) {
       if (typeof sessionStorage !== 'undefined') {
-        sessionStorage.setItem('isAdmin', 'true');
+        sessionStorage.setItem('isAdmin', u.role === 'admin' ? 'true' : 'false');
         sessionStorage.setItem('currentUser', username);
       }
       if (remember && typeof localStorage !== 'undefined') {
@@ -73,19 +74,20 @@
 
   function restoreSession(){
     if (typeof localStorage !== 'undefined') {
-      const u = localStorage.getItem('rememberUser');
-      if (u && typeof sessionStorage !== 'undefined') {
-        sessionStorage.setItem('isAdmin','true');
-        sessionStorage.setItem('currentUser', u);
+      const uName = localStorage.getItem('rememberUser');
+      if (uName && typeof sessionStorage !== 'undefined') {
+        const u = users.find(x => x.username === uName);
+        sessionStorage.setItem('isAdmin', u && u.role === 'admin' ? 'true' : 'false');
+        sessionStorage.setItem('currentUser', uName);
         return true;
       }
     }
     return false;
   }
 
-  function createUser(username, password){
+  function createUser(username, password, role='user'){
     if (users.some(u => u.username === username)) return false;
-    users.push({ username, hash: hash(password) });
+    users.push({ username, hash: hash(password), role });
     saveUsers(users);
     return true;
   }
@@ -98,7 +100,15 @@
     return true;
   }
 
-  const api = { login, logout, createUser, changePassword, loadUsers, restoreSession, hash };
+  function setRole(username, role){
+    const u = users.find(x => x.username === username);
+    if (!u) return false;
+    u.role = role;
+    saveUsers(users);
+    return true;
+  }
+
+  const api = { login, logout, createUser, changePassword, setRole, loadUsers, restoreSession, hash };
   if (typeof module !== 'undefined' && module.exports) module.exports = api;
   global.auth = api;
 })(typeof globalThis !== 'undefined' ? globalThis : window);

--- a/index.html
+++ b/index.html
@@ -13,6 +13,7 @@
           <a href="admin_menu.html" id="editSinLink" style="display:none">Editar sinóptico</a>
           <a href="listado_maestro.html">Listado maestro</a>
           <a href="insumos.html">Insumos</a>
+          <a href="usuarios.html" id="usersLink" style="display:none">Usuarios</a>
           <a href="login.html" id="loginLink">Log in</a>
           <button id="toggleTheme">🌙</button>
       </nav>
@@ -42,10 +43,12 @@
           document.querySelector('main').classList.add('fade-in');
           const link = document.getElementById('loginLink');
           const editLink = document.getElementById('editSinLink');
+          const usersLink = document.getElementById('usersLink');
           function update() {
             const logged = sessionStorage.getItem('isAdmin') === 'true';
             link.textContent = logged ? 'Cerrar sesión' : 'Log in';
             if (editLink) editLink.style.display = logged ? 'inline' : 'none';
+            if (usersLink) usersLink.style.display = logged ? 'inline' : 'none';
           }
           link.addEventListener('click', e => {
             if (sessionStorage.getItem('isAdmin') === 'true') {

--- a/test-auth.js
+++ b/test-auth.js
@@ -6,18 +6,19 @@ global.localStorage = window.localStorage;
 
 const auth = require('./auth.js');
 
-// clear storage
 localStorage.clear();
 sessionStorage.clear();
 
 auth.createUser('user1','pass1');
+auth.setRole('user1','admin');
 if (!auth.login('user1','pass1', true)) throw new Error('login failed');
-if (sessionStorage.getItem('currentUser') !== 'user1') throw new Error('session not stored');
+if (sessionStorage.getItem('isAdmin') !== 'true') throw new Error('role not applied');
+
 sessionStorage.clear();
-if (!auth.restoreSession()) throw new Error('restore failed');
+if (!auth.restoreSession() || sessionStorage.getItem('isAdmin') !== 'true') throw new Error('restore failed');
+
 auth.logout();
 auth.changePassword('user1','new');
-
 if (!auth.login('user1','new')) throw new Error('password change failed');
 
 console.log('auth tests passed');

--- a/usuarios.html
+++ b/usuarios.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Usuarios</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <nav class="main-nav">
+    <a href="welcome.html">Inicio</a>
+    <a href="sinoptico.html">Sinóptico</a>
+    <a href="listado_maestro.html">Listado maestro</a>
+    <a href="insumos.html">Insumos</a>
+    <a href="usuarios.html" aria-current="page" id="usersNav">Usuarios</a>
+    <button id="toggleTheme">🌙</button>
+  </nav>
+  <div id="adminPanel" class="admin-panel fade-in">
+    <h2>Administrar usuarios</h2>
+    <div class="admin-row">
+      <input type="text" id="newUser" placeholder="Usuario">
+      <input type="password" id="newPass" placeholder="Contraseña">
+      <select id="newRole">
+        <option value="user">Usuario</option>
+        <option value="admin">Administrador</option>
+      </select>
+      <button id="createUser">Crear</button>
+    </div>
+    <div class="admin-row">
+      <input type="text" id="chgUser" placeholder="Usuario">
+      <input type="password" id="chgPass" placeholder="Nueva contraseña">
+      <button id="changePassword">Cambiar</button>
+    </div>
+    <button id="logoutBtn">Cerrar sesión</button>
+    <button id="backHome" type="button">Volver al inicio</button>
+  </div>
+  <script src="sha256.min.js"></script>
+  <script src="auth.js"></script>
+  <script src="theme.js" defer></script>
+  <script src="smooth-nav.js" defer></script>
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      auth.restoreSession();
+      if (sessionStorage.getItem('isAdmin') !== 'true') {
+        location.href = 'login.html';
+        return;
+      }
+      document.getElementById('createUser').addEventListener('click', () => {
+        const u = document.getElementById('newUser').value.trim();
+        const p = document.getElementById('newPass').value.trim();
+        const r = document.getElementById('newRole').value;
+        if (u && p) {
+          if (auth.createUser(u, p, r)) {
+            alert('Usuario creado');
+          } else {
+            alert('Ya existe el usuario');
+          }
+        }
+      });
+      document.getElementById('changePassword').addEventListener('click', () => {
+        const u = document.getElementById('chgUser').value.trim();
+        const p = document.getElementById('chgPass').value.trim();
+        if (auth.changePassword(u, p)) {
+          alert('Contraseña actualizada');
+        } else {
+          alert('Usuario no encontrado');
+        }
+      });
+      document.getElementById('logoutBtn').addEventListener('click', () => {
+        auth.logout();
+        location.href = 'index.html';
+      });
+      document.getElementById('backHome').addEventListener('click', () => {
+        location.href = 'index.html';
+      });
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- extend auth.js with user `role` support and ability to set role
- create new `usuarios.html` page to manage users
- show Users link only to admins in the index navigation
- document the new management page
- adjust tests for the updated auth module

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c5f734ba4832f8359c7ccbdf073e6