### PR TITLE
Add product tree builder page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Proyecto Barack
 
-Versión actual: **331**
+Versión actual: **332**
 
 Esta es una pequeña SPA (Single Page Application) escrita en HTML, CSS y JavaScript.
 Incluye un módulo llamado *Sinóptico* para gestionar jerarquías de productos.

--- a/arbol.html
+++ b/arbol.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Crear árbol de producto</title>
+  <link rel="stylesheet" href="assets/styles.css">
+</head>
+<body>
+  <nav class="main-nav">
+    <a href="index.html">Inicio</a>
+    <a href="sinoptico-editor.html">Editor Sinóptico</a>
+    <button id="toggleDarkMode" type="button">🌙</button>
+  </nav>
+  <div id="appMessage" role="alert" aria-live="polite"></div>
+  <div id="step1" class="node-form">
+    <h2>Nuevo Producto</h2>
+    <label for="productCliente">Cliente:</label>
+    <select id="productCliente"></select>
+    <label for="productDesc">Descripción:</label>
+    <input id="productDesc" type="text" required>
+    <label for="productCode">Código:</label>
+    <input id="productCode" type="text">
+    <div class="form-actions">
+      <button id="confirmBtn" type="button">Confirmar</button>
+      <button id="continueBtn" type="button">Continuar</button>
+    </div>
+  </div>
+  <div id="step2" class="node-form" style="display:none">
+    <h2>Agregar Subcomponentes</h2>
+    <label for="subDesc">Descripción:</label>
+    <input id="subDesc" type="text">
+    <label for="subCode">Código:</label>
+    <input id="subCode" type="text">
+    <button id="addSubBtn" type="button">Agregar</button>
+    <ul id="subList"></ul>
+    <div class="form-actions">
+      <button id="finishBtn" type="button">Finalizar</button>
+    </div>
+  </div>
+  <script src="lib/dexie.min.js" defer></script>
+  <script type="module" src="js/dataService.js" defer></script>
+  <script type="module" src="js/arbol.js" defer></script>
+  <script type="module" src="js/darkMode.js" defer></script>
+  <script type="module" src="js/version.js" defer></script>
+</body>
+</html>

