### PR TITLE
Add version timestamp display

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # Proyecto Barack
 
-Versión actual: **329**
+Versión actual: **330**
 
 Esta es una pequeña SPA (Single Page Application) escrita en HTML, CSS y JavaScript.
 Incluye un módulo llamado *Sinóptico* para gestionar jerarquías de productos.
 
 ## Control de versiones
 
-Cada nueva versión debe incluir un número visible en la parte superior derecha de la interfaz. Se recomienda también mostrar la fecha y hora en la parte inferior izquierda para confirmar que el cambio ha sido aplicado.
+Cada nueva versión debe incluir un número visible junto a la fecha y hora en la parte inferior derecha de la interfaz para confirmar que el cambio ha sido aplicado.
 Todos los cambios en este repositorio incrementarán dicho número.
 
 ## Uso

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -1341,3 +1341,6 @@ select {
 }
 
 dialog.modal{border:none;border-radius:8px;padding:20px;box-shadow:0 2px 8px rgba(0,0,0,0.3);}dialog.modal form{display:flex;flex-direction:column;gap:8px;}
+
+.version-info { position: fixed; bottom: 4px; right: 4px; font-size: 0.8rem; opacity: 0.6; }
+

--- a/index.html
+++ b/index.html
@@ -43,5 +43,6 @@
   <script type="module" src="js/views/amfe.js" defer></script>
   <script type="module" src="js/views/settings.js" defer></script>
   <script type="module" src="js/views/users.js" defer></script>
+  <script type="module" src="js/version.js" defer></script>
 </body>
 </html>

--- a/js/version.js
+++ b/js/version.js
@@ -1,0 +1,9 @@
+export const version = '330';
+export function displayVersion() {
+  const div = document.createElement('div');
+  div.className = 'version-info';
+  const now = new Date().toLocaleString('es-ES');
+  div.textContent = `v${version} - ${now}`;
+  document.body.appendChild(div);
+}
+displayVersion();

--- a/sinoptico-editor.html
+++ b/sinoptico-editor.html
@@ -90,6 +90,7 @@
   <script type="module" src="js/editorUI.js" defer></script>
   <script type="module" src="js/newClientDialog.js" defer></script>
   <script type="module" src="js/newProductDialog.js" defer></script>
+  <script type="module" src="js/version.js" defer></script>
   <script>
     sessionStorage.setItem('sinopticoEdit', 'true');
   </script>

--- a/sinoptico.html
+++ b/sinoptico.html
@@ -70,5 +70,6 @@
   <script type="module" src="js/darkMode.js" defer></script>
   <script type="module" src="js/hideLoading.js" defer></script>
   <script type="module" src="js/newClientDialog.js" defer></script>
+  <script type="module" src="js/version.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- show version `v330` at bottom-right
- update styles and README version guidelines

## Testing
- `npm test` *(fails: ENOENT cannot find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684daa29fbf0832f878546e53d5029f3