### PR TITLE
Fix innerHTML for chip buttons

### DIFF
--- a/renderer.js
+++ b/renderer.js
@@ -339,7 +339,7 @@
           chip.className = 'chip';
           chip.textContent = item.text;
           const btn = document.createElement('button');
-          btn.innerHTML = '×';
+          btn.textContent = '×';
           btn.addEventListener('click', () => {
             removeSelectedItem(item.code);
           });


### PR DESCRIPTION
## Summary
- remove dynamic `innerHTML` usage when rendering chips

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c822dceb0832fb656f65ccb82bc88