### PR TITLE
Add image placeholder directory and handle missing thumbnails

### DIFF
--- a/images/README.md
+++ b/images/README.md
@@ -1,0 +1,1 @@
+Placeholder directory for image assets

--- a/js/ui/renderer.js
+++ b/js/ui/renderer.js
@@ -836,6 +836,9 @@ const root = typeof global !== 'undefined' ? global : globalThis;
               img.src = `images/${nombreImg}`;
               img.alt = nombreItem;
               img.classList.add('img-product');
+              img.addEventListener('error', () => {
+                img.style.display = 'none';
+              });
               tdImagen.appendChild(img);
             }
             tdImagen.style.textAlign = 'center';


### PR DESCRIPTION
## Summary
- create `images/` directory for image assets
- hide image thumbnails if the file fails to load

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684d76daba84832facaddff673fe9107