### PR TITLE
Add Dexie open failure fallback

### DIFF
--- a/__tests__/dexieFallback.test.js
+++ b/__tests__/dexieFallback.test.js
@@ -1,0 +1,90 @@
+require('fake-indexeddb/auto');
+
+jest.mock('dexie', () => {
+  return class {
+    constructor() {}
+    version() {
+      return { stores: () => {} };
+    }
+    open() {
+      return Promise.reject(new Error('open failed'));
+    }
+    delete() {
+      return Promise.resolve();
+    }
+  };
+});
+
+function createStorageMock() {
+  let store = {};
+  return {
+    getItem: k => (k in store ? store[k] : null),
+    setItem: (k, v) => {
+      store[k] = String(v);
+    },
+    removeItem: k => {
+      delete store[k];
+    },
+    clear: () => {
+      store = {};
+    },
+    key: i => Object.keys(store)[i] || null,
+    get length() {
+      return Object.keys(store).length;
+    },
+  };
+}
+
+describe('Dexie open failure fallback', () => {
+  let service;
+  let originalProcess;
+  let originalWindow;
+  let originalLocalStorage;
+  let originalDocument;
+  let originalDexie;
+  let originalEvent;
+
+  beforeEach(async () => {
+    jest.resetModules();
+    originalProcess = global.process;
+    originalWindow = global.window;
+    originalLocalStorage = global.localStorage;
+    originalDocument = global.document;
+    originalDexie = global.Dexie;
+    originalEvent = global.Event;
+
+    global.process = undefined;
+    global.window = { document: { dispatchEvent: () => {} }, localStorage: createStorageMock() };
+    global.document = global.window.document;
+    global.localStorage = global.window.localStorage;
+    global.BroadcastChannel = undefined;
+    global.Dexie = undefined;
+    global.Event = function Event(type) { this.type = type; };
+
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    service = require('../js/dataService.js');
+    await new Promise(r => setImmediate(r));
+    await service.default.reset();
+
+    global.process = originalProcess;
+  });
+
+  afterEach(() => {
+    global.window = originalWindow;
+    global.localStorage = originalLocalStorage;
+    global.document = originalDocument;
+    global.Dexie = originalDexie;
+    global.BroadcastChannel = undefined;
+    global.Event = originalEvent;
+  });
+
+  test('fallback persists data when Dexie.open rejects', async () => {
+    const id = await service.addNode({ nombre: 'fallback' });
+    const stored = JSON.parse(global.localStorage.getItem('sinopticoData'));
+    const found = stored.find(n => n.id === id);
+    expect(found).toBeDefined();
+    expect(found.nombre).toBe('fallback');
+  });
+});
+

--- a/js/dataService.js
+++ b/js/dataService.js
@@ -46,7 +46,21 @@ if (Dexie) {
         }
       });
     }
-  }).catch(() => {});
+  }).catch((err) => {
+    console.error(err);
+    db = null;
+    if (hasWindow) {
+      try {
+        const raw = localStorage.getItem(STORAGE_KEY);
+        const arr = raw ? JSON.parse(raw) : [];
+        if (Array.isArray(arr)) {
+          memory.push(...arr);
+        }
+      } catch (e) {
+        console.error('Failed to load fallback storage', e);
+      }
+    }
+  });
 } else if (hasWindow) {
   // hydrate in-memory storage from localStorage
   try {


### PR DESCRIPTION
## Summary
- handle Dexie `open()` rejection by disabling IndexedDB and restoring data from `localStorage`
- add regression test to ensure fallback persists data when `open()` fails

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684cd8eaa3c4832fa97387a9ce345834