### PR TITLE
Fix empty tree editor page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Proyecto Barack
 
-Versión actual: **332**
+Versión actual: **333**
 
 Esta es una pequeña SPA (Single Page Application) escrita en HTML, CSS y JavaScript.
 Incluye un módulo llamado *Sinóptico* para gestionar jerarquías de productos.

--- a/arbol.html
+++ b/arbol.html
@@ -12,6 +12,7 @@
     <a href="sinoptico-editor.html">Editor Sinóptico</a>
     <button id="toggleDarkMode" type="button">🌙</button>
   </nav>
+  <div id="loading"></div>
   <div id="appMessage" role="alert" aria-live="polite"></div>
   <div id="step1" class="node-form">
     <h2>Nuevo Producto</h2>
@@ -41,7 +42,9 @@
   <script src="lib/dexie.min.js" defer></script>
   <script type="module" src="js/dataService.js" defer></script>
   <script type="module" src="js/arbol.js" defer></script>
+  <script type="module" src="js/ui/animations.js" defer></script>
   <script type="module" src="js/darkMode.js" defer></script>
+  <script type="module" src="js/hideLoading.js" defer></script>
   <script type="module" src="js/version.js" defer></script>
 </body>
 </html>

--- a/js/version.js
+++ b/js/version.js
@@ -1,4 +1,4 @@
-export const version = '332';
+export const version = '333';
 export function displayVersion() {
   const div = document.createElement('div');
   div.className = 'version-info';

--- a/sinoptico-editor.html
+++ b/sinoptico-editor.html
@@ -19,7 +19,7 @@
     <button id="btnNuevoCliente">Nuevo cliente</button>
     <button id="btnModificar">Modificar</button>
     <button id="btnEliminar">Eliminar</button>
-    <a href="arbol.html" id="btnArbol">Crear árbol producto</a>
+    <button id="btnArbol" onclick="window.location.href='arbol.html'">Crear árbol producto</button>
   </div>
   <div id="loading"></div>
   <div id="appMessage" role="alert" aria-live="polite"></div>


### PR DESCRIPTION
## Summary
- fix button style in sinoptico editor
- show loading animation and fade effect in tree editor
- bump version number to 333

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684db6de9634832f9a326da6c5e78e23