### PR TITLE
Fix sinoptico filter in edit mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,13 @@ no external dependencies. All header fields and the list of processes persist in
 `localStorage`. Pressing **Guardar** attempts to POST the JSON to `/api/amfe`.
 If that endpoint is missing the page still saves to `localStorage` and shows a
 warning that the server could not be reached.
+
+## Using the sinóptico editor
+
+Open `sinoptico.html` and click **Editar** to modify the hierarchy. Rows remain
+visible while editing even with an empty search box, so you can toggle the level
+checkboxes to quickly hide or show sections.
+
 ## Features
 
 - **Column toggles** – checkboxes let you hide or show specific table columns.

--- a/renderer.js
+++ b/renderer.js
@@ -151,13 +151,6 @@
           if (item.text) keywords.push(item.text.toString().trim());
         });
 
-        const isEdit = sessionStorage.getItem('sinopticoEdit') === 'true';
-
-        if (isEdit && keywords.length === 0) {
-          todasFilas.forEach(tr => (tr.style.display = 'none'));
-          return;
-        }
-
         if (keywords.length === 0) {
           // Mostrar/ocultar según nivel, sin filtro de texto
           todasFilas.forEach(tr => {


### PR DESCRIPTION
## Summary
- keep sinoptico table visible when editing with no search
- document that rows stay visible while editing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c7615d9a4832f88d932f86a4d5ca1