### PR TITLE
Fix phantom product dialog on tree builder button

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Proyecto Barack
 
-Versión actual: **333**
+Versión actual: **334**
 
 Esta es una pequeña SPA (Single Page Application) escrita en HTML, CSS y JavaScript.
 Incluye un módulo llamado *Sinóptico* para gestionar jerarquías de productos.

--- a/js/newProductDialog.js
+++ b/js/newProductDialog.js
@@ -4,7 +4,10 @@ import { addNode, getAll, ready } from './dataService.js';
 export function initNewProductDialog() {
   const dialog = document.getElementById('dlgNuevoProducto');
   const openBtn = document.getElementById('btnArbol');
-  if (!dialog || !openBtn || openBtn.tagName !== 'BUTTON') return;
+  if (!dialog ||
+      !openBtn ||
+      openBtn.tagName !== 'BUTTON' ||
+      openBtn.hasAttribute('onclick')) return;
 
   const clienteSelect = dialog.querySelector('#nuevoProductoCliente');
   const descInput = dialog.querySelector('#nuevoProductoDescripcion');

--- a/js/version.js
+++ b/js/version.js
@@ -1,4 +1,4 @@
-export const version = '333';
+export const version = '334';
 export function displayVersion() {
   const div = document.createElement('div');
   div.className = 'version-info';


### PR DESCRIPTION
## Summary
- stop `initNewProductDialog` from triggering when the "Crear árbol producto" button navigates
- bump version to 334

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684db7f37238832f89eded0b43cd4e6d