### PR TITLE
Add loading overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,6 +7,7 @@
     <link rel="stylesheet" href="styles.css">
 </head>
   <body class="home">
+    <div id="loading">Cargando…</div>
       <nav class="main-nav">
           <a href="index.html" aria-current="page">Inicio</a>
           <a href="sinoptico.html">Sinóptico</a>
@@ -69,6 +70,12 @@
           });
           update();
         });
+      </script>
+      <script>
+        window.onload = () => {
+          const loader = document.getElementById('loading');
+          if (loader) loader.style.display = 'none';
+        };
       </script>
   </body>
 </html>

--- a/sinoptico.html
+++ b/sinoptico.html
@@ -14,6 +14,7 @@
   <script src="https://cdn.jsdelivr.net/npm/fuse.js@6/dist/fuse.min.js" onerror="this.onerror=null;this.src='vendor/fuse.min.js'"></script>
 </head>
 <body>
+  <div id="loading">Cargando…</div>
   <nav class="main-nav">
     <a href="index.html">Inicio</a>
     <a href="sinoptico.html" aria-current="page">Sinóptico</a>
@@ -120,5 +121,11 @@
   <script src="smooth-nav.js" defer></script>
   <script>sessionStorage.setItem('sinopticoEdit','false');</script>
   <script src="renderer.js" defer></script>
+  <script>
+    window.onload = () => {
+      const loader = document.getElementById('loading');
+      if (loader) loader.style.display = 'none';
+    };
+  </script>
 </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -93,6 +93,21 @@ h1 {
   display: none !important;
 }
 
+#loading {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #fff;
+  font-size: 1.2rem;
+  z-index: 2000;
+}
+
 /* highlight invalid form fields */
 .invalid {
   border: 1px solid red !important;

--- a/viewer_lite.html
+++ b/viewer_lite.html
@@ -7,6 +7,7 @@
   <link rel="stylesheet" href="styles.css" />
 </head>
 <body>
+  <div id="loading">Cargando…</div>
   <nav class="main-nav">
     <a href="index.html">Inicio</a>
   </nav>
@@ -37,5 +38,11 @@
   <script src="file-warning.js"></script>
   <script>sessionStorage.setItem('sinopticoEdit','false');</script>
   <script src="renderer.js" defer></script>
+  <script>
+    window.onload = () => {
+      const loader = document.getElementById('loading');
+      if (loader) loader.style.display = 'none';
+    };
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- show a temporary "Cargando…" overlay on the main pages
- hide the overlay when the window finishes loading
- style the overlay with a fixed, translucent background

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c7fcb98f8832fa7ccbf4c94cb2884