### PR TITLE
Fix deletion logic and add confirmation

### DIFF
--- a/js/dataService.js
+++ b/js/dataService.js
@@ -244,7 +244,11 @@ async function importJSON(json) {
 
 
 export async function addNode(node) {
-  return add('sinoptico', node);
+  const n = { ...node };
+  if (n.ID && !n.id) {
+    n.id = String(n.ID);
+  }
+  return add('sinoptico', n);
 }
 
 export async function updateNode(id, changes) {

--- a/js/ui/renderer.js
+++ b/js/ui/renderer.js
@@ -272,7 +272,11 @@ document.addEventListener('DOMContentLoaded', () => {
         dBtn.className='action-btn delete-btn';
         dBtn.innerHTML='🗑️';
         dBtn.title='Eliminar';
-        dBtn.onclick=()=>window.SinopticoEditor.deleteSubtree(fila.ID);
+        dBtn.onclick=()=>{
+          if(!confirm('¿Eliminar este elemento?')) return;
+          if(!confirm('Esta acción es irreversible. ¿Seguro?')) return;
+          window.SinopticoEditor.deleteSubtree(fila.ID);
+        };
         tdA.appendChild(dBtn);
         tr.appendChild(tdA);
       }

--- a/js/version.js
+++ b/js/version.js
@@ -1,4 +1,4 @@
-export const version = '337';
+export const version = '338';
 export function displayVersion() {
   const div = document.createElement('div');
   div.className = 'version-info';


### PR DESCRIPTION
## Summary
- ensure added nodes use the same ID for Dexie key
- add double confirmation before deleting an item
- bump version to 338

## Testing
- `node -e "import('./js/dataService.js').then(()=>console.log('ok'))"`

------
https://chatgpt.com/codex/tasks/task_e_684dc77362f8832fbb275763cb28a435