### PR TITLE
Add user message for DB access errors

### DIFF
--- a/renderer.js
+++ b/renderer.js
@@ -699,6 +699,7 @@ const root = typeof global !== 'undefined' ? global : globalThis;
           sinopticoData = await dataService.getAll();
         } catch (e) {
           console.error('Error loading data from Dexie', e);
+          mostrarMensaje('No se pudo acceder a la base de datos');
           sinopticoData = [];
         }
         if (!Array.isArray(sinopticoData) || sinopticoData.length === 0) {


### PR DESCRIPTION
## Summary
- notify users when Dexie fails to load in `loadData`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684cd264ba3c832fb30054e6112374f6