### PR TITLE
Handle invalid local data in renderer

### DIFF
--- a/renderer.js
+++ b/renderer.js
@@ -779,7 +779,27 @@
           }
         } else {
           stored = localStorage.getItem('sinopticoData');
-          sinopticoData = stored ? JSON.parse(stored) : generarDatosIniciales();
+          if (stored) {
+            try {
+              sinopticoData = JSON.parse(stored);
+            } catch (e) {
+              console.error(
+                'Error parsing sinopticoData from localStorage',
+                e
+              );
+              sinopticoData = generarDatosIniciales();
+              try {
+                localStorage.setItem(
+                  'sinopticoData',
+                  JSON.stringify(sinopticoData)
+                );
+              } catch (err) {
+                console.error('Error persisting sinopticoData', err);
+              }
+            }
+          } else {
+            sinopticoData = generarDatosIniciales();
+          }
         }
 
         if (typeof localStorage !== 'undefined') {


### PR DESCRIPTION
## Summary
- guard against invalid JSON in localStorage for `sinopticoData`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c68e65434832fbcdc550e11ae5037