### PR TITLE
Fix offline usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # Proyecto-barack
 
 This project displays a hierarchical product table built with plain HTML, CSS and JavaScript.
-These pages are completely static. You can serve them locally with Python's built‑in HTTP server or host them on GitHub Pages.
+These pages are completely static and can be opened directly from the file system.
+You may still choose to serve them locally with Python's built‑in HTTP server or host them on GitHub Pages.
 
 
 ## GitHub Pages
@@ -59,8 +60,8 @@ checkboxes to quickly hide or show sections.
 
 ## Agregar clientes
 
-1. Inicia un servidor local dentro de la carpeta del proyecto.
-2. Abre `http://localhost:8000/login.html` e inicia sesión con cualquiera de las cuentas por defecto (**PAULO**, **LEO**, **FACUNDO** o **PABLO**; todas usan la contraseña `1234`).
+1. Abre `login.html` directamente en tu navegador.
+2. Inicia sesión con cualquiera de las cuentas por defecto (**PAULO**, **LEO**, **FACUNDO** o **PABLO**; todas usan la contraseña `1234`).
 3. Tras autenticarte vuelve a `index.html`; aparecerá el enlace **Editar sinóptico**.
 4. Haz clic en ese enlace para abrir `admin_menu.html` y elige **Crear**.
 5. En `sinoptico_crear.html` selecciona la opción **Cliente**, completa la descripción y envía el formulario.
