### PR TITLE
Add dialog for creating clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,11 @@ Incluye un módulo llamado *Sinóptico* para gestionar jerarquías de productos.
 
 1. Abre `index.html` en tu navegador.
 2. Navega a "Sinóptico" para visualizar la tabla con filtros.
-3. Desde "Editar Sinóptico" puedes modificar los datos almacenados en el
+3. Puedes crear clientes desde cualquier vista con el botón "Nuevo cliente".
+4. Desde "Editar Sinóptico" puedes modificar los datos almacenados en el
    navegador.
 
+Hay tres puntos de entrada al Sinóptico: la página standalone `sinoptico.html`, la vista SPA accesible desde `index.html` y el `sinoptico-editor.html` para modificaciones.
 Los datos se guardan localmente mediante **Dexie/IndexedDB**.
 
 ## Desarrollo

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -1364,3 +1364,5 @@ select {
 .users-table td button:hover {
   background-color: var(--color-accent-hover);
 }
+
+dialog.modal{border:none;border-radius:8px;padding:20px;box-shadow:0 2px 8px rgba(0,0,0,0.3);}dialog.modal form{display:flex;flex-direction:column;gap:8px;}

--- a/index.html
+++ b/index.html
@@ -19,6 +19,16 @@
   <div id="loading"></div>
   <div id="appMessage" role="alert" aria-live="polite"></div>
   <div id="app">Cargando…</div>
+  <dialog id="dlgNuevoCliente" class="modal">
+    <form method="dialog">
+      <label for="nuevoClienteNombre">Nombre del cliente:</label>
+      <input id="nuevoClienteNombre" type="text" required>
+      <div class="form-actions">
+        <button type="submit">Crear</button>
+        <button type="button">Cancelar</button>
+      </div>
+    </form>
+  </dialog>
   <script src="lib/dexie.min.js" defer></script>
   <script src="lib/fuse.min.js" defer></script>
   <script type="module" src="js/router.js" defer></script>
@@ -29,6 +39,7 @@
   <script type="module" src="js/ui/animations.js" defer></script>
   <script type="module" src="js/darkMode.js" defer></script>
   <script type="module" src="js/hideLoading.js" defer></script>
+  <script type="module" src="js/newClientDialog.js" defer></script>
   <script type="module" src="js/views/home.js" defer></script>
   <script type="module" src="js/views/amfe.js" defer></script>
   <script type="module" src="js/views/settings.js" defer></script>

--- a/js/editorUI.js
+++ b/js/editorUI.js
@@ -23,26 +23,6 @@ async function deleteSubtree(id) {
   mostrarOk('Eliminado con éxito');
 }
 
-async function handleCrear() {
-  const nombre = prompt('Nombre del cliente');
-  if (!nombre) return;
-  await addNode({
-    ID: Date.now().toString(),
-    ParentID: '',
-    Tipo: 'Cliente',
-    Descripción: nombre,
-    Cliente: nombre,
-    Vehículo: '',
-    RefInterno: '',
-    versión: '',
-    Imagen: '',
-    Consumo: '',
-    Unidad: '',
-    Sourcing: '',
-    Código: ''
-  });
-  mostrarOk('Creado con éxito');
-}
 
 async function handleArbol() {
   const cliente = prompt('Nombre del cliente raíz');
@@ -116,7 +96,6 @@ async function handleArbol() {
 }
 
 function init() {
-  document.getElementById('btnCrearCliente')?.addEventListener('click', handleCrear);
   document.getElementById('btnEliminar')?.addEventListener('click', async () => {
     const id = prompt('ID a eliminar');
     if (id) await deleteSubtree(id);

--- a/js/newClientDialog.js
+++ b/js/newClientDialog.js
@@ -1,0 +1,47 @@
+'use strict';
+import { addNode } from './dataService.js';
+
+export function initNewClientDialog() {
+  const dialog = document.getElementById('dlgNuevoCliente');
+  const openBtn = document.getElementById('btnNuevoCliente');
+  if (!dialog || !openBtn) return;
+
+  openBtn.addEventListener('click', () => dialog.showModal());
+
+  const form = dialog.querySelector('form');
+  const cancelBtn = dialog.querySelector('button[type="button"]');
+  cancelBtn?.addEventListener('click', () => dialog.close());
+
+  form?.addEventListener('submit', async ev => {
+    ev.preventDefault();
+    const input = dialog.querySelector('#nuevoClienteNombre');
+    const nombre = input.value.trim();
+    if (!nombre) return;
+    await addNode({
+      ID: Date.now().toString(),
+      ParentID: '',
+      Tipo: 'Cliente',
+      Descripción: nombre,
+      Cliente: nombre,
+      Vehículo: '',
+      RefInterno: '',
+      versión: '',
+      Imagen: '',
+      Consumo: '',
+      Unidad: '',
+      Sourcing: '',
+      Código: ''
+    });
+    if (typeof window.mostrarMensaje === 'function') {
+      window.mostrarMensaje('Cliente creado con éxito', 'success');
+    }
+    input.value = '';
+    dialog.close();
+    document.dispatchEvent(new Event('sinopticoUpdated'));
+  });
+}
+
+if (typeof window !== 'undefined') {
+  window.initNewClientDialog = initNewClientDialog;
+  document.addEventListener('DOMContentLoaded', initNewClientDialog);
+}

--- a/js/views/sinoptico.js
+++ b/js/views/sinoptico.js
@@ -5,6 +5,7 @@ export async function render(container) {
   container.innerHTML = `
     <div class="toolbar">
       <button id="sin-edit">Editar</button>
+      <button id="btnNuevoCliente">Nuevo cliente</button>
       <button id="sin-delete">Borrar</button>
       <button id="sin-export">Exportar</button>
       <input id="sin-import-file" type="file" accept="application/json" hidden>
@@ -34,6 +35,11 @@ export async function render(container) {
   if (typeof window.renderSinoptico === 'function') {
     window.renderSinoptico(data);
   }
+
+  container.querySelector('#btnNuevoCliente').addEventListener('click', () => {
+    const dlg = document.getElementById('dlgNuevoCliente');
+    if (dlg && dlg.showModal) dlg.showModal();
+  });
 
   container.querySelector('#sin-edit').addEventListener('click', () => {
     const curr = sessionStorage.getItem('sinopticoEdit') === 'true';

--- a/sinoptico-editor.html
+++ b/sinoptico-editor.html
@@ -16,7 +16,7 @@
     <h1 class="editor-title">Editor de Sinóptico</h1>
   </header>
   <div class="editor-menu">
-    <button id="btnCrearCliente">Crear</button>
+    <button id="btnNuevoCliente">Nuevo cliente</button>
     <button id="btnModificar">Modificar</button>
     <button id="btnEliminar">Eliminar</button>
     <button id="btnArbol">Árbol Producto</button>
@@ -60,6 +60,16 @@
       <tbody id="sinopticoBody"></tbody>
     </table>
   </div>
+  <dialog id="dlgNuevoCliente" class="modal">
+    <form method="dialog">
+      <label for="nuevoClienteNombre">Nombre del cliente:</label>
+      <input id="nuevoClienteNombre" type="text" required>
+      <div class="form-actions">
+        <button type="submit">Crear</button>
+        <button type="button">Cancelar</button>
+      </div>
+    </form>
+  </dialog>
   <script src="lib/dexie.min.js" defer></script>
   <script src="https://cdn.jsdelivr.net/npm/xlsx/dist/xlsx.full.min.js" defer></script>
   <script type="module" src="js/dataService.js" defer></script>
@@ -69,6 +79,7 @@
   <script type="module" src="js/darkMode.js" defer></script>
   <script type="module" src="js/hideLoading.js" defer></script>
   <script type="module" src="js/editorUI.js" defer></script>
+  <script type="module" src="js/newClientDialog.js" defer></script>
   <script>
     sessionStorage.setItem('sinopticoEdit', 'true');
   </script>

--- a/sinoptico.html
+++ b/sinoptico.html
@@ -24,6 +24,7 @@
       <button id="colapsarTodo">Colapsar todo</button>
     </div>
     <div class="filtro-opciones">
+      <button id="btnNuevoCliente">Nuevo cliente</button>
       <button id="saveJSON">Guardar JSON</button>
       <input id="jsonFile" type="file" accept="application/json" hidden>
       <button id="loadJSON">Cargar JSON</button>
@@ -49,6 +50,16 @@
       <tbody id="sinopticoBody"></tbody>
     </table>
   </div>
+  <dialog id="dlgNuevoCliente" class="modal">
+    <form method="dialog">
+      <label for="nuevoClienteNombre">Nombre del cliente:</label>
+      <input id="nuevoClienteNombre" type="text" required>
+      <div class="form-actions">
+        <button type="submit">Crear</button>
+        <button type="button">Cancelar</button>
+      </div>
+    </form>
+  </dialog>
   <script src="lib/dexie.min.js" defer></script>
   <script src="lib/fuse.min.js" defer></script>
   <script src="https://cdn.jsdelivr.net/npm/xlsx/dist/xlsx.full.min.js" defer></script>
@@ -58,5 +69,6 @@
   <script type="module" src="js/ui/animations.js" defer></script>
   <script type="module" src="js/darkMode.js" defer></script>
   <script type="module" src="js/hideLoading.js" defer></script>
+  <script type="module" src="js/newClientDialog.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- introduce `newClientDialog.js` for adding clients without prompts
- show **Nuevo cliente** button in the Sinóptico view
- update `sinoptico.html`, `sinoptico-editor.html` and `index.html` with the new dialog
- style the modal dialog
- clean up editor helper and document all entry points

## Testing
- `node --check js/newClientDialog.js`
- `node --check js/views/sinoptico.js`
- `node --check js/editorUI.js`


------
https://chatgpt.com/codex/tasks/task_e_684d8d501578832fb8643a725048a720