### PR TITLE
Handle SheetJS loading gracefully

### DIFF
--- a/renderer.js
+++ b/renderer.js
@@ -105,9 +105,6 @@ const root = typeof global !== 'undefined' ? global : globalThis;
       if (typeof Fuse === 'undefined') {
         mostrarMensaje('Fuse.js no cargó – búsqueda deshabilitada', 'warning');
       }
-      if (typeof XLSX === 'undefined') {
-        mostrarMensaje('SheetJS no cargó – exportar a Excel deshabilitado', 'warning');
-      }
 
       function aplicarFiltro() {
         const criterioElem = document.getElementById('filtroInsumo');

--- a/sinoptico.html
+++ b/sinoptico.html
@@ -9,7 +9,7 @@
   <link rel="stylesheet" href="styles.css" />
 
   <!-- SheetJS (xlsx) para exportar a Excel -->
-  <script src="https://cdn.jsdelivr.net/npm/xlsx@0.18.5/dist/xlsx.full.min.js" onerror="this.onerror=null;this.src='lib/xlsx.full.min.js'" defer></script>
+  <script src="https://cdn.jsdelivr.net/npm/xlsx@0.18.5/dist/xlsx.full.min.js" onload="window.XLSXLoaded=true" onerror="if(!this.dataset.fallback){this.dataset.fallback='1';this.src='lib/xlsx.full.min.js';}else{const warn=()=>typeof mostrarMensaje==='function'&&mostrarMensaje('SheetJS no cargó – exportar a Excel deshabilitado','warning');if(typeof mostrarMensaje==='function'){warn();}else{window.addEventListener('DOMContentLoaded',warn);}}" defer></script>
   <!-- Fuse.js para búsqueda difusa -->
   <script src="https://cdn.jsdelivr.net/npm/fuse.js@6/dist/fuse.min.js" onerror="this.onerror=null;this.src='lib/fuse.min.js'" defer></script>
 </head>


### PR DESCRIPTION
## Summary
- attach load/error handlers to SheetJS script
- only warn if both CDN and fallback fail
- drop duplicate SheetJS check from renderer

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684cd8f18b5c832fba83f0fdf800484f