@@ -122,14 +123,11 @@ The page loads [SheetJS](https://sheetjs.com/) and [Fuse.js](https://fusejs.io/)
 
 If editing pages doesn't work as expected:
 
-1. Verify the site is being served over **HTTP**, not opened directly as local files.
-2. Make sure you are logged in as an administrator before attempting to edit.
-3. Open the browser console and ensure there are no script errors.
-4. Check your browser's `localStorage` for entries such as `sinopticoData`.
-5. Accede siempre con la misma URL (por ejemplo `localhost`) para que los datos guardados estén disponibles.
-6. La biblioteca **Dexie** viene incluida, por lo que la persistencia funciona incluso sin acceso a Internet.
-
-7. Asegúrate de ejecutar el servidor dentro de la carpeta del proyecto. Iniciar el servidor desde otro directorio provoca errores 404.
+1. Make sure you are logged in as an administrator before attempting to edit.
+2. Open the browser console and ensure there are no script errors.
+3. Check your browser's `localStorage` for entries such as `sinopticoData`.
+4. Accede siempre con la misma ruta de archivo para que los datos guardados estén disponibles.
+5. La biblioteca **Dexie** viene incluida, por lo que la persistencia funciona incluso sin acceso a Internet.
 
 If a CDN script fails to load you will see one of the following warnings:
 

--- a/file-warning.js
+++ b/file-warning.js
@@ -1,4 +1,3 @@
 'use strict';
-if (location.protocol === 'file:') {
-  alert('Abra el proyecto a través de un servidor web para que funcione correctamente.');
-}
+// This file previously alerted users to serve pages via HTTP.
+// It is now a no-op so the pages can be opened directly.

--- a/index.html
+++ b/index.html
@@ -46,14 +46,7 @@
       <script src="smooth-nav.js" defer></script>
       <script src="renderer.js" defer></script>
   <script src="https://cdn.jsdelivr.net/npm/dexie@4/dist/dexie.min.js" onerror="this.onerror=null;this.src='lib/dexie.min.js'"></script>
-  <script async src="https://cdn.jsdelivr.net/npm/es-module-shims@1/dist/es-module-shims.min.js" onerror="this.onerror=null;this.src='lib/es-module-shims.min.js'"></script>
-  <script type="importmap">
-  {
-    "imports": {
-      "dexie": "./lib/dexie.mjs"
-    }
-  }
-  </script>
+  <!-- import map removed; Dexie is used as a global -->
   <script type="module" src="js/dataService.js"></script>
   <script type="module" src="js/json_tools.js"></script>
       <script>

--- a/js/dataService.js
+++ b/js/dataService.js
@@ -4,7 +4,9 @@
 export const DATA_CHANGED = 'DATA_CHANGED';
 const STORAGE_KEY = 'sinopticoData';
 
-import Dexie from 'dexie';
+// Dexie is loaded via a regular script tag so grab the global instance
+// Using a global avoids the need for import maps when opening files directly
+const Dexie = typeof globalThis !== 'undefined' ? globalThis.Dexie : undefined;
 
 const isNode =
   typeof process !== 'undefined' &&

--- a/sinoptico-edit.html
+++ b/sinoptico-edit.html
@@ -89,14 +89,7 @@
   <a href="welcome.html" class="home-button">Inicio</a>
 
   <script src="lib/dexie.min.js"></script>
-  <script async src="https://cdn.jsdelivr.net/npm/es-module-shims@1/dist/es-module-shims.min.js" onerror="this.onerror=null;this.src='lib/es-module-shims.min.js'"></script>
-  <script type="importmap">
-  {
-    "imports": {
-      "dexie": "./lib/dexie.mjs"
-    }
-  }
-  </script>
+  <!-- Import maps are no longer required for Dexie -->
   <script type="module" defer src="js/dataService.js"></script>
   <script type="module" defer src="js/sinoptico.js"></script>
   <script src="theme.js" defer></script>

--- a/sinoptico.html
+++ b/sinoptico.html
@@ -114,14 +114,7 @@
   <a href="welcome.html" class="home-button">Inicio</a>
 
   <script src="lib/dexie.min.js"></script>
-  <script async src="https://cdn.jsdelivr.net/npm/es-module-shims@1/dist/es-module-shims.min.js" onerror="this.onerror=null;this.src='lib/es-module-shims.min.js'"></script>
-  <script type="importmap">
-  {
-    "imports": {
-      "dexie": "./lib/dexie.mjs"
-    }
-  }
-  </script>
+  <!-- Dexie is loaded via script tag, modules no longer rely on import maps -->
   <script type="module" defer src="js/dataService.js"></script>
   <script type="module" defer src="js/sinoptico.js"></script>
   <script src="theme.js" defer></script>

--- a/sinoptico_crear.html
+++ b/sinoptico_crear.html
@@ -78,14 +78,7 @@
   <script src="theme.js" defer></script>
   <script src="smooth-nav.js" defer></script>
   <script src="lib/dexie.min.js"></script>
-  <script async src="https://cdn.jsdelivr.net/npm/es-module-shims@1/dist/es-module-shims.min.js" onerror="this.onerror=null;this.src='lib/es-module-shims.min.js'"></script>
-  <script type="importmap">
-  {
-    "imports": {
-      "dexie": "./lib/dexie.mjs"
-    }
-  }
-  </script>
+  <!-- import map removed; dataService now accesses Dexie via the global -->
   <script type="module" defer src="js/dataService.js"></script>
   <script src="renderer.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/fuse.js@6/dist/fuse.min.js"></script>

--- a/sinoptico_eliminar.html
+++ b/sinoptico_eliminar.html
@@ -39,14 +39,7 @@
   <script src="theme.js" defer></script>
   <script src="smooth-nav.js" defer></script>
   <script src="lib/dexie.min.js"></script>
-  <script async src="https://cdn.jsdelivr.net/npm/es-module-shims@1/dist/es-module-shims.min.js" onerror="this.onerror=null;this.src='lib/es-module-shims.min.js'"></script>
-  <script type="importmap">
-  {
-    "imports": {
-      "dexie": "./lib/dexie.mjs"
-    }
-  }
-  </script>
+  <!-- Dexie available globally; import map removed -->
   <script type="module" defer src="js/dataService.js"></script>
   <script src="renderer.js"></script>
   <script src="sinoptico-delete.js"></script>

--- a/sinoptico_modificar.html
+++ b/sinoptico_modificar.html
@@ -34,14 +34,7 @@
   <script src="theme.js" defer></script>
   <script src="smooth-nav.js" defer></script>
   <script src="lib/dexie.min.js"></script>
-  <script async src="https://cdn.jsdelivr.net/npm/es-module-shims@1/dist/es-module-shims.min.js" onerror="this.onerror=null;this.src='lib/es-module-shims.min.js'"></script>
-  <script type="importmap">
-  {
-    "imports": {
-      "dexie": "./lib/dexie.mjs"
-    }
-  }
-  </script>
+  <!-- import map removed; Dexie loaded globally -->
   <script type="module" defer src="js/dataService.js"></script>
   <script src="renderer.js"></script>
   <script src="sinoptico-modify.js"></script>


### PR DESCRIPTION
## Summary
- drop file protocol alert so pages can be opened directly
- load Dexie from the global object and drop import maps
- simplify HTML files that relied on import maps
- update README instructions for direct usage

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684cbe79bce4832fbe3763444f595bc6