### PR TITLE
Fix missing demo data after adding client

### DIFF
--- a/js/ui/renderer.js
+++ b/js/ui/renderer.js
@@ -232,7 +232,12 @@ document.addEventListener('DOMContentLoaded', () => {
   async function loadData() {
     showLoader();
     try { sinopticoData = await dataService.getAll(); } catch { sinopticoData = []; }
-    if(!sinopticoData.length) sinopticoData = generarDatosIniciales();
+    if (!sinopticoData.length) {
+      sinopticoData = generarDatosIniciales();
+      if (dataService && dataService.replaceAll) {
+        await dataService.replaceAll(sinopticoData);
+      }
+    }
     if (typeof Fuse !== 'undefined') {
       fuseSinoptico = new Fuse(sinopticoData, { keys: ['Descripción', 'Código'] });
     } else {


### PR DESCRIPTION
## Summary
- persist initial dataset to storage when no data is found

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684d94c38db8832fa25931a1d006ab03