### PR TITLE
Remove obsolete JSON backup controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,11 +107,6 @@ page. It is intended as a lightweight viewer for quick look-ups.
 - **Cross-tab sync** – modifying the hierarchy in one tab refreshes any other
   open sinóptico pages thanks to the `storage` event.
 
-## Respaldos fuera del repositorio
-
-Pulsa **Exportar JSON** en la página de inicio para descargar el fichero `sinoptico.json` mediante el navegador. Guarda una copia en una carpeta fuera del proyecto si quieres conservarla. Podrás recuperarla más adelante con **Importar JSON** desde el mismo menú.
-
-The product hierarchy is stored in `localStorage`.
 
 ## Listening for data changes
 

--- a/index.html
+++ b/index.html
@@ -32,11 +32,6 @@
             <li>Listado maestro de ingeniería</li>
             <li>Datos actualizados automáticamente</li>
           </ul>
-          <div id="adminDataBtns" style="display:none">
-            <button id="btnExportJson" aria-label="Exportar datos">Exportar datos</button>
-            <input type="file" id="inputImportJson" accept=".json" style="display:none">
-            <button id="btnImportJson" aria-label="Importar datos">Importar datos</button>
-          </div>
       </main>
   <script src="sha256.min.js"></script>
   <script src="auth.js"></script>
@@ -50,13 +45,11 @@
           const link = document.getElementById('loginLink');
           const editLink = document.getElementById('editSinLink');
           const usersLink = document.getElementById('usersLink');
-          const adminBtns = document.getElementById('adminDataBtns');
           function update() {
             const logged = sessionStorage.getItem('isAdmin') === 'true';
             link.textContent = logged ? 'Cerrar sesión' : 'Log in';
             if (editLink) editLink.style.display = logged ? 'inline' : 'none';
             if (usersLink) usersLink.style.display = logged ? 'inline' : 'none';
-            if (adminBtns) adminBtns.style.display = logged ? 'block' : 'none';
           }
           auth.restoreSession();
           link.addEventListener('click', e => {

--- a/renderer.js
+++ b/renderer.js
@@ -533,65 +533,6 @@
       });
 
       /* ==================================================
-         Exportar/Importar JSON
-      ================================================== */
-      const btnExportJson = document.querySelector('#btnExportJson');
-      if (btnExportJson) btnExportJson.addEventListener('click', exportJson);
-
-      const btnImportJson = document.querySelector('#btnImportJson');
-      const inputImportJson = document.querySelector('#inputImportJson');
-      if (btnImportJson && inputImportJson) {
-        btnImportJson.addEventListener('click', () => inputImportJson.click());
-        inputImportJson.addEventListener('change', e => {
-          const file = e.target.files[0];
-          if (file) importJsonFile(file);
-          inputImportJson.value = '';
-        });
-      }
-
-      function exportJson() {
-        try {
-          const blob = new Blob([
-            JSON.stringify(sinopticoData, null, 2)
-          ], { type: 'application/json' });
-          const url = URL.createObjectURL(blob);
-          const a = document.createElement('a');
-          a.href = url;
-          a.download = 'BASE_DE_DATOS.json';
-          a.style.display = 'none';
-          document.body.appendChild(a);
-          a.click();
-          document.body.removeChild(a);
-          URL.revokeObjectURL(url);
-          mostrarMensaje('JSON exportado', 'success');
-        } catch (e) {
-          console.error('Error exporting JSON', e);
-          mostrarMensaje('Error al exportar JSON');
-        }
-      }
-
-      function importJsonFile(file) {
-        if (typeof FileReader === 'undefined') return;
-        const reader = new FileReader();
-        reader.onload = () => {
-          try {
-            const data = JSON.parse(reader.result);
-            if (!Array.isArray(data)) {
-              throw new Error('Formato inválido');
-            }
-            sinopticoData = data;
-            saveSinoptico();
-            loadData();
-            mostrarMensaje('JSON importado', 'success');
-          } catch (e) {
-            console.error('Error importing JSON', e);
-            mostrarMensaje('Error al importar JSON');
-          }
-        };
-        reader.readAsText(file);
-      }
-
-      /* ==================================================
          5) Cargar CSV y construir la tabla jerárquica
          + Recarga automática cada 30 segundos
       ================================================== */


### PR DESCRIPTION
## Summary
- drop admin JSON import/export buttons from the home page
- remove export/import functions from `renderer.js`
- delete the JSON backup section from README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c7fd801f0832f91d830faad270020