### PR TITLE
Improve product tree creation

### DIFF
--- a/js/editorUI.js
+++ b/js/editorUI.js
@@ -111,7 +111,7 @@ function init() {
       mostrarOk('Actualizado con éxito');
     }
   });
-  document.getElementById('btnArbol')?.addEventListener('click', handleArbol);
+  // replaced by newProductDialog.js for a friendlier workflow
   window.SinopticoEditor = { deleteSubtree };
 }
 

--- a/js/newProductDialog.js
+++ b/js/newProductDialog.js
@@ -1,0 +1,63 @@
+'use strict';
+import { addNode, getAll, ready } from './dataService.js';
+
+export function initNewProductDialog() {
+  const dialog = document.getElementById('dlgNuevoProducto');
+  const openBtn = document.getElementById('btnArbol');
+  if (!dialog || !openBtn) return;
+
+  const clienteSelect = dialog.querySelector('#nuevoProductoCliente');
+  const descInput = dialog.querySelector('#nuevoProductoDescripcion');
+  const codeInput = dialog.querySelector('#nuevoProductoCodigo');
+
+  openBtn.addEventListener('click', async () => {
+    await ready;
+    if (clienteSelect) {
+      const clientes = (await getAll('sinoptico')).filter(n => n.Tipo === 'Cliente');
+      clienteSelect.innerHTML = clientes
+        .map(c => `<option value="${c.ID}">${c.Descripción}</option>`)
+        .join('');
+    }
+    dialog.showModal();
+  });
+
+  const cancelBtn = dialog.querySelector('button[type="button"]');
+  cancelBtn?.addEventListener('click', () => dialog.close());
+
+  const form = dialog.querySelector('form');
+  form?.addEventListener('submit', async ev => {
+    ev.preventDefault();
+    const clienteId = clienteSelect?.value;
+    const desc = descInput?.value.trim();
+    if (!clienteId || !desc) return;
+    await ready;
+    const clientes = await getAll('sinoptico');
+    const cliente = clientes.find(c => String(c.ID) === String(clienteId));
+    await addNode({
+      ID: Date.now().toString(),
+      ParentID: clienteId,
+      Tipo: 'Producto',
+      Descripción: desc,
+      Cliente: cliente?.Descripción || '',
+      Vehículo: '',
+      RefInterno: '',
+      versión: '',
+      Imagen: '',
+      Consumo: '',
+      Unidad: '',
+      Sourcing: '',
+      Código: codeInput?.value.trim() || ''
+    });
+    if (typeof window.mostrarMensaje === 'function') {
+      window.mostrarMensaje('Producto creado con éxito', 'success');
+    }
+    if (form) form.reset();
+    dialog.close();
+    document.dispatchEvent(new Event('sinopticoUpdated'));
+  });
+}
+
+if (typeof window !== 'undefined') {
+  window.initNewProductDialog = initNewProductDialog;
+  document.addEventListener('DOMContentLoaded', initNewProductDialog);
+}

--- a/sinoptico-editor.html
+++ b/sinoptico-editor.html
@@ -19,7 +19,7 @@
     <button id="btnNuevoCliente">Nuevo cliente</button>
     <button id="btnModificar">Modificar</button>
     <button id="btnEliminar">Eliminar</button>
-    <button id="btnArbol">Árbol Producto</button>
+    <button id="btnArbol">Crear árbol producto</button>
   </div>
   <div id="loading"></div>
   <div id="appMessage" role="alert" aria-live="polite"></div>
@@ -64,6 +64,20 @@
       </div>
     </form>
   </dialog>
+  <dialog id="dlgNuevoProducto" class="modal">
+    <form method="dialog">
+      <label for="nuevoProductoCliente">Cliente:</label>
+      <select id="nuevoProductoCliente" required></select>
+      <label for="nuevoProductoDescripcion">Descripción del producto:</label>
+      <input id="nuevoProductoDescripcion" type="text" required>
+      <label for="nuevoProductoCodigo">Código:</label>
+      <input id="nuevoProductoCodigo" type="text" required>
+      <div class="form-actions">
+        <button type="submit">Crear</button>
+        <button type="button">Cancelar</button>
+      </div>
+    </form>
+  </dialog>
   <script src="lib/dexie.min.js" defer></script>
   <script src="lib/fuse.min.js" defer></script>
   <script src="https://cdn.jsdelivr.net/npm/xlsx/dist/xlsx.full.min.js" defer></script>
@@ -75,6 +89,7 @@
   <script type="module" src="js/hideLoading.js" defer></script>
   <script type="module" src="js/editorUI.js" defer></script>
   <script type="module" src="js/newClientDialog.js" defer></script>
+  <script type="module" src="js/newProductDialog.js" defer></script>
   <script>
     sessionStorage.setItem('sinopticoEdit', 'true');
   </script>


### PR DESCRIPTION
## Summary
- disable old prompt-based product tree creator
- add dialog-driven product creation workflow
- rename button to 'Crear árbol producto'

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684da12cc820832f878b2a384e96bf32