### PR TITLE
Implement inline editing and deactivation filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Proyecto Barack
 
-Versión actual: **347**
+Versión actual: **348**
 
 Esta es una pequeña SPA (Single Page Application) escrita en HTML, CSS y JavaScript.
 Incluye un módulo llamado *Sinóptico* para gestionar jerarquías de productos.

--- a/database.html
+++ b/database.html
@@ -18,8 +18,6 @@
   </header>
   <div class="editor-menu">
     <div id="dbFilters">
-      <label for="dbClienteFilter">Cliente:</label>
-      <select id="dbClienteFilter"></select>
       <label for="dbTipoFilter">Mostrar:</label>
       <select id="dbTipoFilter">
         <option value="">Todos</option>
@@ -27,6 +25,7 @@
         <option value="Producto">Productos</option>
         <option value="Subproducto">Subproductos</option>
         <option value="Insumo">Insumos</option>
+        <option value="Desactivado">Desactivados</option>
       </select>
     </div>
   </div>
@@ -86,6 +85,20 @@
             <th>Material</th>
             <th>Observaciones</th>
             <th>Origen</th>
+            <th>Acciones</th>
+          </tr>
+        </thead>
+        <tbody></tbody>
+      </table>
+    </details>
+    <details class="category-section" id="desactivadosSection">
+      <summary>Desactivados</summary>
+      <table class="db-table">
+        <thead>
+          <tr>
+            <th>Tipo</th>
+            <th>Descripción</th>
+            <th>Código</th>
             <th>Acciones</th>
           </tr>
         </thead>

--- a/js/dataService.js
+++ b/js/dataService.js
@@ -254,6 +254,9 @@ export async function addNode(node) {
   if (n.id && !n.ID) {
     n.ID = String(n.id);
   }
+  if (n.Desactivado === undefined) {
+    n.Desactivado = false;
+  }
   return add('sinoptico', n);
 }
 

