### PR TITLE
Add UI controls for Sinóptico view

### DIFF
--- a/js/views/sinoptico.js
+++ b/js/views/sinoptico.js
@@ -10,7 +10,67 @@ export async function render(container) {
       <input id="sin-import-file" type="file" accept="application/json" hidden>
       <button id="sin-import">Importar</button>
     </div>
-    <div id="sinoptico"></div>
+
+    <div class="column-toggle-container">
+      <label><input type="checkbox" class="toggle-col" data-colindex="0" checked>Item</label>
+      <label><input type="checkbox" class="toggle-col" data-colindex="1" checked>Cliente</label>
+      <label><input type="checkbox" class="toggle-col" data-colindex="2" checked>Vehículo</label>
+      <label><input type="checkbox" class="toggle-col" data-colindex="3" checked>RefInterno</label>
+      <label><input type="checkbox" class="toggle-col" data-colindex="4" checked>Versión</label>
+      <label><input type="checkbox" class="toggle-col" data-colindex="5" checked>Imagen</label>
+      <label><input type="checkbox" class="toggle-col" data-colindex="6" checked>Consumo</label>
+      <label><input type="checkbox" class="toggle-col" data-colindex="7" checked>Unidad</label>
+      <label><input type="checkbox" class="toggle-col" data-colindex="8" checked>Sourcing</label>
+      <label><input type="checkbox" class="toggle-col" data-colindex="9" checked>Código</label>
+    </div>
+
+    <div class="filtro-contenedor">
+      <div class="filtros-texto">
+        <label for="filtroInsumo">Buscar:</label>
+        <div class="search-wrap">
+          <input id="filtroInsumo" type="text" placeholder="Insumo o código">
+          <button id="clearSearch" type="button">×</button>
+          <ul id="sinopticoSuggestions" class="suggestions-list"></ul>
+        </div>
+        <div id="selectedItems" class="chips"></div>
+      </div>
+
+      <div class="filtro-opciones">
+        <label><input id="chkIncluirAncestros" type="checkbox" checked>Ancestros</label>
+        <label><input id="chkMostrarNivel0" type="checkbox" checked>Nivel 0</label>
+        <label><input id="chkMostrarNivel1" type="checkbox" checked>Nivel 1</label>
+        <label><input id="chkMostrarNivel2" type="checkbox" checked>Nivel 2</label>
+        <label><input id="chkMostrarNivel3" type="checkbox" checked>Nivel 3</label>
+      </div>
+
+      <div class="filtro-opciones">
+        <button id="expandirTodo">Expandir todo</button>
+        <button id="colapsarTodo">Colapsar todo</button>
+        <button id="btnRefrescar">Refrescar</button>
+        <button id="btnExcel">Excel</button>
+      </div>
+    </div>
+
+    <div class="tabla-contenedor">
+      <table id="sinoptico">
+        <thead>
+          <tr>
+            <th>Item</th>
+            <th>Cliente</th>
+            <th>Vehículo</th>
+            <th>RefInterno</th>
+            <th>Versión</th>
+            <th>Imagen</th>
+            <th>Consumo</th>
+            <th>Unidad</th>
+            <th>Sourcing</th>
+            <th>Código</th>
+            <th id="thActions">Acciones</th>
+          </tr>
+        </thead>
+        <tbody></tbody>
+      </table>
+    </div>
   `;
 
   const data = await getAll('sinoptico');


### PR DESCRIPTION
## Summary
- extend `sinoptico.js` markup with column visibility toggles and filter panel
- include buttons for Excel export and manual refresh
- add search and level visibility inputs

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684d7b95fa90832f9af745069193bd5a