### PR TITLE
Handle invalid JSON and move import/export

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 data/*.csv
 data/*.xlsx
+Datos-Nunca borrar/

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Open http://localhost:8000/index.html in a modern browser. All data, including t
 
 All data—including the sinóptico—is stored only in your browser and will not sync across devices. Clearing your browser's storage or visiting the site under a different domain will start you with an empty dataset.
 
+For long-term storage create a folder outside the repository, for example `Datos-Nunca borrar`, and export the JSON there using the **Exportar datos** button on the home page. Add that folder to `.gitignore` so Git does not commit it. When updating the project you can reimport the file with **Importar datos**.
+
 ## GitHub Pages
 
 To host the page publicly you can enable **GitHub Pages**:
@@ -63,7 +65,7 @@ no external dependencies. All header fields and the list of processes persist in
 - **Editing modes** – once logged in you can edit the master list and the sinóptico using their respective **Editar** buttons. The product view is maintained through the interface at `admin_menu.html`.
 - **Excel export** – visible rows can be saved as `sinoptico.xlsx`. The file
   downloads to your browser's default folder.
-- **JSON export/import** – use **Export JSON** to save the hierarchy and **Import JSON** to load a previously saved `.json` file.
+- **JSON export/import** – the **Exportar datos** and **Importar datos** buttons on the home page let you save or restore the hierarchy from a `.json` file.
 - **Dynamic categories** – the master list starts empty and new document sections appear automatically when items are added.
 - **Client grouping** – rows with a value in the `Cliente` column are grouped under that client in the product tree.
 - **Smooth animations** – buttons and rows fade and scale for a more polished experience.

--- a/index.html
+++ b/index.html
@@ -32,22 +32,30 @@
             <li>Listado maestro de ingeniería</li>
             <li>Datos actualizados automáticamente</li>
           </ul>
+          <div id="dataActions" style="display:none">
+            <button id="btnExportJson" aria-label="Exportar datos">Exportar datos</button>
+            <input type="file" id="inputImportJson" accept=".json" style="display:none" />
+            <button id="btnImportJson" aria-label="Importar datos">Importar datos</button>
+          </div>
       </main>
       <script src="sha256.min.js"></script>
   <script src="auth.js"></script>
       <script src="theme.js" defer></script>
       <script src="smooth-nav.js" defer></script>
+      <script src="renderer.js" defer></script>
       <script>
         document.addEventListener('DOMContentLoaded', () => {
           document.querySelector('main').classList.add('fade-in');
           const link = document.getElementById('loginLink');
           const editLink = document.getElementById('editSinLink');
           const usersLink = document.getElementById('usersLink');
+          const dataActions = document.getElementById('dataActions');
           function update() {
             const logged = sessionStorage.getItem('isAdmin') === 'true';
             link.textContent = logged ? 'Cerrar sesión' : 'Log in';
             if (editLink) editLink.style.display = logged ? 'inline' : 'none';
             if (usersLink) usersLink.style.display = logged ? 'inline' : 'none';
+            if (dataActions) dataActions.style.display = logged ? 'block' : 'none';
           }
           auth.restoreSession();
           link.addEventListener('click', e => {

--- a/insumos.js
+++ b/insumos.js
@@ -28,7 +28,16 @@ document.addEventListener('DOMContentLoaded', () => {
       data = [];
     }
   } else {
-    data = JSON.parse(localStorage.getItem(STORAGE_KEY)) || [];
+    try {
+      const raw = localStorage.getItem(STORAGE_KEY);
+      data = raw ? JSON.parse(raw) : [];
+    } catch (e) {
+      console.error('Invalid insumosData in storage', e);
+      data = [];
+      try {
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+      } catch {}
+    }
   }
 
   let fuse = null;

--- a/maestro.js
+++ b/maestro.js
@@ -20,8 +20,18 @@ document.addEventListener('DOMContentLoaded', () => {
   const STORAGE_KEY = 'maestroDocs';
   let isAdmin = sessionStorage.getItem('maestroAdmin') === 'true';
 
-  // Load documents from browser storage
-  let docs = JSON.parse(localStorage.getItem(STORAGE_KEY)) || [];
+  // Load documents from browser storage safely
+  let docs;
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    docs = raw ? JSON.parse(raw) : [];
+  } catch (e) {
+    console.error('Invalid maestroDocs in storage', e);
+    docs = [];
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(docs));
+    } catch {}
+  }
   if (Array.isArray(docs)) {
     // Remove empty placeholder entries from older versions
     docs = docs.filter(d => !(DOC_TYPES.some(t => t.name === d.name) && !d.number && !d.detail));

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "scripts": {
     "pretest": "sh scripts/setup.sh",
-    "test": "node test-maestro.js && node test-renderer.js && node test-auth.js && node test-insumos.js && node test-amfe-ultra.js"
+    "test": "node test-maestro.js && node test-renderer.js && node test-invalid-sinoptico.js && node test-auth.js && node test-insumos.js && node test-amfe-ultra.js"
   },
   "devDependencies": {
     "fuse.js": "^7.1.0",

--- a/renderer.js
+++ b/renderer.js
@@ -779,7 +779,16 @@
           }
         } else {
           stored = localStorage.getItem('sinopticoData');
-          sinopticoData = stored ? JSON.parse(stored) : generarDatosIniciales();
+          if (stored) {
+            try {
+              sinopticoData = JSON.parse(stored);
+            } catch (e) {
+              console.error('Invalid sinopticoData in storage', e);
+              sinopticoData = generarDatosIniciales();
+            }
+          } else {
+            sinopticoData = generarDatosIniciales();
+          }
         }
 
         if (typeof localStorage !== 'undefined') {

--- a/sinoptico.html
+++ b/sinoptico.html
@@ -88,9 +88,6 @@
     <button id="btnRefrescar" aria-label="Recargar datos">Refrescar</button>
     <!-- Botón para exportar la tabla visible a Excel -->
     <button id="btnExcel" aria-label="Exportar la tabla visible a Excel">Exportar a Excel</button>
-    <button id="btnExportJson" aria-label="Exportar datos a JSON">Exportar JSON</button>
-    <input type="file" id="inputImportJson" accept=".json" style="display:none" />
-    <button id="btnImportJson" aria-label="Importar datos desde JSON">Importar JSON</button>
   </div>
     <table id="sinoptico">
       <thead>

--- a/test-invalid-sinoptico.js
+++ b/test-invalid-sinoptico.js
@@ -1,0 +1,48 @@
+const jsdom = require('jsdom-global');
+const Fuse = require('fuse.js');
+jsdom('', { url: 'http://localhost' });
+
+require('./history_utils.js');
+
+global.sessionStorage = window.sessionStorage;
+global.localStorage = window.localStorage;
+
+// minimal globals for renderer.js
+global.Papa = { parse: () => ({ data: [], errors: [] }) };
+global.XLSX = {
+  utils: { book_new(){}, aoa_to_sheet(){}, book_append_sheet(){} },
+  writeFile(){},
+  read(){ return { SheetNames:[], Sheets:{} }; }
+};
+
+document.body.innerHTML = `
+  <div id="mensaje"></div>
+  <table id="sinoptico"><thead><tr><th></th></tr></thead><tbody></tbody></table>
+  <input id="filtroInsumo" />
+  <button id="clearSearch"></button>
+  <ul id="sinopticoSuggestions"></ul>
+  <input type="checkbox" id="chkIncluirAncestros" />
+  <input type="checkbox" id="chkMostrarNivel0" />
+  <input type="checkbox" id="chkMostrarNivel1" />
+  <input type="checkbox" id="chkMostrarNivel2" />
+  <input type="checkbox" id="chkMostrarNivel3" />
+  <button id="expandirTodo"></button>
+  <button id="colapsarTodo"></button>
+  <button id="btnRefrescar"></button>
+  <button id="btnExcel"></button>
+  <label class="toggle-col" data-colindex="0"></label>
+`;
+
+localStorage.clear();
+localStorage.setItem('sinopticoData', '{');
+
+global.Fuse = Fuse;
+require('./renderer.js');
+
+document.dispatchEvent(new Event('DOMContentLoaded'));
+
+const nodes = window.SinopticoEditor.getNodes();
+if (!Array.isArray(nodes) || nodes.length === 0) {
+  throw new Error('renderer did not recover from invalid sinopticoData');
+}
+console.log('invalid sinoptico test passed');


### PR DESCRIPTION
## Summary
- move data import/export buttons to index and toggle with admin session
- keep a `Datos-Nunca borrar/` folder ignored by Git
- recover gracefully from malformed `sinopticoData`
- guard JSON.parse on maestro and insumos pages
- describe export/import workflow in README
- test invalid localStorage handling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c64260ef8832f85917ac5740f519c