### PR TITLE
Cleanup editor page

### DIFF
--- a/sinoptico-editor.html
+++ b/sinoptico-editor.html
@@ -34,12 +34,6 @@
       <button id="expandirTodo">Expandir todo</button>
       <button id="colapsarTodo">Colapsar todo</button>
     </div>
-    <div class="filtro-opciones">
-      <button id="saveJSON">Guardar JSON</button>
-      <input id="jsonFile" type="file" accept="application/json" hidden>
-      <button id="loadJSON">Cargar JSON</button>
-      <button id="btnExcel">Exportar Excel</button>
-    </div>
   </div>
   <div class="tabla-contenedor">
     <table id="sinoptico">
@@ -71,6 +65,7 @@
     </form>
   </dialog>
   <script src="lib/dexie.min.js" defer></script>
+  <script src="lib/fuse.min.js" defer></script>
   <script src="https://cdn.jsdelivr.net/npm/xlsx/dist/xlsx.full.min.js" defer></script>
   <script type="module" src="js/dataService.js" defer></script>
   <script type="module" src="js/views/sinoptico.js" defer></script>


### PR DESCRIPTION
## Summary
- remove duplicate import/export buttons from editor
- include Fuse.js on the editor page so no warning shows

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d925a6928832fbc155a141a5eaf5c