### PR TITLE
Redirect admin on login page

### DIFF
--- a/login.html
+++ b/login.html
@@ -52,6 +52,10 @@
       const logoutBtn = document.getElementById('logoutBtn');
       const backHomeBtn = document.getElementById('backHome');
       auth.restoreSession();
+      if (sessionStorage.isAdmin === 'true') {
+        window.location.href = 'index.html';
+        return;
+      }
       function updatePanel() {
         const isAdmin = sessionStorage.getItem('isAdmin') === 'true';
         panel.style.display = isAdmin ? 'block' : 'none';


### PR DESCRIPTION
## Summary
- check `sessionStorage.isAdmin` on `DOMContentLoaded`
- send admin users directly back to the home page

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684c6335b3b4832f8abfaa3e3cae02ed