### PR TITLE
Ajustar diseño de filas en el sinóptico

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -306,14 +306,14 @@ body.dark-mode .fila-oper {
    ============================== */
 .nivel-0 td:first-child,
 tr[data-level="0"] td:first-child {
-  padding-left: 8px;
+  padding-left: 12px;
   font-weight: bold;
   border-left: none;
 }
 
 /* sangría adicional para niveles superiores */
 tr[data-level] td:first-child {
-  padding-left: calc(8px + var(--lvl, 0) * 20px);
+  padding-left: calc(12px + var(--lvl, 0) * 24px);
 }
 
 /* ==============================
@@ -345,7 +345,7 @@ tr[data-level] td:first-child {
   display: inline-block;
   width: 14px;
   height: 14px;
-  margin-right: 6px;
+  margin-left: 6px;
   font-size: 14px;
   line-height: 14px;
   text-align: center;

--- a/js/ui/renderer.js
+++ b/js/ui/renderer.js
@@ -216,11 +216,6 @@ document.addEventListener('DOMContentLoaded', () => {
       const tr=document.createElement('tr'); tr.dataset.id=fila.ID; tr.dataset.parent=fila.ParentID||''; tr.dataset.level=nivel; tr.style.setProperty('--lvl', nivel);
       const tipo=fila.Tipo.toLowerCase(); tr.classList.add(`nivel-${nivel}`);
       const td0=document.createElement('td');
-      const btn=document.createElement('button');
-      btn.classList.add('toggle-btn');
-      btn.textContent='+';
-      btn.onclick=()=>toggleNodo(btn,fila.ID);
-      td0.appendChild(btn);
       if(nivel>0){
         const arrow=document.createElement('span');
         const idx=Math.min(nivel,6);
@@ -232,6 +227,11 @@ document.addEventListener('DOMContentLoaded', () => {
       span.classList.add('item-text');
       span.textContent=fila['Descripción']||'';
       td0.appendChild(span);
+      const btn=document.createElement('button');
+      btn.classList.add('toggle-btn');
+      btn.textContent='+';
+      btn.onclick=()=>toggleNodo(btn,fila.ID);
+      td0.appendChild(btn);
       tr.appendChild(td0);
       ['Cliente','Vehículo','RefInterno','versión'].forEach(f=>{ const td=document.createElement('td'); td.textContent=fila[f]||''; tr.appendChild(td); });
       const tdImg=document.createElement('td'); if(fila.Imagen){ const img=document.createElement('img'); img.src=`images/${fila.Imagen}`;tdImg.appendChild(img);} tr.appendChild(tdImg);


### PR DESCRIPTION
## Summary
- mover el botón de expandir/contraer al lado derecho del texto
- aumentar la sangría de los productos para mayor claridad

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684da7fb9474832fad9589af87993bbe