### PR TITLE
Add polling safeguard for local files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Proyecto Barack
 
-Versión actual: **352**
+Versión actual: **354**
 
 Esta es una pequeña SPA (Single Page Application) escrita en HTML, CSS y JavaScript.
 Incluye un módulo llamado *Sinóptico* para gestionar jerarquías de productos.
@@ -9,6 +9,12 @@ Incluye un módulo llamado *Sinóptico* para gestionar jerarquías de productos.
 
 Cada nueva versión debe incluir un número visible junto a la fecha y hora en la parte inferior derecha de la interfaz para confirmar que el cambio ha sido aplicado.
 Todos los cambios en este repositorio incrementarán dicho número.
+
+La página consulta de forma automática `js/version.js` cada cierto tiempo y se
+recarga si detecta una versión distinta.
+Esta comprobación solo está disponible si los archivos se sirven mediante un
+servidor web (por ejemplo `npx serve` o `python -m http.server`). Al abrir el
+archivo directamente (`file://`), la verificación se desactiva.
 
 ## Uso
 

--- a/js/version.js
+++ b/js/version.js
@@ -1,4 +1,5 @@
-export const version = '352';
+export const version = '354';
+export const POLLING_INTERVAL = 60000; // 1 minute
 export function displayVersion() {
   const div = document.createElement('div');
   div.className = 'version-info';
@@ -7,3 +8,20 @@ export function displayVersion() {
   document.body.appendChild(div);
 }
 displayVersion();
+
+async function pollVersion() {
+  try {
+    const response = await fetch('js/version.js', { cache: 'no-cache' });
+    const text = await response.text();
+    const match = text.match(/version\s*=\s*['"](\d+)['"]/);
+    if (match && match[1] !== version) {
+      location.reload();
+    }
+  } catch (e) {
+    console.error('Error checking version', e);
+  }
+}
+
+if (location.protocol.startsWith('http')) {
+  setInterval(pollVersion, POLLING_INTERVAL);
+}


### PR DESCRIPTION
## Summary
- increment version to **354**
- disable version polling when site is opened via `file://`
- clarify README instructions about needing a local server for auto-update

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684ed9c09190832f9463a4c5507d6fee