### PR TITLE
Introduce salted hashing for auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ locate the **Application** or **Storage** tab. Select the site's entry under
 Use the **Log in** link or open `login.html` directly to access the sign‑in page. The project includes four default accounts: **PAULO**, **LEO**, **FACUNDO** and **PABLO**, all with password `1234`. After logging in an admin panel becomes visible where you can create new users or update existing passwords. A dedicated management page is also available at `usuarios.html` for administrators.
 If the page detects `sessionStorage.isAdmin` is already set to `true`, it skips the form and redirects straight to `index.html`.
 
-Account information is now stored as SHA‑256 hashes in the browser's `localStorage`. Tick **Recordarme** on the login form to keep the session between visits. Clear the `users` entry to reset all accounts.
+Account information is now stored as SHA‑256 hashes combined with a per‑user salt in the browser's `localStorage`. Tick **Recordarme** on the login form to keep the session between visits. Clear the `users` entry to reset all accounts.
 
 Editing the master list and the sinóptico now requires being logged in.
 

--- a/test-auth.js
+++ b/test-auth.js
@@ -11,6 +11,8 @@ sessionStorage.clear();
 
 auth.createUser('user1','pass1');
 auth.setRole('user1','admin');
+const uRec = auth.loadUsers().find(u => u.username === 'user1');
+if (!uRec || !uRec.salt) throw new Error('salt missing');
 if (!auth.login('user1','pass1', true)) throw new Error('login failed');
 if (sessionStorage.getItem('isAdmin') !== 'true') throw new Error('role not applied');
 


### PR DESCRIPTION
## Summary
- add random salt to auth records
- compute hash using salt for all auth operations
- update README with salted hash info
- ensure tests cover new user fields

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c7fccdb20832f8df82f84724a77d5