### PR TITLE
Fix deactivated item view and bump version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Proyecto Barack
 
-Versión actual: **351**
+Versión actual: **352**
 
 Esta es una pequeña SPA (Single Page Application) escrita en HTML, CSS y JavaScript.
 Incluye un módulo llamado *Sinóptico* para gestionar jerarquías de productos.

--- a/js/dbPage.js
+++ b/js/dbPage.js
@@ -106,6 +106,7 @@ document.addEventListener('DOMContentLoaded', () => {
       } else if (btn.classList.contains('db-deact')) {
         if (confirm('¿Desactivar elemento?')) {
           await updateNode(id, { Desactivado: true });
+          tipoFilter.value = 'Desactivado';
           await load();
         }
       } else if (btn.classList.contains('db-activate')) {

--- a/js/version.js
+++ b/js/version.js
@@ -1,4 +1,4 @@
-export const version = '351';
+export const version = '352';
 export function displayVersion() {
   const div = document.createElement('div');
   div.className = 'version-info';


### PR DESCRIPTION
## Summary
- auto-switch filter to show deactivated items after disabling one
- bump version number to 352

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_684e3eda7140832fb6ab54a65c476df3