### PR TITLE
Move JSON import/export buttons to home page

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,22 +32,30 @@
             <li>Listado maestro de ingeniería</li>
             <li>Datos actualizados automáticamente</li>
           </ul>
+          <div id="adminDataBtns" style="display:none">
+            <button id="btnExportJson" aria-label="Exportar datos">Exportar datos</button>
+            <input type="file" id="inputImportJson" accept=".json" style="display:none">
+            <button id="btnImportJson" aria-label="Importar datos">Importar datos</button>
+          </div>
       </main>
       <script src="sha256.min.js"></script>
   <script src="auth.js"></script>
       <script src="theme.js" defer></script>
       <script src="smooth-nav.js" defer></script>
+      <script src="renderer.js" defer></script>
       <script>
         document.addEventListener('DOMContentLoaded', () => {
           document.querySelector('main').classList.add('fade-in');
           const link = document.getElementById('loginLink');
           const editLink = document.getElementById('editSinLink');
           const usersLink = document.getElementById('usersLink');
+          const adminBtns = document.getElementById('adminDataBtns');
           function update() {
             const logged = sessionStorage.getItem('isAdmin') === 'true';
             link.textContent = logged ? 'Cerrar sesión' : 'Log in';
             if (editLink) editLink.style.display = logged ? 'inline' : 'none';
             if (usersLink) usersLink.style.display = logged ? 'inline' : 'none';
+            if (adminBtns) adminBtns.style.display = logged ? 'block' : 'none';
           }
           auth.restoreSession();
           link.addEventListener('click', e => {

--- a/renderer.js
+++ b/renderer.js
@@ -554,11 +554,11 @@
       /* ==================================================
          Exportar/Importar JSON
       ================================================== */
-      const btnExportJson = document.getElementById('btnExportJson');
+      const btnExportJson = document.querySelector('#btnExportJson');
       if (btnExportJson) btnExportJson.addEventListener('click', exportJson);
 
-      const btnImportJson = document.getElementById('btnImportJson');
-      const inputImportJson = document.getElementById('inputImportJson');
+      const btnImportJson = document.querySelector('#btnImportJson');
+      const inputImportJson = document.querySelector('#inputImportJson');
       if (btnImportJson && inputImportJson) {
         btnImportJson.addEventListener('click', () => inputImportJson.click());
         inputImportJson.addEventListener('change', e => {

--- a/sinoptico.html
+++ b/sinoptico.html
@@ -88,9 +88,6 @@
     <button id="btnRefrescar" aria-label="Recargar datos">Refrescar</button>
     <!-- Botón para exportar la tabla visible a Excel -->
     <button id="btnExcel" aria-label="Exportar la tabla visible a Excel">Exportar a Excel</button>
-    <button id="btnExportJson" aria-label="Exportar datos a JSON">Exportar JSON</button>
-    <input type="file" id="inputImportJson" accept=".json" style="display:none" />
-    <button id="btnImportJson" aria-label="Importar datos desde JSON">Importar JSON</button>
   </div>
     <table id="sinoptico">
       <thead>


### PR DESCRIPTION
## Summary
- remove JSON export/import buttons from `sinoptico.html`
- add export/import controls to the home page
- show controls only to logged in admins
- update `renderer.js` selectors to work with new placement

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c68ec5108832faed8989716a2172d