### PR TITLE
Add global developer settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Proyecto Barack
 
-Versión actual: **347**
+Versión actual: **348**
 
 Esta es una pequeña SPA (Single Page Application) escrita en HTML, CSS y JavaScript.
 Incluye un módulo llamado *Sinóptico* para gestionar jerarquías de productos.

--- a/arbol.html
+++ b/arbol.html
@@ -85,6 +85,7 @@
   <script type="module" src="js/arbol.js" defer></script>
   <script type="module" src="js/ui/animations.js" defer></script>
   <script type="module" src="js/darkMode.js" defer></script>
+  <script type="module" src="js/pageSettings.js" defer></script>
   <script type="module" src="js/hideLoading.js" defer></script>
   <script type="module" src="js/version.js" defer></script>
 </body>

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -1440,3 +1440,16 @@ body.dark-mode .fila-subens {
 
 .version-info { position: fixed; bottom: 4px; right: 4px; font-size: 0.8rem; opacity: 0.6; }
 
+/* Grid overlay for developer mode */
+body.grid-overlay::before {
+  content: '';
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  background-image:
+    linear-gradient(rgba(0, 0, 0, 0.15) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(0, 0, 0, 0.15) 1px, transparent 1px);
+  background-size: 20px 20px;
+  z-index: 9999;
+}
+

--- a/database.html
+++ b/database.html
@@ -98,6 +98,7 @@
   <script type="module" src="js/dbPage.js" defer></script>
   <script type="module" src="js/ui/animations.js" defer></script>
   <script type="module" src="js/darkMode.js" defer></script>
+  <script type="module" src="js/pageSettings.js" defer></script>
   <script type="module" src="js/version.js" defer></script>
 </body>
 </html>

--- a/js/pageSettings.js
+++ b/js/pageSettings.js
@@ -6,6 +6,15 @@ export function applyUserSettings() {
   const show = showVersion !== 'false';
   const overlay = document.querySelector('.version-info');
   if (overlay) overlay.style.display = show ? 'block' : 'none';
+
+  const grid = localStorage.getItem('showGrid') === 'true';
+  document.body.classList.toggle('grid-overlay', grid);
+
+  const edit = localStorage.getItem('defaultEditMode') === 'true';
+  if (edit) {
+    sessionStorage.setItem('sinopticoEdit', 'true');
+    document.dispatchEvent(new Event('sinoptico-mode'));
+  }
 }
 
 document.addEventListener('DOMContentLoaded', applyUserSettings);

--- a/js/version.js
+++ b/js/version.js
@@ -1,4 +1,4 @@
-export const version = '347';
+export const version = '348';
 export function displayVersion() {
   const div = document.createElement('div');
   div.className = 'version-info';

--- a/js/views/settings.js
+++ b/js/views/settings.js
@@ -13,6 +13,14 @@ export async function render(container) {
         <input type="checkbox" id="toggleVersionOverlay">
         Mostrar versión en pantalla
       </label>
+      <label>
+        <input type="checkbox" id="toggleGridOverlay">
+        Mostrar cuadrícula
+      </label>
+      <label>
+        <input type="checkbox" id="toggleEditMode">
+        Activar edición de Sinóptico
+      </label>
     </section>`;
 
   await ready;
@@ -24,6 +32,8 @@ export async function render(container) {
   const range = container.querySelector('#brightnessRange');
   const valueLabel = container.querySelector('#brightnessValue');
   const versionChk = container.querySelector('#toggleVersionOverlay');
+  const gridChk = container.querySelector('#toggleGridOverlay');
+  const editChk = container.querySelector('#toggleEditMode');
 
   const storedBrightness = localStorage.getItem('pageBrightness') || '100';
   range.value = storedBrightness;
@@ -48,5 +58,24 @@ export async function render(container) {
     const state = ev.target.checked;
     if (overlay) overlay.style.display = state ? 'block' : 'none';
     localStorage.setItem('showVersion', state);
+  });
+
+  const gridState = localStorage.getItem('showGrid') === 'true';
+  gridChk.checked = gridState;
+  document.body.classList.toggle('grid-overlay', gridState);
+  gridChk.addEventListener('change', ev => {
+    const val = ev.target.checked;
+    document.body.classList.toggle('grid-overlay', val);
+    localStorage.setItem('showGrid', val);
+  });
+
+  const editState = localStorage.getItem('defaultEditMode') === 'true';
+  editChk.checked = editState;
+  if (editState) sessionStorage.setItem('sinopticoEdit', 'true');
+  editChk.addEventListener('change', ev => {
+    const val = ev.target.checked;
+    sessionStorage.setItem('sinopticoEdit', val.toString());
+    localStorage.setItem('defaultEditMode', val.toString());
+    document.dispatchEvent(new Event('sinoptico-mode'));
   });
 }

--- a/sinoptico-editor.html
+++ b/sinoptico-editor.html
@@ -105,6 +105,7 @@
   <script type="module" src="js/ui/renderer.js" defer></script>
   <script type="module" src="js/ui/animations.js" defer></script>
   <script type="module" src="js/darkMode.js" defer></script>
+  <script type="module" src="js/pageSettings.js" defer></script>
   <script type="module" src="js/hideLoading.js" defer></script>
   <script type="module" src="js/editorUI.js" defer></script>
   <script type="module" src="js/newClientDialog.js" defer></script>

--- a/sinoptico.html
+++ b/sinoptico.html
@@ -64,6 +64,7 @@
   <script type="module" src="js/ui/renderer.js" defer></script>
   <script type="module" src="js/ui/animations.js" defer></script>
   <script type="module" src="js/darkMode.js" defer></script>
+  <script type="module" src="js/pageSettings.js" defer></script>
   <script type="module" src="js/hideLoading.js" defer></script>
   <script type="module" src="js/newClientDialog.js" defer></script>
   <script type="module" src="js/version.js" defer></script>


### PR DESCRIPTION
## Summary
- add grid overlay style
- add global setting toggles for grid overlay and default edit mode
- apply saved developer settings on page load
- update all HTML pages to load global settings
- bump version to 348

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684e2badf08c832fa309cc6008d91ee3