### PR TITLE
Add JSON export/import buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,6 +33,10 @@
             <li>Listado maestro de ingeniería</li>
             <li>Datos actualizados automáticamente</li>
           </ul>
+          <div id="jsonTools" style="display:none;margin-top:1em;text-align:center;">
+            <button id="exportJsonBtn">Exportar JSON</button>
+            <input type="file" id="importJsonInput" accept="application/json" />
+          </div>
       </main>
   <script src="sha256.min.js"></script>
   <script src="auth.js"></script>
@@ -40,6 +44,16 @@
   <script src="theme.js" defer></script>
       <script src="smooth-nav.js" defer></script>
       <script src="renderer.js" defer></script>
+  <script src="https://cdn.jsdelivr.net/npm/dexie@4/dist/dexie.min.js" onerror="this.onerror=null;this.src='vendor/dexie.min.js'"></script>
+  <script type="importmap">
+  {
+    "imports": {
+      "dexie": "./vendor/dexie.min.mjs"
+    }
+  }
+  </script>
+  <script type="module" src="js/dataService.js"></script>
+  <script type="module" src="js/json_tools.js"></script>
       <script>
         document.addEventListener('DOMContentLoaded', () => {
           document.querySelector('main').classList.add('fade-in');

--- a/js/dataService.js
+++ b/js/dataService.js
@@ -131,6 +131,26 @@ export async function deleteNode(id) {
   }
 }
 
+export async function replaceAll(arr) {
+  if (!Array.isArray(arr)) return;
+  if (db) {
+    try {
+      await db.transaction('rw', db.sinoptico, async () => {
+        await db.sinoptico.clear();
+        if (arr.length) await db.sinoptico.bulkAdd(arr);
+      });
+      notifyChange();
+    } catch (e) {
+      console.error(e);
+    }
+  } else {
+    memory.length = 0;
+    memory.push(...arr);
+    _fallbackPersist();
+    notifyChange();
+  }
+}
+
 export function subscribeToChanges(handler) {
   if (channel) {
     channel.addEventListener('message', (ev) => {

--- a/js/json_tools.js
+++ b/js/json_tools.js
@@ -1,0 +1,46 @@
+import { getAll, replaceAll } from './dataService.js';
+
+document.addEventListener('DOMContentLoaded', () => {
+  const tools = document.getElementById('jsonTools');
+  if (!tools) return;
+  const exportBtn = document.getElementById('exportJsonBtn');
+  const importInput = document.getElementById('importJsonInput');
+
+  const isAdmin = sessionStorage.getItem('isAdmin') === 'true';
+  tools.style.display = isAdmin ? 'block' : 'none';
+  if (!isAdmin) return;
+
+  exportBtn.addEventListener('click', async () => {
+    try {
+      const data = await getAll();
+      const blob = new Blob([JSON.stringify(data, null, 2)], {
+        type: 'application/json'
+      });
+      const a = document.createElement('a');
+      a.href = URL.createObjectURL(blob);
+      a.download = 'sinoptico.json';
+      a.click();
+      setTimeout(() => URL.revokeObjectURL(a.href), 1000);
+    } catch (e) {
+      console.error('Error al exportar JSON', e);
+      alert('No se pudo exportar los datos');
+    }
+  });
+
+  importInput.addEventListener('change', async (ev) => {
+    const file = ev.target.files && ev.target.files[0];
+    if (!file) return;
+    try {
+      const text = await file.text();
+      const arr = JSON.parse(text);
+      if (!Array.isArray(arr)) throw new Error('Formato inválido');
+      await replaceAll(arr);
+      alert('Datos importados correctamente');
+    } catch (err) {
+      console.error('Error al importar JSON', err);
+      alert('No se pudo importar el archivo');
+    } finally {
+      ev.target.value = '';
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- allow replacing data in `js/dataService.js`
- add admin-only JSON export/import tools on the home page
- load new `json_tools.js` module for export/import logic

## Testing
- `scripts/setup.sh`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ca3a0b640832f800af474c9fb8af2