### PR TITLE
Add subproduct support in product dialog

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Proyecto Barack
 
-Versión actual: **329**
+Versión actual: **330**
 
 Esta es una pequeña SPA (Single Page Application) escrita en HTML, CSS y JavaScript.
 Incluye un módulo llamado *Sinóptico* para gestionar jerarquías de productos.

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -1341,3 +1341,7 @@ select {
 }
 
 dialog.modal{border:none;border-radius:8px;padding:20px;box-shadow:0 2px 8px rgba(0,0,0,0.3);}dialog.modal form{display:flex;flex-direction:column;gap:8px;}
+.subproduct-item{display:flex;gap:6px;align-items:center;margin-bottom:4px;}
+.subproduct-item input{flex:1;padding:4px;}
+.subproduct-item button{background:#e74c3c;color:#fff;border:none;border-radius:4px;padding:0 6px;cursor:pointer;}
+.subproduct-item button:hover{background:#c0392b;}

--- a/js/newProductDialog.js
+++ b/js/newProductDialog.js
@@ -9,6 +9,21 @@ export function initNewProductDialog() {
   const clienteSelect = dialog.querySelector('#nuevoProductoCliente');
   const descInput = dialog.querySelector('#nuevoProductoDescripcion');
   const codeInput = dialog.querySelector('#nuevoProductoCodigo');
+  const subList = dialog.querySelector('#subproductList');
+  const addSubBtn = dialog.querySelector('#addSubproduct');
+
+  function addSubRow() {
+    if (!subList) return;
+    const div = document.createElement('div');
+    div.className = 'subproduct-item';
+    div.innerHTML = `<input type="text" class="subDesc" placeholder="Descripción"> ` +
+      `<input type="text" class="subCode" placeholder="Código"> ` +
+      `<button type="button" class="removeSub">×</button>`;
+    div.querySelector('.removeSub').onclick = () => div.remove();
+    subList.appendChild(div);
+  }
+
+  addSubBtn?.addEventListener('click', addSubRow);
 
   openBtn.addEventListener('click', async () => {
     await ready;
@@ -18,6 +33,7 @@ export function initNewProductDialog() {
         .map(c => `<option value="${c.ID}">${c.Descripción}</option>`)
         .join('');
     }
+    if (subList) subList.innerHTML = '';
     dialog.showModal();
   });
 
@@ -33,8 +49,9 @@ export function initNewProductDialog() {
     await ready;
     const clientes = await getAll('sinoptico');
     const cliente = clientes.find(c => String(c.ID) === String(clienteId));
+    const baseId = Date.now().toString();
     await addNode({
-      ID: Date.now().toString(),
+      ID: baseId,
       ParentID: clienteId,
       Tipo: 'Producto',
       Descripción: desc,
@@ -48,6 +65,29 @@ export function initNewProductDialog() {
       Sourcing: '',
       Código: codeInput?.value.trim() || ''
     });
+    if (subList) {
+      const rows = Array.from(subList.querySelectorAll('.subproduct-item'));
+      rows.forEach((row, idx) => {
+        const sDesc = row.querySelector('.subDesc')?.value.trim();
+        if (!sDesc) return;
+        const sCode = row.querySelector('.subCode')?.value.trim() || '';
+        addNode({
+          ID: `${baseId}-${idx+1}`,
+          ParentID: baseId,
+          Tipo: 'Subproducto',
+          Descripción: sDesc,
+          Cliente: cliente?.Descripción || '',
+          Vehículo: '',
+          RefInterno: '',
+          versión: '',
+          Imagen: '',
+          Consumo: '',
+          Unidad: '',
+          Sourcing: '',
+          Código: sCode
+        });
+      });
+    }
     if (typeof window.mostrarMensaje === 'function') {
       window.mostrarMensaje('Producto creado con éxito', 'success');
     }

--- a/sinoptico-editor.html
+++ b/sinoptico-editor.html
@@ -72,6 +72,11 @@
       <input id="nuevoProductoDescripcion" type="text" required>
       <label for="nuevoProductoCodigo">Código:</label>
       <input id="nuevoProductoCodigo" type="text" required>
+      <fieldset id="subproductContainer">
+        <legend>Subproductos (opcional)</legend>
+        <div id="subproductList"></div>
+        <button id="addSubproduct" type="button">Agregar subproducto</button>
+      </fieldset>
       <div class="form-actions">
         <button type="submit">Crear</button>
         <button type="button">Cancelar</button>


### PR DESCRIPTION
## Summary
- support adding subproducts when creating a new product
- style new subproduct rows
- bump version number to 330

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_684daacb60b8832fbdbf81d15f2664cc