### PR TITLE
Fix renderer script order

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,10 +44,10 @@
   <script src="file-warning.js"></script>
   <script src="theme.js" defer></script>
       <script src="smooth-nav.js" defer></script>
-      <script src="renderer.js" defer></script>
   <script src="https://cdn.jsdelivr.net/npm/dexie@4/dist/dexie.min.js" onerror="this.onerror=null;this.src='lib/dexie.min.js'"></script>
   <!-- import map removed; Dexie is used as a global -->
   <script type="module" src="js/dataService.js"></script>
+      <script src="renderer.js" defer></script>
   <script type="module" src="js/json_tools.js"></script>
       <script>
         document.addEventListener('DOMContentLoaded', () => {


### PR DESCRIPTION
## Summary
- ensure renderer.js loads after dataService.js on index
- keep Dexie loaded before both scripts

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684cc3a7c934832fb1886889ab96b499