### PR TITLE
Fix sinoptico dynamic rendering

### DIFF
--- a/js/sinoptico.js
+++ b/js/sinoptico.js
@@ -1,23 +1,64 @@
 'use strict';
-import { getAll, subscribeToChanges } from './dataService.js';
-import '../renderer.js';
+import { getAllSinoptico, subscribeSinopticoChanges } from './dataService.js';
 
 document.addEventListener('DOMContentLoaded', async () => {
-  console.log('▶ renderSinoptico arrancó');
-  sessionStorage.setItem('sinopticoEdit', 'false');
-  const nodes = await getAll();
-  console.log('▷ nodos obtenidos', nodes);
-  if (typeof renderSinoptico === 'function') {
-    renderSinoptico(nodes);
-  }
   const loader = document.getElementById('loading');
+  if (loader) loader.style.display = 'block';
+
+  const nodes = await getAllSinoptico();
+  console.log('▷ nodos obtenidos', nodes);
+
+  const tbody = document.getElementById('sinopticoBody');
+  if (tbody) {
+    tbody.innerHTML = '';
+    if (!nodes.length) {
+      const tr = document.createElement('tr');
+      tr.innerHTML = `<td colspan="8">No hay productos</td>`;
+      tbody.appendChild(tr);
+    } else {
+      nodes.forEach(n => {
+        const tr = document.createElement('tr');
+        tr.innerHTML = `
+          <td>${n.id}</td>
+          <td>${n.parentId}</td>
+          <td>${n.nombre}</td>
+          <td>${n.orden}</td>
+          <td>
+            <button data-id="${n.id}" class="edit">Editar</button>
+            <button data-id="${n.id}" class="delete">Borrar</button>
+          </td>`;
+        tbody.appendChild(tr);
+      });
+    }
+  }
+
   if (loader) loader.style.display = 'none';
   console.log('▶ spinner oculto');
 
-  subscribeToChanges(async () => {
-    const updated = await getAll();
-    if (typeof renderSinoptico === 'function') {
-      renderSinoptico(updated);
+  subscribeSinopticoChanges(async () => {
+    const updated = await getAllSinoptico();
+    const body = document.getElementById('sinopticoBody');
+    if (body) {
+      body.innerHTML = '';
+      if (!updated.length) {
+        const tr = document.createElement('tr');
+        tr.innerHTML = `<td colspan="8">No hay productos</td>`;
+        body.appendChild(tr);
+      } else {
+        updated.forEach(n => {
+          const tr = document.createElement('tr');
+          tr.innerHTML = `
+            <td>${n.id}</td>
+            <td>${n.parentId}</td>
+            <td>${n.nombre}</td>
+            <td>${n.orden}</td>
+            <td>
+              <button data-id="${n.id}" class="edit">Editar</button>
+              <button data-id="${n.id}" class="delete">Borrar</button>
+            </td>`;
+          body.appendChild(tr);
+        });
+      }
     }
   });
 });

--- a/sinoptico.html
+++ b/sinoptico.html
@@ -106,15 +106,14 @@
           <th id="thActions" style="display:none">Acciones</th>
         </tr>
       </thead>
-      <tbody>
+      <tbody id="sinopticoBody">
         <!-- Aquí se insertarán las filas dinámicamente -->
       </tbody>
     </table>
   </div>
   <a href="welcome.html" class="home-button">Inicio</a>
 
-  <script src="lib/dexie.min.js"></script>
-  <!-- Dexie is loaded via script tag, modules no longer rely on import maps -->
+  <script src="https://cdn.jsdelivr.net/npm/dexie@4/dist/dexie.min.js"></script>
   <script type="module" defer src="js/dataService.js"></script>
   <script type="module" defer src="js/sinoptico.js"></script>
   <script src="theme.js" defer></script>


### PR DESCRIPTION
## Summary
- add alternate BroadcastChannel and DOM event for sinoptico updates
- expose `getAllSinoptico` and `subscribeSinopticoChanges`
- implement data-driven rendering in `sinoptico.js`
- load Dexie from CDN and add tbody id for script

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684cc553eb7c832fb501606d4a0d70a4