### PR TITLE
Fix database edits not persisting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Proyecto Barack
 
-Versión actual: **349**
+Versión actual: **350**
 
 Esta es una pequeña SPA (Single Page Application) escrita en HTML, CSS y JavaScript.
 Incluye un módulo llamado *Sinóptico* para gestionar jerarquías de productos.


### PR DESCRIPTION
## Summary
- handle numeric IDs when updating or removing records
- bump version number to 350

## Testing
- `node - <<'NODE'
(async () => {
  const dataServiceModule = await import('./js/dataService.js');
  const dataService = dataServiceModule.default;
  await dataService.ready;
  await dataService.reset();
  const id = await dataService.addNode({Tipo:'Cliente',Descripcion:'test',ID:'1'});
  await dataService.updateNode(id, {Descripcion:'updated'});
  const all = await dataService.getAll('sinoptico');
  console.log('data', all);
  await dataService.deleteNode(id);
  console.log('after delete', await dataService.getAll('sinoptico'));
})();
NODE

------
https://chatgpt.com/codex/tasks/task_e_684e31551638832faf4aa5afbdab9f6f