### PR TITLE
Remove Quick start section

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,24 +3,6 @@
 This project displays a hierarchical product table built with plain HTML, CSS and JavaScript.
 These pages are completely static. You can serve them locally with Python's built‑in HTTP server or host them on GitHub Pages.
 
-## Quick start
-
-Run a simple web server **from inside this folder** and visit the site from
-`http://localhost`:
-
-```bash
-cd /path/to/Proyecto-barack
-python3 -m http.server
-```
-
-Open http://localhost:8000/index.html in a modern browser. Opening the HTML
-files directly (for example using the `file://` protocol) disables several
-features because the pages rely on `localStorage` and other browser APIs that
-only work over HTTP. All dependencies are included in the repository, so no
-internet connection is needed once the server is running. The site relies on
-IndexedDB via [Dexie](https://dexie.org/) for persistence, and a copy of the
-library is bundled under `lib/` to load locally if the CDN is unreachable.
-Luego abre http://localhost:8000/login.html e inicia sesión con cualquiera de las cuentas por defecto (PAULO, LEO, FACUNDO o PABLO; todas usan la contraseña `1234`). Sin iniciar sesión las opciones de edición no aparecen.
 
 ## GitHub Pages
 
@@ -77,7 +59,7 @@ checkboxes to quickly hide or show sections.
 
 ## Agregar clientes
 
-1. Inicia un servidor local como se explica en [Quick start](#quick-start).
+1. Inicia un servidor local dentro de la carpeta del proyecto.
 2. Abre `http://localhost:8000/login.html` e inicia sesión con cualquiera de las cuentas por defecto (**PAULO**, **LEO**, **FACUNDO** o **PABLO**; todas usan la contraseña `1234`).
 3. Tras autenticarte vuelve a `index.html`; aparecerá el enlace **Editar sinóptico**.
 4. Haz clic en ese enlace para abrir `admin_menu.html` y elige **Crear**.
@@ -147,7 +129,7 @@ If editing pages doesn't work as expected:
 5. Accede siempre con la misma URL (por ejemplo `localhost`) para que los datos guardados estén disponibles.
 6. La biblioteca **Dexie** viene incluida, por lo que la persistencia funciona incluso sin acceso a Internet.
 
-7. Asegúrate de ejecutar el servidor dentro de la carpeta del proyecto como se indica en [Quick start](#quick-start). Iniciar el servidor desde otro directorio provoca errores 404.
+7. Asegúrate de ejecutar el servidor dentro de la carpeta del proyecto. Iniciar el servidor desde otro directorio provoca errores 404.
 
 If a CDN script fails to load you will see one of the following warnings:
 


### PR DESCRIPTION
## Summary
- drop Quick start instructions from README
- remove references to the deleted section

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684cbd092f34832fba8d517e8bd4e7b8