### PR TITLE
Sync sinoptico across tabs

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ no external dependencies. All header fields and the list of processes persist in
 - **AMFE persistence** – the AMFE pages store their data in `localStorage`.
 - **Data change event** – pages dispatch a `sinoptico-data-changed` event after
   updating the product tree so other modules can refresh their views.
+- **Cross-tab sync** – modifying the hierarchy in one tab refreshes any other
+  open sinóptico pages thanks to the `storage` event.
 
 The product hierarchy is stored in `localStorage`.
 

--- a/renderer.js
+++ b/renderer.js
@@ -1168,4 +1168,10 @@
         loadData();
       });
 
+      window.addEventListener('storage', e => {
+        if (e.key === 'sinopticoData') {
+          loadData();
+        }
+      });
+
     }); // FIN DOMContentLoaded


### PR DESCRIPTION
## Summary
- reload hierarchy on storage events to keep open pages in sync
- document the new cross-tab sync behavior in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c622cd658832f9a823906a59d65b6