### PR TITLE
Fix dark mode styles, show import/export

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Proyecto Barack
 
-Versión actual: **343**
+Versión actual: **344**
 
 Esta es una pequeña SPA (Single Page Application) escrita en HTML, CSS y JavaScript.
 Incluye un módulo llamado *Sinóptico* para gestionar jerarquías de productos.

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -507,6 +507,9 @@ tr[data-level] td:first-child {
   border-radius: 4px;
   cursor: pointer;
 }
+body.dark-mode .category-section summary {
+  background-color: var(--color-surface-dark);
+}
 
 .category-section table {
   width: 100%;
@@ -524,6 +527,9 @@ tr[data-level] td:first-child {
 }
 .category-section tbody tr:nth-child(even) {
   background-color: #f7f7f7;
+}
+body.dark-mode .category-section tbody tr:nth-child(even) {
+  background-color: #1a1a1a;
 }
 .maestro-form {
   display: flex;
@@ -758,6 +764,23 @@ body.amfe-page:not(.dark-mode) .logo {
 .tagline {
   font-size: 1.2rem;
   margin-bottom: 1.5rem;
+}
+.import-export {
+  margin-top: 1rem;
+  display: flex;
+  gap: 12px;
+}
+.import-export button {
+  padding: 0.75rem 1.25rem;
+  background-color: var(--color-accent);
+  color: var(--color-light);
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 1rem;
+}
+.import-export button:hover {
+  background-color: var(--color-accent-hover);
 }
 .features {
   list-style: none;

--- a/js/version.js
+++ b/js/version.js
@@ -1,4 +1,4 @@
-export const version = '343';
+export const version = '344';
 export function displayVersion() {
   const div = document.createElement('div');
   div.className = 'version-info';

--- a/js/views/home.js
+++ b/js/views/home.js
@@ -5,6 +5,11 @@ export function render(container) {
     <section class="hero">
       <h1>Ingeniería Barack</h1>
       <p class="tagline">Soluciones modernas para tu negocio</p>
+      <div class="import-export">
+        <button id="saveJSON">Guardar JSON</button>
+        <input id="jsonFile" type="file" accept="application/json" hidden>
+        <button id="loadJSON">Cargar JSON</button>
+      </div>
     </section>
     <section class="intro">
       <h1>Características</h1>
@@ -13,11 +18,6 @@ export function render(container) {
         <li>Visualización de sinóptico interactivo</li>
         <li>Modo oscuro integrado</li>
       </ul>
-    </section>
-    <section class="import-export">
-      <button id="saveJSON">Guardar JSON</button>
-      <input id="jsonFile" type="file" accept="application/json" hidden>
-      <button id="loadJSON">Cargar JSON</button>
     </section>
   `;
 


### PR DESCRIPTION
## Summary
- tweak dark mode table styles
- style and reposition import/export buttons
- bump version to 344

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684df003b4d0832f972092c8455cf1e4