### PR TITLE
Improve loader hiding in sinoptico

### DIFF
--- a/sinoptico.html
+++ b/sinoptico.html
@@ -124,7 +124,13 @@
    <script src="smooth-nav.js" defer></script>
    <script src="file-warning.js"></script>
    <script>
+     function hideLoader() {
+       const loader = document.getElementById('loading');
+       if (loader) loader.style.display = 'none';
+     }
+
      document.addEventListener('DOMContentLoaded', () => {
+       hideLoader();
        auth.restoreSession();
        const editLink = document.getElementById('editSinLink');
        if (editLink) {
@@ -132,10 +138,8 @@
          editLink.style.display = logged ? 'inline' : 'none';
        }
      });
-      window.addEventListener('load', () => {
-        const loader = document.getElementById('loading');
-        if (loader) loader.style.display = 'none';
-      });
+     window.addEventListener('load', hideLoader);
+     setTimeout(hideLoader, 3000);
    </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- implement `hideLoader` helper in `sinoptico.html`
- call it on `DOMContentLoaded`, `load` and via `setTimeout`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684cd2636e08832fbac04d2cccb568ec