### PR TITLE
Rename filtro input

### DIFF
--- a/js/ui/renderer.js
+++ b/js/ui/renderer.js
@@ -108,7 +108,7 @@ const root = typeof global !== 'undefined' ? global : globalThis;
       }
 
       function aplicarFiltro() {
-        const criterioElem = document.getElementById('filtroInsumo');
+        const criterioElem = document.getElementById('search');
         const criterio = criterioElem ? criterioElem.value.trim().toLowerCase() : '';
         const incluirAncestrosElem = document.getElementById('chkIncluirAncestros');
         const incluirAncestros = incluirAncestrosElem ? incluirAncestrosElem.checked : true;
@@ -247,7 +247,7 @@ const root = typeof global !== 'undefined' ? global : globalThis;
       }
 
       // Adjuntamos eventos a campos de filtro
-      const filtroInputElem = document.getElementById('filtroInsumo');
+      const filtroInputElem = document.getElementById('search');
       if (filtroInputElem) {
         filtroInputElem.addEventListener('input', () => {
           if (fuseSinoptico) {
@@ -376,7 +376,7 @@ const root = typeof global !== 'undefined' ? global : globalThis;
       }
 
       function applyFuzzySearchSinoptico() {
-        const input = document.getElementById('filtroInsumo');
+        const input = document.getElementById('search');
         const suggestionList = document.getElementById('sinopticoSuggestions');
         if (!fuseSinoptico || !input || !suggestionList) return;
         suggestionList.innerHTML = '';

--- a/js/views/sinoptico.js
+++ b/js/views/sinoptico.js
@@ -10,6 +10,17 @@ export async function render(container) {
       <input id="sin-import-file" type="file" accept="application/json" hidden>
       <button id="sin-import">Importar</button>
     </div>
+    <div class="filtro-contenedor">
+      <div class="filtros-texto">
+        <label for="search">Buscar:</label>
+        <div class="search-wrap">
+          <input id="search" type="text" />
+          <button id="clearSearch" type="button">×</button>
+          <ul id="sinopticoSuggestions" class="suggestions-list"></ul>
+        </div>
+      </div>
+      <div id="selectedItems" class="chips"></div>
+    </div>
     <table id="sinoptico">
       <thead>
         <tr>


### PR DESCRIPTION
## Summary
- add search input to Sinóptico page
- reference new `search` id in renderer

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_684d80997e68832f962ecbbdc309969e