### PR TITLE
Add sinoptico editor page

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,6 +11,7 @@
     <a href="#/home">Inicio</a>
     <a href="#/sinoptico">Sinóptico</a>
     <a href="sinoptico.html">Ver tabla</a>
+    <a href="sinoptico-editor.html">Editar Sinóptico</a>
     <a href="#/amfe">AMFE</a>
     <a href="#/settings">Ajustes</a>
     <a href="#/users">Usuarios</a>

--- a/sinoptico-editor.html
+++ b/sinoptico-editor.html
@@ -3,13 +3,13 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Sinóptico</title>
+  <title>Editor de Sinóptico</title>
   <link rel="stylesheet" href="assets/styles.css">
 </head>
 <body>
   <nav class="main-nav">
     <a href="index.html">Inicio</a>
-    <a href="#/sinoptico">Sinóptico SPA</a>
+    <a href="sinoptico.html">Ver Sinóptico</a>
     <button id="toggleDarkMode" type="button">🌙</button>
   </nav>
   <div class="filtro-contenedor">
@@ -57,5 +57,8 @@
   <script type="module" src="js/ui/animations.js" defer></script>
   <script type="module" src="js/darkMode.js" defer></script>
   <script type="module" src="js/hideLoading.js" defer></script>
+  <script>
+    sessionStorage.setItem('sinopticoEdit', 'true');
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add link in navigation to open a new standalone editor page
- create new `sinoptico-editor.html` to allow editing the table
- trim unused scripts from `sinoptico.html`

## Testing
- `npx --yes prettier -c index.html sinoptico.html sinoptico-editor.html`
- `npx --yes htmlhint index.html sinoptico.html sinoptico-editor.html`


------
https://chatgpt.com/codex/tasks/task_e_684d84bad3ec832fadbb6412b6039fb8