### PR TITLE
Fix loader overlay on sinoptico page

### DIFF
--- a/sinoptico.html
+++ b/sinoptico.html
@@ -132,6 +132,10 @@
          editLink.style.display = logged ? 'inline' : 'none';
        }
      });
+      window.addEventListener('load', () => {
+        const loader = document.getElementById('loading');
+        if (loader) loader.style.display = 'none';
+      });
    </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- hide loading overlay once the sinoptico page finishes loading

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ccfac5030832fadd63fdc03f2320e