### PR TITLE
Fix Dexie loading and await data before rendering

### DIFF
--- a/js/dataService.js
+++ b/js/dataService.js
@@ -3,27 +3,21 @@
 export const DATA_CHANGED = 'DATA_CHANGED';
 const STORAGE_KEY = 'sinopticoData';
 
+import Dexie from 'dexie';
+
 const isNode =
   typeof process !== 'undefined' &&
   process.versions != null &&
   process.versions.node != null;
 const hasWindow = !isNode && typeof window !== 'undefined' && window.document;
-let DexieLib = null;
-if (hasWindow) {
-  DexieLib =
-    // if Dexie is loaded via a <script> tag it will be on window
-    window.Dexie ||
-    // otherwise try to require (for Node environments or bundlers)
-    (typeof require === 'function' ? require('dexie') : undefined);
-}
 
 let db = null;
 // in-memory fallback
 const memory = [];
 
 // initialize IndexedDB if Dexie is available
-if (DexieLib) {
-  db = new DexieLib('ProyectoBarackDB');
+if (Dexie) {
+  db = new Dexie('ProyectoBarackDB');
   db.version(1).stores({
     sinoptico: '++id,parentId,nombre,orden',
   });

--- a/js/sinoptico.js
+++ b/js/sinoptico.js
@@ -1,25 +1,22 @@
-import { getAll, DATA_CHANGED } from './dataService.js';
+import { getAll, subscribeToChanges } from './dataService.js';
+import '../renderer.js';
 
-function refresh() {
-  const data = getAll();
-  try {
-    localStorage.setItem('sinopticoData', JSON.stringify(data));
-  } catch (e) {
-    console.error('Could not persist sinoptico data', e);
-  }
-  document.dispatchEvent(new CustomEvent('sinoptico-data-changed'));
-}
-
-document.addEventListener('DOMContentLoaded', () => {
+document.addEventListener('DOMContentLoaded', async () => {
+  console.log('▶ renderSinoptico arrancó');
   sessionStorage.setItem('sinopticoEdit', 'false');
-  refresh();
-  window.addEventListener('load', () => {
-    const loader = document.getElementById('loading');
-    if (loader) loader.style.display = 'none';
+  const nodes = await getAll();
+  console.log('▷ nodos obtenidos', nodes);
+  if (typeof renderSinoptico === 'function') {
+    renderSinoptico(nodes);
+  }
+  const loader = document.getElementById('loading');
+  if (loader) loader.style.display = 'none';
+  console.log('▶ spinner oculto');
+
+  subscribeToChanges(async () => {
+    const updated = await getAll();
+    if (typeof renderSinoptico === 'function') {
+      renderSinoptico(updated);
+    }
   });
 });
-
-document.addEventListener(DATA_CHANGED, refresh);
-
-// Load existing rendering logic
-import '../renderer.js';

--- a/sinoptico.html
+++ b/sinoptico.html
@@ -113,6 +113,7 @@
   </div>
   <a href="welcome.html" class="home-button">Inicio</a>
 
+  <script src="https://cdn.jsdelivr.net/npm/dexie@4/dist/dexie.min.js"></script>
   <script type="module" defer src="js/dataService.js"></script>
   <script type="module" defer src="js/sinoptico.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- add Dexie script tag to `sinoptico.html`
- switch to ESM `dexie` import and always create DB when Dexie is present
- load sinóptico after `DOMContentLoaded` and wait for data

## Testing
- `bash scripts/setup.sh`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c87de27dc832f86b6343662629c44