### PR TITLE
Add localStorage fallback tests

### DIFF
--- a/__tests__/dataService.test.js
+++ b/__tests__/dataService.test.js
@@ -1,12 +1,71 @@
 require('fake-indexeddb/auto');
-const Dexie = require('dexie');
+
+// Prevent js/dataService.js from loading Dexie so the fallback
+// persistence that writes to localStorage is exercised.
+jest.mock('dexie', () => {
+  throw new Error('Dexie not available');
+});
 
 let service;
+let originalDexie;
+let originalProcess;
+let originalWindow;
+let originalLocalStorage;
+
+function createStorageMock() {
+  let store = {};
+  return {
+    getItem: (k) => (k in store ? store[k] : null),
+    setItem: (k, v) => {
+      store[k] = String(v);
+    },
+    removeItem: (k) => {
+      delete store[k];
+    },
+    clear: () => {
+      store = {};
+    },
+    key: (i) => Object.keys(store)[i] || null,
+    get length() {
+      return Object.keys(store).length;
+    },
+  };
+}
 
 beforeAll(() => {
-  global.Dexie = Dexie;
-  service = require('../js/dataService.js');
+  originalDexie = global.Dexie;
+  originalProcess = global.process;
+  originalWindow = global.window;
+  originalLocalStorage = global.localStorage;
+  originalDocument = global.document;
+  originalEvent = global.Event;
+
+  // Simulate a browser environment without Dexie installed
+  global.Dexie = undefined;
+  global.process = undefined;
+  global.window = {
+    document: { dispatchEvent: () => {} },
+    localStorage: createStorageMock(),
+  };
+  global.document = global.window.document;
+  global.localStorage = global.window.localStorage;
+  global.Event = function Event(type) { this.type = type; };
+
   jest.spyOn(console, 'error').mockImplementation(() => {});
+
+  service = require('../js/dataService.js');
+
+  // Restore process after module initialization
+  global.process = originalProcess;
+});
+
+afterAll(() => {
+  global.Dexie = originalDexie;
+  global.process = originalProcess;
+  global.window = originalWindow;
+  global.localStorage = originalLocalStorage;
+  global.document = originalDocument;
+  global.Event = originalEvent;
 });
 
 beforeEach(async () => {
@@ -15,8 +74,8 @@ beforeEach(async () => {
 
 test('addNode stores node and returns id', async () => {
   const id = await service.addNode({ nombre: 'test' });
-  const all = await service.getAll();
-  const found = all.find(n => n.id === id);
+  const stored = JSON.parse(localStorage.getItem('sinopticoData'));
+  const found = stored.find((n) => n.id === id);
   expect(found).toBeDefined();
   expect(found.nombre).toBe('test');
 });
@@ -24,14 +83,14 @@ test('addNode stores node and returns id', async () => {
 test('updateNode modifies existing node', async () => {
   const id = await service.addNode({ nombre: 'initial' });
   await service.updateNode(id, { nombre: 'updated' });
-  const all = await service.getAll();
-  const found = all.find(n => n.id === id);
+  const stored = JSON.parse(localStorage.getItem('sinopticoData'));
+  const found = stored.find((n) => n.id === id);
   expect(found.nombre).toBe('updated');
 });
 
 test('deleteNode removes the node', async () => {
   const id = await service.addNode({ nombre: 'todelete' });
   await service.deleteNode(id);
-  const all = await service.getAll();
-  expect(all.find(n => n.id === id)).toBeUndefined();
+  const stored = JSON.parse(localStorage.getItem('sinopticoData'));
+  expect(stored.find((n) => n.id === id)).toBeUndefined();
 });


### PR DESCRIPTION
## Summary
- test fallback persistence when Dexie is unavailable

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684cd6273314832fa3324bfb7640dab1