### PR TITLE
Add sinoptico editor module

### DIFF
--- a/js/editors/sinopticoEditor.js
+++ b/js/editors/sinopticoEditor.js
@@ -1,0 +1,91 @@
+'use strict';
+const root = typeof global !== 'undefined' ? global : globalThis;
+
+export function createSinopticoEditor(options = {}) {
+  const {
+    getData = () => [],
+    setData = () => {},
+    generateId = () => Date.now().toString(),
+    saveSinoptico = () => {},
+    loadData = () => {},
+    dataService = null
+  } = options;
+
+  const service =
+    dataService ||
+    (typeof require === 'function'
+      ? require('../dataService.js')
+      : null);
+
+  function setEditFlag(val) {
+    if (root.sessionStorage) {
+      root.sessionStorage.setItem('sinopticoEdit', val ? 'true' : 'false');
+    }
+  }
+
+  function refresh() {
+    if (typeof loadData === 'function') {
+      loadData();
+    }
+  }
+
+  async function addNode(node) {
+    const data = Array.isArray(getData()) ? getData().slice() : [];
+    const newNode = { ID: generateId(), ...node };
+    data.push(newNode);
+    setData(data);
+    if (service && service.addNode) {
+      await service.addNode(newNode);
+    }
+    setEditFlag(true);
+    refresh();
+  }
+
+  async function updateNode(id, changes) {
+    const data = Array.isArray(getData()) ? getData().slice() : [];
+    const idStr = String(id);
+    const item = data.find(n => String(n.ID) === idStr);
+    if (item) Object.assign(item, changes);
+    setData(data);
+    if (service && service.updateNode) {
+      await service.updateNode(id, changes);
+    }
+    setEditFlag(true);
+    refresh();
+  }
+
+  async function deleteSubtree(id) {
+    const data = Array.isArray(getData()) ? getData().slice() : [];
+    const idStr = String(id);
+    const toDelete = new Set();
+    const stack = [idStr];
+    while (stack.length) {
+      const pid = stack.pop();
+      toDelete.add(pid);
+      data
+        .filter(n => String(n.ParentID) === pid)
+        .forEach(n => stack.push(String(n.ID)));
+    }
+    const newData = data.filter(n => !toDelete.has(String(n.ID)));
+    setData(newData);
+    if (service && service.deleteNode) {
+      for (const del of toDelete) {
+        await service.deleteNode(del);
+      }
+    }
+    setEditFlag(true);
+    refresh();
+  }
+
+  function save() {
+    setEditFlag(false);
+    if (typeof saveSinoptico === 'function') saveSinoptico();
+    refresh();
+  }
+
+  return { addNode, updateNode, deleteSubtree, save };
+}
+
+if (root) {
+  root.createSinopticoEditor = createSinopticoEditor;
+}

--- a/js/views/sinoptico.js
+++ b/js/views/sinoptico.js
@@ -1,4 +1,5 @@
 import { getAll, remove, exportJSON, importJSON } from '../dataService.js';
+import { createSinopticoEditor } from '../editors/sinopticoEditor.js';
 
 export async function render(container) {
   container.innerHTML = `
@@ -18,6 +19,8 @@ export async function render(container) {
   }
 
   container.querySelector('#sin-edit').addEventListener('click', () => {
+    const curr = sessionStorage.getItem('sinopticoEdit') === 'true';
+    sessionStorage.setItem('sinopticoEdit', (!curr).toString());
     document.dispatchEvent(new Event('sinoptico-mode'));
   });
 
@@ -45,4 +48,10 @@ export async function render(container) {
     const text = await file.text();
     await importJSON(text);
   });
+}
+
+// expose editor factory for renderer.js
+export { createSinopticoEditor };
+if (typeof window !== 'undefined') {
+  window.createSinopticoEditor = createSinopticoEditor;
 }


### PR DESCRIPTION
## Summary
- implement `js/editors/sinopticoEditor.js` exposing `createSinopticoEditor`
- toggle edit mode from Sinóptico view and re-export the editor factory

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684d76c72968832f9147af4b36a713ee