### PR TITLE
Update sinoptico layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Proyecto Barack
 
-Versión actual: **345**
+Versión actual: **346**
 
 Esta es una pequeña SPA (Single Page Application) escrita en HTML, CSS y JavaScript.
 Incluye un módulo llamado *Sinóptico* para gestionar jerarquías de productos.

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -392,22 +392,22 @@ tr[data-level] td:first-child {
 }
 #sinoptico th:nth-child(2),
 #sinoptico td:nth-child(2) {
-  width: 10%;
+  width: 15%;
   text-align: center;
 }
 #sinoptico th:nth-child(3),
 #sinoptico td:nth-child(3) {
-  width: 10%;
+  width: 15%;
   text-align: center;
 }
 #sinoptico th:nth-child(4),
 #sinoptico td:nth-child(4) {
-  width: 10%;
+  width: 8%;
   text-align: center;
 }
 #sinoptico th:nth-child(5),
 #sinoptico td:nth-child(5) {
-  width: 10%;
+  width: 7%;
   text-align: center;
 }
 #sinoptico th:nth-child(6),
@@ -417,21 +417,6 @@ tr[data-level] td:first-child {
 }
 #sinoptico th:nth-child(7),
 #sinoptico td:nth-child(7) {
-  width: 7%;
-  text-align: center;
-}
-#sinoptico th:nth-child(8),
-#sinoptico td:nth-child(8) {
-  width: 7%;
-  text-align: center;
-}
-#sinoptico th:nth-child(9),
-#sinoptico td:nth-child(9) {
-  width: 11%;
-  text-align: center;
-}
-#sinoptico th:nth-child(10),
-#sinoptico td:nth-child(10) {
   width: 10%;
   text-align: center;
 }

--- a/js/ui/renderer.js
+++ b/js/ui/renderer.js
@@ -267,7 +267,7 @@ document.addEventListener('DOMContentLoaded', () => {
       thActions.style.display=show?'':'none';
     }
     // Inline edit helper
-    const fieldOrder=['Descripción','Cliente','Vehículo','RefInterno','versión','Imagen','Consumo','Unidad','Sourcing','Código'];
+    const fieldOrder=['Descripción','Vehículo','Código','Consumo','Unidad','Imagen'];
     function startEditRow(tr,fila) {
       if(tr.classList.contains('editing'))return; 
       tr.classList.add('editing');
@@ -321,9 +321,8 @@ document.addEventListener('DOMContentLoaded', () => {
       btn.onclick=()=>toggleNodo(btn,fila.ID);
       td0.appendChild(btn);
       tr.appendChild(td0);
-      ['Cliente','Vehículo','RefInterno','versión'].forEach(f=>{ const td=document.createElement('td'); td.textContent=fila[f]||''; tr.appendChild(td); });
+      ['Vehículo','Código','Consumo','Unidad'].forEach(f=>{ const td=document.createElement('td'); td.textContent=fila[f]||''; tr.appendChild(td); });
       const tdImg=document.createElement('td'); if(fila.Imagen){ const img=document.createElement('img'); img.src=`images/${fila.Imagen}`;tdImg.appendChild(img);} tr.appendChild(tdImg);
-      ['Consumo','Unidad','Sourcing','Código'].forEach(f=>{ const td=document.createElement('td'); td.textContent=fila[f]||''; tr.appendChild(td); });
       const editing=sessionStorage.getItem('sinopticoEdit')==='true';
       if(editing){
         const tdA=document.createElement('td');

--- a/js/version.js
+++ b/js/version.js
@@ -1,4 +1,4 @@
-export const version = '345';
+export const version = '346';
 export function displayVersion() {
   const div = document.createElement('div');
   div.className = 'version-info';

--- a/js/views/sinoptico.js
+++ b/js/views/sinoptico.js
@@ -12,15 +12,11 @@ export async function render(container) {
       <thead>
         <tr>
           <th>Descripción</th>
-          <th>Cliente</th>
-          <th>Vehículo</th>
-          <th>RefInterno</th>
-          <th>versión</th>
-          <th>Imagen</th>
+          <th>Proyecto</th>
+          <th>Código</th>
           <th>Consumo</th>
           <th>Unidad</th>
-          <th>Sourcing</th>
-          <th>Código</th>
+          <th>Imagen</th>
           <th id="thActions" style="display:none">Acciones</th>
         </tr>
       </thead>

--- a/sinoptico-editor.html
+++ b/sinoptico-editor.html
@@ -55,15 +55,11 @@
       <thead>
         <tr>
           <th>Descripción</th>
-          <th>Cliente</th>
-          <th>Vehículo</th>
-          <th>RefInterno</th>
-          <th>versión</th>
-          <th>Imagen</th>
+          <th>Proyecto</th>
+          <th>Código</th>
           <th>Consumo</th>
           <th>Unidad</th>
-          <th>Sourcing</th>
-          <th>Código</th>
+          <th>Imagen</th>
         </tr>
       </thead>
       <tbody id="sinopticoBody"></tbody>

--- a/sinoptico.html
+++ b/sinoptico.html
@@ -46,15 +46,11 @@
       <thead>
         <tr>
           <th>Descripción</th>
-          <th>Cliente</th>
-          <th>Vehículo</th>
-          <th>RefInterno</th>
-          <th>versión</th>
-          <th>Imagen</th>
+          <th>Proyecto</th>
+          <th>Código</th>
           <th>Consumo</th>
           <th>Unidad</th>
-          <th>Sourcing</th>
-          <th>Código</th>
+          <th>Imagen</th>
         </tr>
       </thead>
       <tbody id="sinopticoBody"></tbody>


### PR DESCRIPTION
## Summary
- trim sinoptico table headers to essential fields
- show 'Proyecto' and keep image column
- adjust renderer and widths accordingly
- bump version to trigger UI update

## Testing
- `npm test` *(fails: package.json missing)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684e25e9f82c832fade21890c82c5b37