### PR TITLE
Fix DB export/import and document usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Proyecto Barack
 
-Versión actual: **351**
+Versión actual: **352**
 
 Esta es una pequeña SPA (Single Page Application) escrita en HTML, CSS y JavaScript.
 Incluye un módulo llamado *Sinóptico* para gestionar jerarquías de productos.
@@ -22,6 +22,18 @@ Todos los cambios en este repositorio incrementarán dicho número.
 
 Hay tres puntos de entrada al Sinóptico: la página standalone `sinoptico.html`, la vista SPA accesible desde `index.html` y el `sinoptico-editor.html` para modificaciones.
 Los datos se guardan localmente mediante **Dexie/IndexedDB**.
+
+### Exportar e importar datos
+
+Todas las vistas utilizan la misma base de datos `ProyectoBarackDB` a través del
+módulo `js/dataService.js`. Para realizar copias de seguridad manuales puedes
+ejecutar en la consola del navegador (o desde Node) lo siguiente:
+
+```js
+const json = await dataService.exportJSON();
+// Guarda el contenido de `json` donde prefieras
+await dataService.importJSON(json); // Restaura la copia
+```
 
 
 Si ya conoces estas páginas, puedes trabajar solo con `sinoptico-editor.html` y consultar los datos desde `sinoptico.html`. La SPA (`index.html`) queda como opción adicional.

--- a/js/dataService.js
+++ b/js/dataService.js
@@ -100,6 +100,7 @@ const simpleChannel =
 
 function _fallbackPersist() {
   // sync in-memory object to localStorage
+  if (!hasWindow) return;
   try {
     localStorage.setItem(STORAGE_KEY, JSON.stringify(memory));
   } catch (e) {


### PR DESCRIPTION
## Summary
- fix `_fallbackPersist` when running without `window`
- document shared DB and manual JSON export/import
- bump version to 352

## Testing
- `node - <<'EOF'
(async () => {const srv = require('./js/dataService.js').default;await srv.ready;await srv.reset();await srv.importJSON('{"sinoptico":[{"ID":"1","Tipo":"Cliente"}]}');const json = await srv.exportJSON();console.log(json);})();
EOF`

------
https://chatgpt.com/codex/tasks/task_e_684e3f1f5294832faa72161a4314d045