### PR TITLE
Fix duplicate ready export

### DIFF
--- a/js/dataService.js
+++ b/js/dataService.js
@@ -27,7 +27,7 @@ let db = null;
 const memory = {};
 // promise that resolves once IndexedDB is ready (or failed)
 let readyResolve;
-export const ready = new Promise((res) => {
+const ready = new Promise((res) => {
   readyResolve = res;
 });
 


### PR DESCRIPTION
## Summary
- avoid exporting `ready` twice by removing the keyword from its declaration

## Testing
- `node --check js/dataService.js`
- `python3 -m http.server 8000` (manual check via `curl`)
- `node -e "import('./js/dataService.js').then(m=>console.log(Object.keys(m)));" --experimental-modules`

------
https://chatgpt.com/codex/tasks/task_e_684d9c58f7bc832f9736e08e5352bf5c