### PR TITLE
Fix client filtering in editor

### DIFF
--- a/sinoptico-editor.html
+++ b/sinoptico-editor.html
@@ -39,15 +39,15 @@
         <option value="Subproducto">Subproducto</option>
         <option value="Insumo">Insumo</option>
       </select>
+      <span class="filtro-opciones">
+        <label><input type="checkbox" id="chkMostrarNivel0" checked> Nivel 0</label>
+        <label><input type="checkbox" id="chkMostrarNivel1" checked> Nivel 1</label>
+        <label><input type="checkbox" id="chkMostrarNivel2" checked> Nivel 2</label>
+        <label><input type="checkbox" id="chkMostrarNivel3" checked> Nivel 3</label>
+      </span>
       <div id="selectedItems" class="chips"></div>
       <button id="expandirTodo">Expandir todo</button>
       <button id="colapsarTodo">Colapsar todo</button>
-    </div>
-    <div class="filtro-opciones">
-      <label><input type="checkbox" id="chkMostrarNivel0" checked> Nivel 0</label>
-      <label><input type="checkbox" id="chkMostrarNivel1" checked> Nivel 1</label>
-      <label><input type="checkbox" id="chkMostrarNivel2" checked> Nivel 2</label>
-      <label><input type="checkbox" id="chkMostrarNivel3" checked> Nivel 3</label>
     </div>
   </div>
   <div class="tabla-contenedor">


### PR DESCRIPTION
## Summary
- show level checkboxes right next to type filter in editor
- keep the selected type filter when applying table filtering

## Testing
- `node -c js/ui/renderer.js`

------
https://chatgpt.com/codex/tasks/task_e_684de53cdd98832f9ae1931e6c566bf7