--- a/js/arbol.js
+++ b/js/arbol.js
@@ -1,0 +1,114 @@
+import { getAll, addNode, ready } from './dataService.js';
+
+function getClienteNombre(clientes, id) {
+  const c = clientes.find(x => String(x.ID) === String(id));
+  return c ? c.Descripción : '';
+}
+
+document.addEventListener('DOMContentLoaded', async () => {
+  const clienteSel = document.getElementById('productCliente');
+  const descInput = document.getElementById('productDesc');
+  const codeInput = document.getElementById('productCode');
+  const continueBtn = document.getElementById('continueBtn');
+  const confirmBtn = document.getElementById('confirmBtn');
+  const step1 = document.getElementById('step1');
+  const step2 = document.getElementById('step2');
+
+  const subDesc = document.getElementById('subDesc');
+  const subCode = document.getElementById('subCode');
+  const addSubBtn = document.getElementById('addSubBtn');
+  const subList = document.getElementById('subList');
+  const finishBtn = document.getElementById('finishBtn');
+
+  await ready;
+  const all = await getAll('sinoptico');
+  const clientes = all.filter(n => n.Tipo === 'Cliente');
+  if (clienteSel) {
+    clienteSel.innerHTML = clientes
+      .map(c => `<option value="${c.ID}">${c.Descripción}</option>`)
+      .join('');
+  }
+
+  const subcomponents = [];
+  let productData = null;
+
+  function buildProduct(desc, code, clienteId) {
+    return {
+      ID: Date.now().toString(),
+      ParentID: clienteId,
+      Tipo: 'Producto',
+      Descripción: desc,
+      Cliente: getClienteNombre(clientes, clienteId),
+      Vehículo: '',
+      RefInterno: '',
+      versión: '',
+      Imagen: '',
+      Consumo: '',
+      Unidad: '',
+      Sourcing: '',
+      Código: code || ''
+    };
+  }
+
+  async function persist(product, subs) {
+    await addNode(product);
+    for (const sub of subs) {
+      await addNode({
+        ID: Date.now().toString() + Math.random().toString(16).slice(2),
+        ParentID: product.ID,
+        Tipo: 'Subcomponente',
+        Descripción: sub.desc,
+        Cliente: product.Cliente,
+        Vehículo: '',
+        RefInterno: '',
+        versión: '',
+        Imagen: '',
+        Consumo: '',
+        Unidad: '',
+        Sourcing: '',
+        Código: sub.code || ''
+      });
+    }
+  }
+
+  confirmBtn?.addEventListener('click', async () => {
+    const cid = clienteSel.value;
+    const desc = descInput.value.trim();
+    if (!cid || !desc) return;
+    const code = codeInput.value.trim();
+    const product = buildProduct(desc, code, cid);
+    await persist(product, []);
+    if (window.mostrarMensaje) window.mostrarMensaje('Producto creado con éxito', 'success');
+    window.location.href = 'sinoptico-editor.html';
+  });
+
+  continueBtn?.addEventListener('click', () => {
+    const cid = clienteSel.value;
+    const desc = descInput.value.trim();
+    if (!cid || !desc) return;
+    const code = codeInput.value.trim();
+    productData = { cid, desc, code };
+    step1.style.display = 'none';
+    step2.style.display = 'flex';
+  });
+
+  addSubBtn?.addEventListener('click', () => {
+    const d = subDesc.value.trim();
+    if (!d) return;
+    const c = subCode.value.trim();
+    subcomponents.push({ desc: d, code: c });
+    const li = document.createElement('li');
+    li.textContent = c ? `${d} (${c})` : d;
+    subList.appendChild(li);
+    subDesc.value = '';
+    subCode.value = '';
+  });
+
+  finishBtn?.addEventListener('click', async () => {
+    if (!productData) return;
+    const product = buildProduct(productData.desc, productData.code, productData.cid);
+    await persist(product, subcomponents);
+    if (window.mostrarMensaje) window.mostrarMensaje('Árbol creado con éxito', 'success');
+    window.location.href = 'sinoptico-editor.html';
+  });
+});

--- a/js/newProductDialog.js
+++ b/js/newProductDialog.js
@@ -4,7 +4,7 @@ import { addNode, getAll, ready } from './dataService.js';
 export function initNewProductDialog() {
   const dialog = document.getElementById('dlgNuevoProducto');
   const openBtn = document.getElementById('btnArbol');
-  if (!dialog || !openBtn) return;
+  if (!dialog || !openBtn || openBtn.tagName !== 'BUTTON') return;
 
   const clienteSelect = dialog.querySelector('#nuevoProductoCliente');
   const descInput = dialog.querySelector('#nuevoProductoDescripcion');

--- a/js/version.js
+++ b/js/version.js
@@ -1,4 +1,4 @@
-export const version = '331';
+export const version = '332';
 export function displayVersion() {
   const div = document.createElement('div');
   div.className = 'version-info';

--- a/sinoptico-editor.html
+++ b/sinoptico-editor.html
@@ -19,7 +19,7 @@
     <button id="btnNuevoCliente">Nuevo cliente</button>
     <button id="btnModificar">Modificar</button>
     <button id="btnEliminar">Eliminar</button>
-    <button id="btnArbol">Crear árbol producto</button>
+    <a href="arbol.html" id="btnArbol">Crear árbol producto</a>
   </div>
   <div id="loading"></div>
   <div id="appMessage" role="alert" aria-live="polite"></div>


### PR DESCRIPTION
## Summary
- add simple `arbol.html` page to build products with subcomponents
- support subcomponent workflow with new `js/arbol.js`
- update editor link to new page
- ignore the old dialog when the button is a link
- bump version to 332

## Testing
- `node -c js/arbol.js`
- `node -c js/newProductDialog.js`


------
https://chatgpt.com/codex/tasks/task_e_684db5a39ce4832fb8f8972958c61044