### PR TITLE
Implement developer settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Proyecto Barack
 
-Versión actual: **346**
+Versión actual: **347**
 
 Esta es una pequeña SPA (Single Page Application) escrita en HTML, CSS y JavaScript.
 Incluye un módulo llamado *Sinóptico* para gestionar jerarquías de productos.

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -17,6 +17,7 @@
   --primary-color: var(--color-primary);
   --secondary-color: var(--color-accent);
   --accent-color: var(--color-accent);
+  --page-brightness: 100%;
 }
 
 body.dark-mode {
@@ -59,8 +60,9 @@ body {
   background-color: #fff;
   pointer-events: auto;
   color: var(--color-text);
+  filter: brightness(var(--page-brightness, 100%));
   opacity: 0;
-  transition: opacity 0.15s ease-in-out;
+  transition: opacity 0.15s ease-in-out, filter 0.2s ease-in-out;
 }
 
 body.page-loaded {
@@ -117,6 +119,19 @@ h1 {
 .invalid {
   border: 1px solid red !important;
   background-color: #ffe5e5 !important;
+}
+
+/* Developer options in settings */
+.dev-options {
+  margin: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.dev-options label {
+  display: flex;
+  align-items: center;
+  gap: 8px;
 }
 
 /* ==============================

--- a/index.html
+++ b/index.html
@@ -38,6 +38,7 @@
   <script type="module" src="js/ui/renderer.js" defer></script>
   <script type="module" src="js/ui/animations.js" defer></script>
   <script type="module" src="js/darkMode.js" defer></script>
+  <script type="module" src="js/pageSettings.js" defer></script>
   <script type="module" src="js/hideLoading.js" defer></script>
   <script type="module" src="js/newClientDialog.js" defer></script>
   <script type="module" src="js/views/home.js" defer></script>

--- a/js/pageSettings.js
+++ b/js/pageSettings.js
@@ -1,0 +1,11 @@
+// Apply saved UI preferences like brightness and version overlay
+export function applyUserSettings() {
+  const brightness = localStorage.getItem('pageBrightness') || '100';
+  document.documentElement.style.setProperty('--page-brightness', brightness + '%');
+  const showVersion = localStorage.getItem('showVersion');
+  const show = showVersion !== 'false';
+  const overlay = document.querySelector('.version-info');
+  if (overlay) overlay.style.display = show ? 'block' : 'none';
+}
+
+document.addEventListener('DOMContentLoaded', applyUserSettings);

--- a/js/version.js
+++ b/js/version.js
@@ -1,4 +1,4 @@
-export const version = '346';
+export const version = '347';
 export function displayVersion() {
   const div = document.createElement('div');
   div.className = 'version-info';

--- a/js/views/settings.js
+++ b/js/views/settings.js
@@ -1,11 +1,52 @@
 import { getAll, ready } from '../dataService.js';
 
 export async function render(container) {
-  container.innerHTML = '<h1>Ajustes de la aplicación</h1>';
-  // Muestra el número de elementos cargados en sinoptico
+  container.innerHTML = `
+    <h1>Ajustes de la aplicación</h1>
+    <section class="dev-options">
+      <label>
+        Brillo de la página:
+        <input id="brightnessRange" type="range" min="50" max="150" step="10">
+        <span id="brightnessValue"></span>
+      </label>
+      <label>
+        <input type="checkbox" id="toggleVersionOverlay">
+        Mostrar versión en pantalla
+      </label>
+    </section>`;
+
   await ready;
   const data = await getAll('sinoptico');
   const p = document.createElement('p');
   p.textContent = `Registros en sinóptico: ${data.length}`;
   container.appendChild(p);
+
+  const range = container.querySelector('#brightnessRange');
+  const valueLabel = container.querySelector('#brightnessValue');
+  const versionChk = container.querySelector('#toggleVersionOverlay');
+
+  const storedBrightness = localStorage.getItem('pageBrightness') || '100';
+  range.value = storedBrightness;
+  valueLabel.textContent = storedBrightness + '%';
+
+  range.addEventListener('input', ev => {
+    const val = ev.target.value;
+    document.documentElement.style.setProperty('--page-brightness', val + '%');
+    valueLabel.textContent = val + '%';
+  });
+  range.addEventListener('change', ev => {
+    localStorage.setItem('pageBrightness', ev.target.value);
+  });
+
+  const overlay = document.querySelector('.version-info');
+  const showVersion = localStorage.getItem('showVersion');
+  const show = showVersion !== 'false';
+  versionChk.checked = show;
+  if (overlay) overlay.style.display = show ? 'block' : 'none';
+
+  versionChk.addEventListener('change', ev => {
+    const state = ev.target.checked;
+    if (overlay) overlay.style.display = state ? 'block' : 'none';
+    localStorage.setItem('showVersion', state);
+  });
 }


### PR DESCRIPTION
## Summary
- bump version number
- add global brightness variable and developer settings UI
- create `pageSettings.js` to apply UI choices
- integrate brightness and version toggles in settings view
- load the new script in `index.html`

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_684e2645bf0c832fb6f1818bf8c08639