### PR TITLE
Add users management view

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,6 +11,7 @@
     <a href="#/sinoptico">Sinóptico</a>
     <a href="#/amfe">AMFE</a>
     <a href="#/settings">Ajustes</a>
+    <a href="#/users">Usuarios</a>
     <button id="toggleDarkMode" type="button">🌙</button>
   </nav>
   <div id="loading"></div>
@@ -28,5 +29,6 @@
   <script type="module" src="js/views/sinoptico.js" defer></script>
   <script type="module" src="js/views/amfe.js" defer></script>
   <script type="module" src="js/views/settings.js" defer></script>
+  <script type="module" src="js/views/users.js" defer></script>
 </body>
 </html>

--- a/js/dataService.js
+++ b/js/dataService.js
@@ -43,8 +43,11 @@ function hydrateFromStorage() {
 if (Dexie) {
   db = new Dexie('ProyectoBarackDB');
   db.version(1).stores({
-    // use string "id" as primary key
     sinoptico: 'id,parentId,nombre,orden',
+  });
+  db.version(2).stores({
+    sinoptico: 'id,parentId,nombre,orden',
+    users: 'id,name,role',
   });
   // migrate existing records that used numeric primary keys
   db.open().then(async () => {
@@ -239,6 +242,22 @@ export async function deleteNode(id) {
   return remove('sinoptico', id);
 }
 
+export async function getAllUsers() {
+  return getAll('users');
+}
+
+export async function addUser(user) {
+  return add('users', user);
+}
+
+export async function updateUser(id, changes) {
+  return update('users', id, changes);
+}
+
+export async function deleteUser(id) {
+  return remove('users', id);
+}
+
 export async function replaceAll(arr) {
   if (!Array.isArray(arr)) return;
   if (db) {
@@ -303,6 +322,10 @@ const api = {
   addNode,
   updateNode,
   deleteNode,
+  getAllUsers,
+  addUser,
+  updateUser,
+  deleteUser,
   replaceAll,
   add,
   update,
@@ -314,6 +337,10 @@ const api = {
       await db.delete();
       db = new Dexie('ProyectoBarackDB');
       db.version(1).stores({ sinoptico: 'id,parentId,nombre,orden' });
+      db.version(2).stores({
+        sinoptico: 'id,parentId,nombre,orden',
+        users: 'id,name,role',
+      });
     }
     for (const key of Object.keys(memory)) delete memory[key];
     _fallbackPersist();
@@ -329,4 +356,5 @@ if (hasWindow) {
 
 export default api;
 
-export { getAll, add, update, remove, exportJSON, importJSON };
+export { getAll, add, update, remove, exportJSON, importJSON,
+  getAllUsers, addUser, updateUser, deleteUser };

--- a/js/dataService.js
+++ b/js/dataService.js
@@ -356,5 +356,4 @@ if (hasWindow) {
 
 export default api;
 
-export { getAll, add, update, remove, exportJSON, importJSON,
-  getAllUsers, addUser, updateUser, deleteUser };
+export { getAll, add, update, remove, exportJSON, importJSON };

--- a/js/router.js
+++ b/js/router.js
@@ -1,6 +1,7 @@
 import { render as renderSinoptico } from './views/sinoptico.js';
 import { render as renderAmfe } from './views/amfe.js';
 import { render as renderSettings } from './views/settings.js';
+import { render as renderUsers } from './views/users.js';
 
 function renderNotFound(container) {
   container.textContent = 'Página no encontrada';
@@ -10,6 +11,7 @@ const routes = {
   '#/sinoptico': renderSinoptico,
   '#/amfe': renderAmfe,
   '#/settings': renderSettings,
+  '#/users': renderUsers,
   '#/404': renderNotFound,
 };
 

--- a/js/views/users.js
+++ b/js/views/users.js
@@ -1,0 +1,93 @@
+import { getAll, add, update, remove } from '../dataService.js';
+
+export async function render(container) {
+  container.innerHTML = `
+    <h1>Usuarios</h1>
+    <table class="users-table">
+      <thead>
+        <tr><th>Nombre</th><th>Rol</th><th>Acciones</th></tr>
+      </thead>
+      <tbody></tbody>
+    </table>
+    <button id="addUserBtn">Añadir usuario</button>
+  `;
+
+  const tbody = container.querySelector('tbody');
+
+  async function load() {
+    const users = await getAll('users');
+    tbody.innerHTML = '';
+    users.forEach(u => {
+      const tr = document.createElement('tr');
+      tr.dataset.id = u.id;
+      tr.innerHTML = `
+        <td>${u.name || ''}</td>
+        <td>${u.role || ''}</td>
+        <td>
+          <button class="edit">Editar</button>
+          <button class="delete">Eliminar</button>
+        </td>`;
+      tbody.appendChild(tr);
+    });
+  }
+
+  await load();
+
+  container.querySelector('#addUserBtn').addEventListener('click', () => {
+    showEditor();
+  });
+
+  tbody.addEventListener('click', async ev => {
+    const btn = ev.target.closest('button');
+    if (!btn) return;
+    const row = btn.closest('tr');
+    const id = row.dataset.id;
+    if (btn.classList.contains('delete')) {
+      if (confirm('¿Eliminar usuario?')) {
+        await remove('users', id);
+        await load();
+      }
+    } else if (btn.classList.contains('edit')) {
+      const users = await getAll('users');
+      const user = users.find(u => u.id === id);
+      showEditor(user, row);
+    }
+  });
+
+  function showEditor(user = {}, refRow) {
+    const tr = document.createElement('tr');
+    tr.innerHTML = `
+      <td><input type="text" value="${user.name || ''}" /></td>
+      <td>
+        <select>
+          <option value="admin"${user.role === 'admin' ? ' selected' : ''}>Admin</option>
+          <option value="user"${user.role === 'user' ? ' selected' : ''}>User</option>
+        </select>
+      </td>
+      <td>
+        <button class="save">Guardar</button>
+        <button class="cancel">Cancelar</button>
+      </td>`;
+    if (refRow) {
+      tbody.replaceChild(tr, refRow);
+    } else {
+      tbody.appendChild(tr);
+    }
+
+    const nameInput = tr.querySelector('input');
+    const roleSelect = tr.querySelector('select');
+
+    tr.querySelector('.save').addEventListener('click', async () => {
+      const data = { name: nameInput.value.trim(), role: roleSelect.value };
+      if (!data.name) return;
+      if (user.id) {
+        await update('users', user.id, data);
+      } else {
+        await add('users', data);
+      }
+      await load();
+    });
+
+    tr.querySelector('.cancel').addEventListener('click', load);
+  }
+}


### PR DESCRIPTION
## Summary
- implement `users` view rendering editable table
- support `#/users` route in router
- persist users with new store and helpers in dataService
- expose new users page in navigation

## Testing
- `node --check js/views/users.js && node --check js/router.js && node --check js/dataService.js`

------
https://chatgpt.com/codex/tasks/task_e_684d76d85578832fa098732c2e650f41