### PR TITLE
Add safe parsing for localStorage

### DIFF
--- a/insumos.js
+++ b/insumos.js
@@ -28,7 +28,14 @@ document.addEventListener('DOMContentLoaded', () => {
       data = [];
     }
   } else {
-    data = JSON.parse(localStorage.getItem(STORAGE_KEY)) || [];
+    try {
+      const raw = localStorage.getItem(STORAGE_KEY);
+      data = raw ? JSON.parse(raw) : [];
+      if (!Array.isArray(data)) data = [];
+    } catch (e) {
+      data = [];
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+    }
   }
 
   let fuse = null;

--- a/maestro.js
+++ b/maestro.js
@@ -20,8 +20,16 @@ document.addEventListener('DOMContentLoaded', () => {
   const STORAGE_KEY = 'maestroDocs';
   let isAdmin = sessionStorage.getItem('maestroAdmin') === 'true';
 
-  // Load documents from browser storage
-  let docs = JSON.parse(localStorage.getItem(STORAGE_KEY)) || [];
+  // Load documents from browser storage with error handling
+  let docs;
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    docs = raw ? JSON.parse(raw) : [];
+    if (!Array.isArray(docs)) docs = [];
+  } catch (e) {
+    docs = [];
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(docs));
+  }
   if (Array.isArray(docs)) {
     // Remove empty placeholder entries from older versions
     docs = docs.filter(d => !(DOC_TYPES.some(t => t.name === d.name) && !d.number && !d.detail));


### PR DESCRIPTION
## Summary
- guard maestro document loading in case localStorage is corrupted
- guard insumo data loading in case localStorage is corrupted

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c68eb8bc8832fa71969701b855298