### PR TITLE
Update home page and toolbar

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,6 @@
 <body>
   <nav class="main-nav">
     <a href="#/home">Inicio</a>
-    <a href="#/sinoptico">Sinóptico</a>
     <a href="sinoptico-editor.html">Editar Sinóptico</a>
     <a href="#/amfe">AMFE</a>
     <a href="#/settings">Ajustes</a>

--- a/js/views/home.js
+++ b/js/views/home.js
@@ -1,9 +1,10 @@
+import { exportJSON, importJSON } from '../dataService.js';
+
 export function render(container) {
   container.innerHTML = `
     <section class="hero">
       <h1>Ingeniería Barack</h1>
       <p class="tagline">Soluciones modernas para tu negocio</p>
-      <a class="btn-link" href="#/sinoptico">Ir al Sinóptico</a>
     </section>
     <section class="intro">
       <h1>Características</h1>
@@ -13,5 +14,28 @@ export function render(container) {
         <li>Modo oscuro integrado</li>
       </ul>
     </section>
+    <section class="import-export">
+      <button id="saveJSON">Guardar JSON</button>
+      <input id="jsonFile" type="file" accept="application/json" hidden>
+      <button id="loadJSON">Cargar JSON</button>
+    </section>
   `;
+
+  container.querySelector('#saveJSON').addEventListener('click', async () => {
+    const json = await exportJSON();
+    const a = document.createElement('a');
+    a.href = URL.createObjectURL(new Blob([json], { type: 'application/json' }));
+    a.download = 'sinoptico.json';
+    a.click();
+    URL.revokeObjectURL(a.href);
+  });
+
+  const fileInput = container.querySelector('#jsonFile');
+  container.querySelector('#loadJSON').addEventListener('click', () => fileInput.click());
+  fileInput.addEventListener('change', async ev => {
+    const file = ev.target.files[0];
+    if (!file) return;
+    const text = await file.text();
+    await importJSON(text);
+  });
 }

--- a/js/views/sinoptico.js
+++ b/js/views/sinoptico.js
@@ -1,4 +1,4 @@
-import { getAll, remove, exportJSON, importJSON } from '../dataService.js';
+import { getAll, remove } from '../dataService.js';
 import { createSinopticoEditor } from '../editors/sinopticoEditor.js';
 
 export async function render(container) {
@@ -7,9 +7,6 @@ export async function render(container) {
       <button id="sin-edit">Editar</button>
       <button id="btnNuevoCliente">Nuevo cliente</button>
       <button id="sin-delete">Borrar</button>
-      <button id="sin-export">Exportar</button>
-      <input id="sin-import-file" type="file" accept="application/json" hidden>
-      <button id="sin-import">Importar</button>
     </div>
     <table id="sinoptico">
       <thead>
@@ -53,24 +50,6 @@ export async function render(container) {
     for (const item of items) await remove('sinoptico', item.id);
   });
 
-  container.querySelector('#sin-export').addEventListener('click', async () => {
-    const json = await exportJSON();
-    const a = document.createElement('a');
-    a.href = URL.createObjectURL(new Blob([json], { type: 'application/json' }));
-    a.download = 'sinoptico.json';
-    a.click();
-    URL.revokeObjectURL(a.href);
-  });
-
-  const fileInput = container.querySelector('#sin-import-file');
-  container.querySelector('#sin-import').addEventListener('click', () => fileInput.click());
-
-  fileInput.addEventListener('change', async ev => {
-    const file = ev.target.files[0];
-    if (!file) return;
-    const text = await file.text();
-    await importJSON(text);
-  });
 }
 
 // expose editor factory for renderer.js


### PR DESCRIPTION
## Summary
- remove "Sinóptico" link from nav
- add JSON import/export functionality on the home view
- drop import/export buttons from the Sinóptico view

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684d90ef46b0832f8af73d4de2c5aa18