### PR TITLE
Enable Excel export

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,6 +20,7 @@
   <script src="https://cdn.jsdelivr.net/npm/fuse.js@6.6.2/dist/fuse.min.js" defer></script>
   <script type="module" src="js/router.js" defer></script>
   <script type="module" src="js/dataService.js" defer></script>
+  <script src="https://cdn.jsdelivr.net/npm/xlsx/dist/xlsx.full.min.js" defer></script>
   <script type="module" src="js/ui/renderer.js" defer></script>
   <script type="module" src="js/ui/animations.js" defer></script>
   <script type="module" src="js/darkMode.js" defer></script>


### PR DESCRIPTION
## Summary
- load SheetJS before the renderer

## Testing
- `npm install jsdom@24.0.0 --save-dev`

------
https://chatgpt.com/codex/tasks/task_e_684d76d510e8832f8de1d10d81b935a6