### PR TITLE
Fix Dexie loading in sinoptico

### DIFF
--- a/renderer.js
+++ b/renderer.js
@@ -1,9 +1,11 @@
+const root = typeof global !== 'undefined' ? global : globalThis;
+
     document.addEventListener('DOMContentLoaded', () => {
       const dataService =
-        global.dataService ||
+        root.dataService ||
         (typeof require === 'function' ? require('./js/dataService.js') : null);
-      if (typeof requestAnimationFrame === 'undefined') {
-        global.requestAnimationFrame = cb => setTimeout(cb, 0);
+      if (typeof root.requestAnimationFrame === 'undefined') {
+        root.requestAnimationFrame = cb => setTimeout(cb, 0);
       }
       let fuseSinoptico = null;
       let sinopticoData = [];
@@ -1091,5 +1093,10 @@
       if (dataService && dataService.subscribeToChanges) {
         dataService.subscribeToChanges(() => loadData());
       }
+
+      root.renderSinoptico = datos => {
+        sinopticoData = Array.isArray(datos) ? datos.slice() : [];
+        procesarDatos(sinopticoData, []);
+      };
 
     }); // FIN DOMContentLoaded

--- a/sinoptico.html
+++ b/sinoptico.html
@@ -114,6 +114,13 @@
   <a href="welcome.html" class="home-button">Inicio</a>
 
   <script src="https://cdn.jsdelivr.net/npm/dexie@4/dist/dexie.min.js"></script>
+  <script type="importmap">
+  {
+    "imports": {
+      "dexie": "https://cdn.jsdelivr.net/npm/dexie@4/dist/modern/dexie.mjs"
+    }
+  }
+  </script>
   <script type="module" defer src="js/dataService.js"></script>
   <script type="module" defer src="js/sinoptico.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- expose global `renderSinoptico` from renderer.js and guard `global` usage
- map `dexie` specifier to the CDN in `sinoptico.html`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c8e087e5c832fb94f4c05c18d44ba