--- a/js/dbPage.js
+++ b/js/dbPage.js
@@ -2,96 +2,143 @@
 import { getAll, updateNode, deleteNode, ready } from './dataService.js';
 
 document.addEventListener('DOMContentLoaded', () => {
-  const clientFilter = document.getElementById('dbClienteFilter');
   const tipoFilter = document.getElementById('dbTipoFilter');
   const clientesBody = document.querySelector('#clientesSection tbody');
   const productosBody = document.querySelector('#productosSection tbody');
   const subproductosBody = document.querySelector('#subproductosSection tbody');
   const insumosBody = document.querySelector('#insumosSection tbody');
+  const desactivadosBody = document.querySelector('#desactivadosSection tbody');
+  const clientesSection = document.getElementById('clientesSection');
+  const productosSection = document.getElementById('productosSection');
+  const subproductosSection = document.getElementById('subproductosSection');
+  const insumosSection = document.getElementById('insumosSection');
+  const desactivadosSection = document.getElementById('desactivadosSection');
   const tableContainer = document.getElementById('dbTables');
 
   async function load() {
     await ready;
     const data = await getAll('sinoptico');
     const clientes = data.filter(d => d.Tipo === 'Cliente');
-    const sel = clientFilter.value || '';
-    clientFilter.innerHTML = '<option value="">Todos</option>' +
-      clientes.map(c => `<option value="${c.Descripción}">${c.Descripción}</option>`).join('');
-    clientFilter.value = sel;
 
     clientesBody.innerHTML = '';
     productosBody.innerHTML = '';
     subproductosBody.innerHTML = '';
     insumosBody.innerHTML = '';
+    desactivadosBody.innerHTML = '';
+
+    const sections = {
+      Cliente: clientesSection,
+      Producto: productosSection,
+      Subproducto: subproductosSection,
+      Insumo: insumosSection,
+      Desactivado: desactivadosSection
+    };
+    Object.values(sections).forEach(s => (s.style.display = ''));
     let items = data.slice();
-    if (clientFilter.value) {
-      items = items.filter(i => i.Cliente === clientFilter.value || i.Descripción === clientFilter.value);
-    }
-    if (tipoFilter.value) {
-      items = items.filter(i => i.Tipo === tipoFilter.value);
+    if (tipoFilter.value && tipoFilter.value !== 'Desactivado') {
+      items = items.filter(i => i.Tipo === tipoFilter.value && !i.Desactivado);
+      Object.keys(sections).forEach(k => {
+        sections[k].style.display = k === tipoFilter.value ? '' : 'none';
+      });
+    } else if (tipoFilter.value === 'Desactivado') {
+      items = items.filter(i => i.Desactivado);
+      Object.keys(sections).forEach(k => {
+        sections[k].style.display = k === 'Desactivado' ? '' : 'none';
+      });
+    } else {
+      items = items.filter(i => !i.Desactivado);
     }
 
     items.forEach(item => {
       const tr = document.createElement('tr');
+      const actBtn = item.Desactivado
+        ? `<button class="db-activate" data-id="${item.ID}">✅</button>`
+        : `<button class="db-deact" data-id="${item.ID}">🚫</button>`;
       if (item.Tipo === 'Cliente') {
-        tr.innerHTML = `<td>${item.Descripción || ''}</td>` +
-          `<td>${item.Código || ''}</td>` +
-          `<td><button class="db-edit" data-id="${item.ID}">✏️</button>` +
-          `<button class="db-del" data-id="${item.ID}">🗑️</button></td>`;
-        clientesBody.appendChild(tr);
+        tr.innerHTML =
+          `<td data-edit="Descripción" data-id="${item.ID}">${item.Descripción || ''}</td>` +
+          `<td data-edit="Código" data-id="${item.ID}">${item.Código || ''}</td>` +
+          `<td>${actBtn}<button class="db-del" data-id="${item.ID}">🗑️</button></td>`;
+        (tipoFilter.value === 'Desactivado' ? desactivadosBody : clientesBody).appendChild(tr);
       } else if (item.Tipo === 'Producto') {
         tr.innerHTML =
-          `<td>${item.Descripción || ''}</td>` +
-          `<td>${item.Código || ''}</td>` +
-          `<td>${item.Largo || ''}</td>` +
-          `<td>${item.Ancho || ''}</td>` +
-          `<td>${item.Alto || ''}</td>` +
-          `<td>${item.Peso || ''}</td>` +
-          `<td><button class="db-edit" data-id="${item.ID}">✏️</button>` +
-          `<button class="db-del" data-id="${item.ID}">🗑️</button></td>`;
-        productosBody.appendChild(tr);
+          `<td data-edit="Descripción" data-id="${item.ID}">${item.Descripción || ''}</td>` +
+          `<td data-edit="Código" data-id="${item.ID}">${item.Código || ''}</td>` +
+          `<td data-edit="Largo" data-id="${item.ID}">${item.Largo || ''}</td>` +
+          `<td data-edit="Ancho" data-id="${item.ID}">${item.Ancho || ''}</td>` +
+          `<td data-edit="Alto" data-id="${item.ID}">${item.Alto || ''}</td>` +
+          `<td data-edit="Peso" data-id="${item.ID}">${item.Peso || ''}</td>` +
+          `<td>${actBtn}<button class="db-del" data-id="${item.ID}">🗑️</button></td>`;
+        (tipoFilter.value === 'Desactivado' ? desactivadosBody : productosBody).appendChild(tr);
       } else if (item.Tipo === 'Insumo') {
         tr.innerHTML =
-          `<td>${item.Unidad || ''}</td>` +
-          `<td>${item.Proveedor || ''}</td>` +
-          `<td>${item.Descripción || ''}</td>` +
-          `<td>${item.Código || ''}</td>` +
-          `<td>${item.Material || ''}</td>` +
-          `<td>${item.Observaciones || ''}</td>` +
-          `<td>${item.Sourcing || ''}</td>` +
-          `<td><button class="db-edit" data-id="${item.ID}">✏️</button>` +
-          `<button class="db-del" data-id="${item.ID}">🗑️</button></td>`;
-        insumosBody.appendChild(tr);
+          `<td data-edit="Unidad" data-id="${item.ID}">${item.Unidad || ''}</td>` +
+          `<td data-edit="Proveedor" data-id="${item.ID}">${item.Proveedor || ''}</td>` +
+          `<td data-edit="Descripción" data-id="${item.ID}">${item.Descripción || ''}</td>` +
+          `<td data-edit="Código" data-id="${item.ID}">${item.Código || ''}</td>` +
+          `<td data-edit="Material" data-id="${item.ID}">${item.Material || ''}</td>` +
+          `<td data-edit="Observaciones" data-id="${item.ID}">${item.Observaciones || ''}</td>` +
+          `<td data-edit="Sourcing" data-id="${item.ID}">${item.Sourcing || ''}</td>` +
+          `<td>${actBtn}<button class="db-del" data-id="${item.ID}">🗑️</button></td>`;
+        (tipoFilter.value === 'Desactivado' ? desactivadosBody : insumosBody).appendChild(tr);
       } else {
         // Subproducto o cualquier otro
-        tr.innerHTML = `<td>${item.Descripción || ''}</td>` +
-          `<td>${item.Código || ''}</td>` +
-          `<td><button class="db-edit" data-id="${item.ID}">✏️</button>` +
-          `<button class="db-del" data-id="${item.ID}">🗑️</button></td>`;
-        subproductosBody.appendChild(tr);
+        tr.innerHTML =
+          `<td data-edit="Descripción" data-id="${item.ID}">${item.Descripción || ''}</td>` +
+          `<td data-edit="Código" data-id="${item.ID}">${item.Código || ''}</td>` +
+          `<td>${actBtn}<button class="db-del" data-id="${item.ID}">🗑️</button></td>`;
+        (tipoFilter.value === 'Desactivado' ? desactivadosBody : subproductosBody).appendChild(tr);
       }
     });
   }
 
-  clientFilter.addEventListener('change', load);
   tipoFilter.addEventListener('change', load);
 
   tableContainer.addEventListener('click', async ev => {
     const btn = ev.target.closest('button');
-    if (!btn) return;
-    const id = btn.dataset.id;
-    if (btn.classList.contains('db-edit')) {
-      const desc = prompt('Nueva descripción');
-      if (desc != null) {
-        await updateNode(id, { Descripción: desc });
-        await load();
+    if (btn) {
+      const id = btn.dataset.id;
+      if (btn.classList.contains('db-del')) {
+        if (confirm('¿Eliminar elemento?')) {
+          await deleteNode(id);
+          await load();
+        }
+      } else if (btn.classList.contains('db-deact')) {
+        if (confirm('¿Desactivar elemento?')) {
+          await updateNode(id, { Desactivado: true });
+          await load();
+        }
+      } else if (btn.classList.contains('db-activate')) {
+        if (confirm('¿Reactivar elemento?')) {
+          await updateNode(id, { Desactivado: false });
+          await load();
+        }
       }
-    } else if (btn.classList.contains('db-del')) {
-      if (confirm('¿Eliminar elemento?')) {
-        await deleteNode(id);
-        await load();
+      return;
+    }
+
+    const cell = ev.target.closest('td[data-edit]');
+    if (!cell) return;
+    cell.contentEditable = 'true';
+    cell.focus();
+    const original = cell.textContent;
+    function finishEdit(ev2) {
+      if (ev2.type === 'keydown' && ev2.key !== 'Enter') return;
+      ev2.preventDefault();
+      cell.removeEventListener('blur', finishEdit);
+      cell.removeEventListener('keydown', finishEdit);
+      cell.contentEditable = 'false';
+      const value = cell.textContent.trim();
+      if (value === original) return;
+      if (confirm(`¿Aplicar el nuevo valor "${value}"?`)) {
+        const field = cell.dataset.edit;
+        updateNode(cell.dataset.id, { [field]: value }).then(load);
+      } else {
+        cell.textContent = original;
       }
     }
+    cell.addEventListener('blur', finishEdit);
+    cell.addEventListener('keydown', finishEdit);
   });
 
   load();

--- a/js/version.js
+++ b/js/version.js
@@ -1,4 +1,4 @@
-export const version = '347';
+export const version = '348';
 export function displayVersion() {
   const div = document.createElement('div');
   div.className = 'version-info';


### PR DESCRIPTION
## Summary
- allow new nodes to default to `Desactivado: false`
- drop cliente filter and add option to show deactivated items
- add new "Desactivados" section and hide unused tables when filtering
- enable editing by clicking table cells with confirmation
- support deactivating/reactivating records
- bump version to 348

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684e2b912428832f93865cdb8be740ff