### PR TITLE
Fix message container and JS safeguard

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -75,7 +75,7 @@ h1 {
   font-size: 1.8rem;
   color: var(--color-primary);
 }
-#mensaje {
+#appMessage {
   margin: 15px auto;
   max-width: 90%;
   padding: 10px;

--- a/index.html
+++ b/index.html
@@ -12,6 +12,8 @@
     <a href="#/amfe">AMFE</a>
     <a href="#/settings">Ajustes</a>
   </nav>
+  <div id="loading"></div>
+  <div id="appMessage" role="alert" aria-live="polite"></div>
   <div id="app">Cargando…</div>
   <script src="lib/dexie.min.js" defer></script>
   <script type="module" src="js/router.js" defer></script>

--- a/js/ui/renderer.js
+++ b/js/ui/renderer.js
@@ -76,7 +76,8 @@ const root = typeof global !== 'undefined' ? global : globalThis;
          2) Funciones de alerta y filtrado
       ================================================== */
       function mostrarMensaje(texto, tipo = 'error') {
-        const div = document.getElementById('mensaje');
+        const div = document.getElementById('appMessage');
+        if (!div) return;
         const colores = {
           error: '#e74c3c',
           warning: '#f39c12',


### PR DESCRIPTION
## Summary
- add `#appMessage` container after `#loading`
- style `#appMessage`
- prevent errors in `mostrarMensaje` when the element is missing

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684d72d46104832fa4b5a50c4c9e295c