### PR TITLE
fix edit option for clients/products

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Proyecto Barack
 
-Versión actual: **339**
+Versión actual: **340**
 
 Esta es una pequeña SPA (Single Page Application) escrita en HTML, CSS y JavaScript.
 Incluye un módulo llamado *Sinóptico* para gestionar jerarquías de productos.

--- a/js/ui/renderer.js
+++ b/js/ui/renderer.js
@@ -262,12 +262,16 @@ document.addEventListener('DOMContentLoaded', () => {
       const editing=sessionStorage.getItem('sinopticoEdit')==='true';
       if(editing){
         const tdA=document.createElement('td');
-        const eBtn=document.createElement('button');
-        eBtn.className='action-btn edit-btn';
-        eBtn.innerHTML='✏️';
-        eBtn.title='Editar';
-        eBtn.onclick=()=>startEditRow(tr,fila);
-        tdA.appendChild(eBtn);
+        const tipo=(fila.Tipo||'').toLowerCase();
+        const allowEdit=!['cliente','producto','pieza final'].includes(tipo);
+        if(allowEdit){
+          const eBtn=document.createElement('button');
+          eBtn.className='action-btn edit-btn';
+          eBtn.innerHTML='✏️';
+          eBtn.title='Editar';
+          eBtn.onclick=()=>startEditRow(tr,fila);
+          tdA.appendChild(eBtn);
+        }
         const dBtn=document.createElement('button');
         dBtn.className='action-btn delete-btn';
         dBtn.innerHTML='🗑️';

--- a/js/version.js
+++ b/js/version.js
@@ -1,4 +1,4 @@
-export const version = '339';
+export const version = '340';
 export function displayVersion() {
   const div = document.createElement('div');
   div.className = 'version-info';


### PR DESCRIPTION
## Summary
- disable inline edit for Cliente and Producto nodes
- bump version number to 340

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684dcf1f2514832fa6ee567a0512e135