### PR TITLE
Fix cancel behavior in new product dialog

### DIFF
--- a/js/newProductDialog.js
+++ b/js/newProductDialog.js
@@ -21,7 +21,7 @@ export function initNewProductDialog() {
     dialog.showModal();
   });
 
-  const cancelBtn = dialog.querySelector('button[type="button"]');
+  const cancelBtn = dialog.querySelector('#cancelNuevoProducto');
   cancelBtn?.addEventListener('click', () => dialog.close());
 
   const form = dialog.querySelector('form');

--- a/sinoptico-editor.html
+++ b/sinoptico-editor.html
@@ -74,7 +74,7 @@
       <input id="nuevoProductoCodigo" type="text" required>
       <div class="form-actions">
         <button type="submit">Crear</button>
-        <button type="button">Cancelar</button>
+        <button id="cancelNuevoProducto" type="button">Cancelar</button>
       </div>
     </form>
   </dialog>


### PR DESCRIPTION
## Summary
- add an id to the Cancel button in the new product dialog
- hook the dialog close handler to this button

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_684dac607354832f9db8286b371c6857