### PR TITLE
Refactor home and settings UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Proyecto Barack
 
-Versión actual: **348**
+Versión actual: **349**
 
 Esta es una pequeña SPA (Single Page Application) escrita en HTML, CSS y JavaScript.
 Incluye un módulo llamado *Sinóptico* para gestionar jerarquías de productos.

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -767,22 +767,12 @@ body.amfe-page:not(.dark-mode) .logo {
   font-size: 1.2rem;
   margin-bottom: 1.5rem;
 }
-.import-export {
+.quick-links {
   margin-top: 1rem;
   display: flex;
   gap: 12px;
-}
-.import-export button {
-  padding: 0.75rem 1.25rem;
-  background-color: var(--color-accent);
-  color: var(--color-light);
-  border: none;
-  border-radius: 4px;
-  cursor: pointer;
-  font-size: 1rem;
-}
-.import-export button:hover {
-  background-color: var(--color-accent-hover);
+  flex-wrap: wrap;
+  justify-content: center;
 }
 .features {
   list-style: none;

--- a/js/ui/renderer.js
+++ b/js/ui/renderer.js
@@ -358,12 +358,9 @@ document.addEventListener('DOMContentLoaded', () => {
     await ready;
     try { sinopticoData = await dataService.getAll(); } catch { sinopticoData = []; }
     await ready;
-    if (!sinopticoData.length) {
-      sinopticoData = generarDatosIniciales();
-      if (dataService && dataService.replaceAll) {
-        await dataService.replaceAll(sinopticoData);
-      }
-    }
+    // Si la base está vacía simplemente mostramos una tabla sin datos. Ya no
+    // generamos registros de demostración para permitir que el usuario elimine
+    // por completo los valores iniciales.
     if (typeof Fuse !== 'undefined') {
       fuseSinoptico = new Fuse(sinopticoData, { keys: ['Descripción', 'Código'] });
     } else {

--- a/js/version.js
+++ b/js/version.js
@@ -1,4 +1,4 @@
-export const version = '348';
+export const version = '349';
 export function displayVersion() {
   const div = document.createElement('div');
   div.className = 'version-info';

--- a/js/views/home.js
+++ b/js/views/home.js
@@ -1,15 +1,15 @@
-import { exportJSON, importJSON } from '../dataService.js';
+// Página de inicio con enlaces directos a las herramientas
 
 export function render(container) {
   container.innerHTML = `
     <section class="hero">
       <h1>Ingeniería Barack</h1>
       <p class="tagline">Soluciones modernas para tu negocio</p>
-      <div class="import-export">
-        <button id="saveJSON">Guardar JSON</button>
-        <input id="jsonFile" type="file" accept="application/json" hidden>
-        <button id="loadJSON">Cargar JSON</button>
-      </div>
+    <div class="quick-links">
+      <a href="sinoptico-editor.html" class="btn-link">Editar Sinóptico</a>
+      <a href="#/sinoptico" class="btn-link">Ver Sinóptico</a>
+      <a href="#/amfe" class="btn-link">AMFE</a>
+    </div>
     </section>
     <section class="intro">
       <h1>Características</h1>
@@ -21,21 +21,5 @@ export function render(container) {
     </section>
   `;
 
-  container.querySelector('#saveJSON').addEventListener('click', async () => {
-    const json = await exportJSON();
-    const a = document.createElement('a');
-    a.href = URL.createObjectURL(new Blob([json], { type: 'application/json' }));
-    a.download = 'sinoptico.json';
-    a.click();
-    URL.revokeObjectURL(a.href);
-  });
-
-  const fileInput = container.querySelector('#jsonFile');
-  container.querySelector('#loadJSON').addEventListener('click', () => fileInput.click());
-  fileInput.addEventListener('change', async ev => {
-    const file = ev.target.files[0];
-    if (!file) return;
-    const text = await file.text();
-    await importJSON(text);
-  });
+  // sin lógica adicional
 }

--- a/js/views/settings.js
+++ b/js/views/settings.js
@@ -17,10 +17,6 @@ export async function render(container) {
         <input type="checkbox" id="toggleGridOverlay">
         Mostrar cuadrícula
       </label>
-      <label>
-        <input type="checkbox" id="toggleEditMode">
-        Activar edición de Sinóptico
-      </label>
     </section>`;
 
   await ready;
@@ -33,7 +29,6 @@ export async function render(container) {
   const valueLabel = container.querySelector('#brightnessValue');
   const versionChk = container.querySelector('#toggleVersionOverlay');
   const gridChk = container.querySelector('#toggleGridOverlay');
-  const editChk = container.querySelector('#toggleEditMode');
 
   const storedBrightness = localStorage.getItem('pageBrightness') || '100';
   range.value = storedBrightness;
@@ -69,13 +64,4 @@ export async function render(container) {
     localStorage.setItem('showGrid', val);
   });
 
-  const editState = localStorage.getItem('defaultEditMode') === 'true';
-  editChk.checked = editState;
-  if (editState) sessionStorage.setItem('sinopticoEdit', 'true');
-  editChk.addEventListener('change', ev => {
-    const val = ev.target.checked;
-    sessionStorage.setItem('sinopticoEdit', val.toString());
-    localStorage.setItem('defaultEditMode', val.toString());
-    document.dispatchEvent(new Event('sinoptico-mode'));
-  });
 }


### PR DESCRIPTION
## Summary
- drop demo data regeneration in renderer so clients can be removed
- clean up home page and replace JSON buttons with navigation links
- remove edit mode toggle from settings page
- style quick links on home
- update version to 349

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_684e2e5cf110832fa7bd596bde9a35ba