### PR TITLE
Refactor views to use generic render()

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -1,6 +1,6 @@
-import { renderSinoptico } from './views/sinoptico.js';
-import { renderAmfe } from './views/amfe.js';
-import { renderSettings } from './views/settings.js';
+import { render as renderSinoptico } from './views/sinoptico.js';
+import { render as renderAmfe } from './views/amfe.js';
+import { render as renderSettings } from './views/settings.js';
 
 function renderNotFound(container) {
   container.textContent = 'Página no encontrada';

--- a/src/views/amfe.js
+++ b/src/views/amfe.js
@@ -1,3 +1,12 @@
-export function renderAmfe(container) {
-  container.textContent = 'Vista AMFE';
+import { getAll } from '../dataService.js';
+
+export async function render(container) {
+  container.innerHTML = `
+    <h1>AMFE</h1>
+    <pre id="amfe-list"></pre>
+  `;
+
+  const data = await getAll('amfe');
+  const pre = container.querySelector('#amfe-list');
+  pre.textContent = JSON.stringify(data, null, 2);
 }

--- a/src/views/settings.js
+++ b/src/views/settings.js
@@ -1,3 +1,10 @@
-export function renderSettings(container) {
-  container.textContent = 'Ajustes de la aplicación';
+import { getAll } from '../dataService.js';
+
+export async function render(container) {
+  container.innerHTML = '<h1>Ajustes de la aplicación</h1>';
+  // Muestra el número de elementos cargados en sinoptico
+  const data = await getAll('sinoptico');
+  const p = document.createElement('p');
+  p.textContent = `Registros en sinóptico: ${data.length}`;
+  container.appendChild(p);
 }

--- a/src/views/sinoptico.js
+++ b/src/views/sinoptico.js
@@ -1,3 +1,48 @@
-export function renderSinoptico(container) {
-  container.textContent = 'Vista sinóptico';
+import { getAll, remove, exportJSON, importJSON } from '../dataService.js';
+
+export async function render(container) {
+  container.innerHTML = `
+    <div class="toolbar">
+      <button id="sin-edit">Editar</button>
+      <button id="sin-delete">Borrar</button>
+      <button id="sin-export">Exportar</button>
+      <input id="sin-import-file" type="file" accept="application/json" hidden>
+      <button id="sin-import">Importar</button>
+    </div>
+    <div id="sinoptico"></div>
+  `;
+
+  const data = await getAll('sinoptico');
+  if (typeof window.renderSinoptico === 'function') {
+    window.renderSinoptico(data);
+  }
+
+  container.querySelector('#sin-edit').addEventListener('click', () => {
+    document.dispatchEvent(new Event('sinoptico-mode'));
+  });
+
+  container.querySelector('#sin-delete').addEventListener('click', async () => {
+    if (!confirm('¿Eliminar todos los elementos?')) return;
+    const items = await getAll('sinoptico');
+    for (const item of items) await remove('sinoptico', item.id);
+  });
+
+  container.querySelector('#sin-export').addEventListener('click', async () => {
+    const json = await exportJSON();
+    const a = document.createElement('a');
+    a.href = URL.createObjectURL(new Blob([json], { type: 'application/json' }));
+    a.download = 'sinoptico.json';
+    a.click();
+    URL.revokeObjectURL(a.href);
+  });
+
+  const fileInput = container.querySelector('#sin-import-file');
+  container.querySelector('#sin-import').addEventListener('click', () => fileInput.click());
+
+  fileInput.addEventListener('change', async ev => {
+    const file = ev.target.files[0];
+    if (!file) return;
+    const text = await file.text();
+    await importJSON(text);
+  });
 }


### PR DESCRIPTION
## Summary
- use a unified `render` export in each view
- fetch data with `getAll()` and show with `renderer.js`
- adjust router imports

## Testing
- `npm test -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_684d67f23494832fb392a8181eeeaf18