### PR TITLE
Enable manual refresh and live updates

### DIFF
--- a/js/sinoptico.js
+++ b/js/sinoptico.js
@@ -1,7 +1,7 @@
 'use strict';
 import { getAllSinoptico, subscribeSinopticoChanges } from './dataService.js';
 
-document.addEventListener('DOMContentLoaded', async () => {
+async function refresh() {
   const loader = document.getElementById('loading');
   if (loader) loader.style.display = 'block';
 
@@ -34,31 +34,11 @@ document.addEventListener('DOMContentLoaded', async () => {
 
   if (loader) loader.style.display = 'none';
   console.log('▶ spinner oculto');
+}
 
-  subscribeSinopticoChanges(async () => {
-    const updated = await getAllSinoptico();
-    const body = document.getElementById('sinopticoBody');
-    if (body) {
-      body.innerHTML = '';
-      if (!updated.length) {
-        const tr = document.createElement('tr');
-        tr.innerHTML = `<td colspan="8">No hay productos</td>`;
-        body.appendChild(tr);
-      } else {
-        updated.forEach(n => {
-          const tr = document.createElement('tr');
-          tr.innerHTML = `
-            <td>${n.id}</td>
-            <td>${n.parentId}</td>
-            <td>${n.nombre}</td>
-            <td>${n.orden}</td>
-            <td>
-              <button data-id="${n.id}" class="edit">Editar</button>
-              <button data-id="${n.id}" class="delete">Borrar</button>
-            </td>`;
-          body.appendChild(tr);
-        });
-      }
-    }
-  });
+document.addEventListener('DOMContentLoaded', () => {
+  refresh();
+  const btn = document.getElementById('refreshBtn');
+  if (btn) btn.addEventListener('click', refresh);
+  subscribeSinopticoChanges(refresh);
 });

--- a/sinoptico-edit.html
+++ b/sinoptico-edit.html
@@ -61,7 +61,7 @@
 
     <button id="expandirTodo" aria-label="Expandir todas las filas">Expandir Todo</button>
     <button id="colapsarTodo" aria-label="Colapsar todas las filas">Colapsar Todo</button>
-    <button id="btnRefrescar" aria-label="Recargar datos">Refrescar</button>
+    <button id="refreshBtn" aria-label="Recargar datos">Refrescar</button>
     <button id="btnExcel" aria-label="Exportar la tabla visible a Excel">Exportar a Excel</button>
   </div>
 

--- a/sinoptico.html
+++ b/sinoptico.html
@@ -86,7 +86,7 @@
     <!-- Botones globales -->
     <button id="expandirTodo" aria-label="Expandir todas las filas">Expandir Todo</button>
     <button id="colapsarTodo" aria-label="Colapsar todas las filas">Colapsar Todo</button>
-    <button id="btnRefrescar" aria-label="Recargar datos">Refrescar</button>
+    <button id="refreshBtn" aria-label="Recargar datos">Refrescar</button>
     <!-- Botón para exportar la tabla visible a Excel -->
     <button id="btnExcel" aria-label="Exportar la tabla visible a Excel">Exportar a Excel</button>
   </div>


### PR DESCRIPTION
## Summary
- add a new `refresh` helper to load rows
- wire `refreshBtn` button to reload table
- update HTML buttons to use `refreshBtn`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684cc8058f30832fb8f917d0ff91b946