### PR TITLE
Fix HTML injection by avoiding innerHTML

### DIFF
--- a/product_builder.js
+++ b/product_builder.js
@@ -81,15 +81,30 @@ document.addEventListener('DOMContentLoaded', () => {
     if (!subContainer) return;
     const row = document.createElement('div');
     row.className = 'new-sub-row';
-    row.innerHTML = `
-      <input type="text" class="new-sub-desc" placeholder="Descripción">
-      <input type="text" class="new-sub-code" placeholder="Código">
-      <button type="button" class="remove-sub">×</button>`;
-    row.querySelector('.remove-sub').addEventListener('click', () => {
+    const descInput = document.createElement('input');
+    descInput.type = 'text';
+    descInput.className = 'new-sub-desc';
+    descInput.placeholder = 'Descripción';
+
+    const codeInput = document.createElement('input');
+    codeInput.type = 'text';
+    codeInput.className = 'new-sub-code';
+    codeInput.placeholder = 'Código';
+
+    const removeBtn = document.createElement('button');
+    removeBtn.type = 'button';
+    removeBtn.className = 'remove-sub';
+    removeBtn.textContent = '×';
+
+    row.appendChild(descInput);
+    row.appendChild(codeInput);
+    row.appendChild(removeBtn);
+
+    removeBtn.addEventListener('click', () => {
       row.remove();
       renderPreview();
     });
-    row.querySelectorAll('input').forEach(inp =>
+    [descInput, codeInput].forEach(inp =>
       inp.addEventListener('input', renderPreview)
     );
     subContainer.appendChild(row);

--- a/sinoptico-modify.js
+++ b/sinoptico-modify.js
@@ -12,7 +12,23 @@ document.addEventListener('DOMContentLoaded', () => {
     const nodes = window.SinopticoEditor.getNodes();
     nodes.forEach(n => {
       const tr = document.createElement('tr');
-      tr.innerHTML = `<td>${n.ID}</td><td>${n.Tipo}</td><td>${n['Descripción'] || ''}</td><td>${n.Código || ''}</td>`;
+
+      const idTd = document.createElement('td');
+      idTd.textContent = n.ID;
+      tr.appendChild(idTd);
+
+      const typeTd = document.createElement('td');
+      typeTd.textContent = n.Tipo;
+      tr.appendChild(typeTd);
+
+      const descTd = document.createElement('td');
+      descTd.textContent = n['Descripción'] || '';
+      tr.appendChild(descTd);
+
+      const codeTd = document.createElement('td');
+      codeTd.textContent = n.Código || '';
+      tr.appendChild(codeTd);
+
       const td = document.createElement('td');
       const btn = document.createElement('button');
       btn.textContent = 'Editar';


### PR DESCRIPTION
## Summary
- avoid using `innerHTML` to construct DOM elements in product builder
- build table rows without `innerHTML` in sinoptico modifier

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c7fd0bbc0832fa60e5de9e723cfc7