### PR TITLE
Add save confirmation to sinoptico

### DIFF
--- a/renderer.js
+++ b/renderer.js
@@ -1107,6 +1107,9 @@
             console.error('Error writing sinoptico JSON', e);
           }
         }
+        if (typeof mostrarMensaje === 'function') {
+          mostrarMensaje('Datos guardados', 'success');
+        }
       }
 
       function generateId(){


### PR DESCRIPTION
## Summary
- notify user with a success message when saving Sinoptico data
- keep editor operations triggering `saveSinoptico()`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c785df4a8832fba9f23c3f9b90fe9