### PR TITLE
Restore session on home load

### DIFF
--- a/index.html
+++ b/index.html
@@ -49,6 +49,7 @@
             if (editLink) editLink.style.display = logged ? 'inline' : 'none';
             if (usersLink) usersLink.style.display = logged ? 'inline' : 'none';
           }
+          auth.restoreSession();
           link.addEventListener('click', e => {
             if (sessionStorage.getItem('isAdmin') === 'true') {
               e.preventDefault();


### PR DESCRIPTION
## Summary
- restore previously remembered session when `index.html` loads

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c632e47c0832f9ca1afa2ca8d02f0