### PR TITLE
Add simple table renderers

### DIFF
--- a/public/assets/styles.css
+++ b/public/assets/styles.css
@@ -813,6 +813,10 @@ body.amfe-page:not(.dark-mode) .logo {
   animation: fadeIn 0.3s ease-in-out;
 }
 
+.fade-out {
+  animation: fadeOut 0.3s ease-in-out forwards;
+}
+
 .scale {
   animation: scaleUp 0.2s ease-in-out;
 }

--- a/src/ui/animations.js
+++ b/src/ui/animations.js
@@ -1,4 +1,29 @@
 'use strict';
+
+export function animateInsert(el) {
+  if (!el) return;
+  el.classList.add('fade-in');
+  el.addEventListener('animationend', () => el.classList.remove('fade-in'), {
+    once: true,
+  });
+}
+
+export function animateRemove(el, cb) {
+  if (!el) {
+    if (typeof cb === 'function') cb();
+    return;
+  }
+  el.classList.add('fade-out');
+  el.addEventListener(
+    'animationend',
+    () => {
+      el.classList.remove('fade-out');
+      if (typeof cb === 'function') cb();
+    },
+    { once: true },
+  );
+}
+
 // Add smooth page transitions
 window.addEventListener('DOMContentLoaded', () => {
   document.body.classList.add('page-loaded');
@@ -18,3 +43,7 @@ window.addEventListener('DOMContentLoaded', () => {
     });
   });
 });
+
+const root = typeof global !== 'undefined' ? global : globalThis;
+root.animateInsert = animateInsert;
+root.animateRemove = animateRemove;

--- a/src/ui/renderer.js
+++ b/src/ui/renderer.js
@@ -1003,4 +1003,52 @@ const root = typeof global !== 'undefined' ? global : globalThis;
         procesarDatos(sinopticoData, []);
       };
 
+      function renderSimpleTable(containerId, rows) {
+        const container = document.getElementById(containerId);
+        if (!container) return;
+        const old = container.querySelector('table');
+        if (old) {
+          if (root.animateRemove) {
+            root.animateRemove(old, () => old.remove());
+          } else {
+            old.remove();
+          }
+        } else {
+          container.textContent = '';
+        }
+
+        const table = document.createElement('table');
+        table.id = containerId;
+        const thead = document.createElement('thead');
+        const tbody = document.createElement('tbody');
+        table.appendChild(thead);
+        table.appendChild(tbody);
+        container.appendChild(table);
+
+        if (!Array.isArray(rows) || rows.length === 0) return;
+        const cols = Object.keys(rows[0]);
+        const headRow = document.createElement('tr');
+        cols.forEach(c => {
+          const th = document.createElement('th');
+          th.textContent = c;
+          headRow.appendChild(th);
+        });
+        thead.appendChild(headRow);
+
+        rows.forEach(r => {
+          const tr = document.createElement('tr');
+          cols.forEach(c => {
+            const td = document.createElement('td');
+            td.textContent = r[c] == null ? '' : r[c];
+            tr.appendChild(td);
+          });
+          tbody.appendChild(tr);
+          if (root.animateInsert) root.animateInsert(tr);
+        });
+      }
+
+      root.renderAMFE = rows => {
+        renderSimpleTable('amfe', Array.isArray(rows) ? rows : []);
+      };
+
     }); // FIN DOMContentLoaded

--- a/src/views/amfe.js
+++ b/src/views/amfe.js
@@ -3,10 +3,11 @@ import { getAll } from '../dataService.js';
 export async function render(container) {
   container.innerHTML = `
     <h1>AMFE</h1>
-    <pre id="amfe-list"></pre>
+    <div id="amfe"></div>
   `;
 
   const data = await getAll('amfe');
-  const pre = container.querySelector('#amfe-list');
-  pre.textContent = JSON.stringify(data, null, 2);
+  if (typeof window.renderAMFE === 'function') {
+    window.renderAMFE(data);
+  }
 }


### PR DESCRIPTION
## Summary
- expose `renderSinoptico` and new `renderAMFE` functions
- add helper table animations
- show AMFE data in a table
- include `fade-out` style

## Testing
- `npm test -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_684d691ef0f4832fa21d4ab368c92761