### PR TITLE
Improve product tree workflow

### DIFF
--- a/arbol.html
+++ b/arbol.html
@@ -23,7 +23,7 @@
     <label for="productCode">Código:</label>
     <input id="productCode" type="text">
     <div class="form-actions">
-      <button id="confirmBtn" type="button">Confirmar</button>
+      <button id="confirmBtn" type="button">Crear sin subcomponentes</button>
       <button id="continueBtn" type="button">Continuar</button>
     </div>
   </div>

--- a/js/arbol.js
+++ b/js/arbol.js
@@ -72,6 +72,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   }
 
   confirmBtn?.addEventListener('click', async () => {
+    if (!confirm('¿Seguro que no deseas agregar subcomponentes?')) return;
     const cid = clienteSel.value;
     const desc = descInput.value.trim();
     if (!cid || !desc) return;

--- a/js/version.js
+++ b/js/version.js
@@ -1,4 +1,4 @@
-export const version = '334';
+export const version = '335';
 export function displayVersion() {
   const div = document.createElement('div');
   div.className = 'version-info';


### PR DESCRIPTION
## Summary
- change product tree button to clearly indicate it creates without subcomponents
- ask for confirmation before creating product without subcomponents
- bump version to 335

## Testing
- `npm test` *(fails: no such command)*

------
https://chatgpt.com/codex/tasks/task_e_684db9f9a1f8832f9e3b67bb7539d946