### PR TITLE
Adjust sinoptico view spacing and disable edit options

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -257,7 +257,7 @@ table#sinoptico tbody tr:hover {
   background-color: #f0f0f0;
 }
 table#sinoptico tbody td {
-  padding: 10px 8px;
+  padding: 14px 8px;
   border-bottom: 1px solid #e0e0e0;
   font-size: 0.95rem;
   word-wrap: break-word;
@@ -288,6 +288,9 @@ body.dark-mode table#sinoptico tbody td {
 .fila-oper {
   background-color: #e7f5ff !important;
 } /* Azul claro (Insumo) */
+tr.fila-cliente td {
+  padding-top: 20px;
+}
 body.dark-mode .fila-cliente {
   background-color: #00284d !important;
 }
@@ -310,7 +313,7 @@ tr[data-level="0"] td:first-child {
 /* sangría adicional para niveles superiores */
 tr[data-level] td:first-child {
   /* increase indentation for nested levels */
-  padding-left: calc(16px + var(--lvl, 0) * 36px);
+  padding-left: calc(16px + var(--lvl, 0) * 48px);
 }
 
 /* ==============================
@@ -323,9 +326,9 @@ tr[data-level] td:first-child {
 .arrow-nivel-5,
 .arrow-nivel-6 {
   display: inline-block;
-  width: 20px;       /* espacio fijo un poco mayor */
+  width: 24px;       /* espacio fijo un poco mayor */
   text-align: center;
-  margin-right: 4px; /* separación más evidente */
+  margin-right: 6px; /* separación más evidente */
   font-weight: bold;
 }
 .arrow-nivel-1 { color: var(--color-primary); }

--- a/sinoptico.html
+++ b/sinoptico.html
@@ -24,10 +24,6 @@
       <button id="colapsarTodo">Colapsar todo</button>
     </div>
     <div class="filtro-opciones">
-      <button id="btnNuevoCliente">Nuevo cliente</button>
-      <button id="saveJSON">Guardar JSON</button>
-      <input id="jsonFile" type="file" accept="application/json" hidden>
-      <button id="loadJSON">Cargar JSON</button>
       <button id="btnExcel">Exportar Excel</button>
     </div>
   </div>
@@ -50,16 +46,6 @@
       <tbody id="sinopticoBody"></tbody>
     </table>
   </div>
-  <dialog id="dlgNuevoCliente" class="modal">
-    <form method="dialog">
-      <label for="nuevoClienteNombre">Nombre del cliente:</label>
-      <input id="nuevoClienteNombre" type="text" required>
-      <div class="form-actions">
-        <button type="submit">Crear</button>
-        <button type="button">Cancelar</button>
-      </div>
-    </form>
-  </dialog>
   <script src="lib/dexie.min.js" defer></script>
   <script src="lib/fuse.min.js" defer></script>
   <script src="https://cdn.jsdelivr.net/npm/xlsx/dist/xlsx.full.min.js" defer></script>
@@ -71,5 +57,8 @@
   <script type="module" src="js/hideLoading.js" defer></script>
   <script type="module" src="js/newClientDialog.js" defer></script>
   <script type="module" src="js/version.js" defer></script>
+  <script>
+    sessionStorage.setItem('sinopticoEdit', 'false');
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- increase indentation and padding in Sinóptico table to visually separate items
- remove edit buttons from the read-only `sinoptico.html`
- ensure `sinoptico.html` loads in view mode

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684dd104fcc8832fa5f0aa73d7df7b4b