### PR TITLE
Page improvements

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -52,7 +52,8 @@ body {
   font-family: var(--font-base, sans-serif);
   margin: 0;
   padding: 60px 0 0 0;
-  background-color: var(--color-bg);
+  background-color: #fff;
+  pointer-events: auto;
   color: var(--color-text);
   opacity: 0;
   transition: opacity 0.15s ease-in-out;
@@ -722,6 +723,13 @@ body, html {
 }
 .main-nav a[aria-current="page"] {
   text-decoration: underline;
+}
+.main-nav #toggleDarkMode {
+  background: none;
+  border: none;
+  color: var(--color-light);
+  font-size: 1rem;
+  cursor: pointer;
 }
 
 header {

--- a/index.html
+++ b/index.html
@@ -7,19 +7,23 @@
   <link rel="stylesheet" href="assets/styles.css">
 </head>
 <body>
-  <nav>
+  <nav class="main-nav">
     <a href="#/sinoptico">Sinóptico</a>
     <a href="#/amfe">AMFE</a>
     <a href="#/settings">Ajustes</a>
+    <button id="toggleDarkMode" type="button">🌙</button>
   </nav>
   <div id="loading"></div>
   <div id="appMessage" role="alert" aria-live="polite"></div>
   <div id="app">Cargando…</div>
   <script src="lib/dexie.min.js" defer></script>
+  <script src="https://cdn.jsdelivr.net/npm/fuse.js@6.6.2/dist/fuse.min.js" defer></script>
   <script type="module" src="js/router.js" defer></script>
   <script type="module" src="js/dataService.js" defer></script>
   <script type="module" src="js/ui/renderer.js" defer></script>
   <script type="module" src="js/ui/animations.js" defer></script>
+  <script type="module" src="js/darkMode.js" defer></script>
+  <script type="module" src="js/hideLoading.js" defer></script>
   <script type="module" src="js/views/sinoptico.js" defer></script>
   <script type="module" src="js/views/amfe.js" defer></script>
   <script type="module" src="js/views/settings.js" defer></script>

--- a/js/darkMode.js
+++ b/js/darkMode.js
@@ -1,0 +1,12 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const btn = document.getElementById('toggleDarkMode');
+  if (!btn) return;
+  const apply = state => document.body.classList.toggle('dark-mode', state);
+  const stored = localStorage.getItem('darkMode');
+  apply(stored === 'true');
+  btn.addEventListener('click', () => {
+    const active = document.body.classList.contains('dark-mode');
+    apply(!active);
+    localStorage.setItem('darkMode', !active);
+  });
+});

--- a/js/hideLoading.js
+++ b/js/hideLoading.js
@@ -1,0 +1,4 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const loader = document.getElementById('loading');
+  if (loader) loader.style.display = 'none';
+});


### PR DESCRIPTION
## Summary
- style body with white background and enable pointer events
- load Fuse.js library
- add dark mode toggle
- hide the loading overlay on start

## Testing
- `npx eslint js/darkMode.js js/hideLoading.js` *(fails: ESLint couldn't find a config file)*
- `node -c js/darkMode.js`
- `node -c js/hideLoading.js`


------
https://chatgpt.com/codex/tasks/task_e_684d74592ed4832f8d2562ee859409ad