### PR TITLE
Fix sinoptico editor load order

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,12 +23,12 @@
   <script type="module" src="js/router.js" defer></script>
   <script type="module" src="js/dataService.js" defer></script>
   <script src="https://cdn.jsdelivr.net/npm/xlsx/dist/xlsx.full.min.js" defer></script>
+  <script type="module" src="js/views/sinoptico.js" defer></script>
   <script type="module" src="js/ui/renderer.js" defer></script>
   <script type="module" src="js/ui/animations.js" defer></script>
   <script type="module" src="js/darkMode.js" defer></script>
   <script type="module" src="js/hideLoading.js" defer></script>
   <script type="module" src="js/views/home.js" defer></script>
-  <script type="module" src="js/views/sinoptico.js" defer></script>
   <script type="module" src="js/views/amfe.js" defer></script>
   <script type="module" src="js/views/settings.js" defer></script>
   <script type="module" src="js/views/users.js" defer></script>


### PR DESCRIPTION
## Summary
- ensure `views/sinoptico.js` loads before `ui/renderer.js`

## Testing
- `node --check js/ui/renderer.js`
- `node --check js/views/sinoptico.js`


------
https://chatgpt.com/codex/tasks/task_e_684d7d8c164c832fa6999231cdc79592