### PR TITLE
Add login system with guest option

### DIFF
--- a/arbol.html
+++ b/arbol.html
@@ -14,8 +14,9 @@
 <body>
   <nav class="main-nav">
     <a href="index.html">Inicio</a>
-    <a href="sinoptico-editor.html">Editor Sinóptico</a>
+    <a href="sinoptico-editor.html" class="no-guest">Editor Sinóptico</a>
     <button id="toggleDarkMode" type="button">🌙</button>
+    <button type="button" class="logout-link">Salir</button>
   </nav>
   <div id="loading"></div>
   <div id="appMessage" role="alert" aria-live="polite"></div>
@@ -86,6 +87,7 @@
     </div>
   </div>
   <script src="lib/dexie.min.js" defer></script>
+  <script type="module" src="js/authGuard.js"></script>
   <script type="module" src="js/dataService.js" defer></script>
   <script type="module" src="js/arbol.js" defer></script>
   <script type="module" src="js/ui/animations.js" defer></script>

--- a/database.html
+++ b/database.html
@@ -15,8 +15,9 @@
   <nav class="main-nav">
     <a href="index.html">Inicio</a>
     <a href="sinoptico.html">Sinóptico</a>
-    <a href="sinoptico-editor.html">Editor</a>
+    <a href="sinoptico-editor.html" class="no-guest">Editor</a>
     <button id="toggleDarkMode" type="button">🌙</button>
+    <button type="button" class="logout-link">Salir</button>
   </nav>
   <header class="editor-header">
     <h1 class="editor-title">Base de Datos</h1>
@@ -112,6 +113,7 @@
     </details>
   </div>
   <script src="lib/dexie.min.js" defer></script>
+  <script type="module" src="js/authGuard.js"></script>
   <script type="module" src="js/dataService.js" defer></script>
   <script type="module" src="js/dbPage.js" defer></script>
   <script type="module" src="js/ui/animations.js" defer></script>

--- a/index.html
+++ b/index.html
@@ -14,12 +14,13 @@
 <body>
   <nav class="main-nav">
     <a href="#/home">Inicio</a>
-    <a href="sinoptico-editor.html">Editar Sinóptico</a>
-    <a href="database.html">Base de Datos</a>
+    <a href="sinoptico-editor.html" class="no-guest">Editar Sinóptico</a>
+    <a href="database.html" class="no-guest">Base de Datos</a>
     <a href="#/amfe">AMFE</a>
-    <a href="#/settings">Ajustes</a>
-    <a href="#/users">Usuarios</a>
+    <a href="#/settings" class="no-guest">Ajustes</a>
+    <a href="#/users" class="admin-only">Usuarios</a>
     <button id="toggleDarkMode" type="button">🌙</button>
+    <button type="button" class="logout-link">Salir</button>
   </nav>
   <div id="loading"></div>
   <div id="appMessage" role="alert" aria-live="polite"></div>
@@ -36,6 +37,7 @@
   </dialog>
   <script src="lib/dexie.min.js" defer></script>
   <script src="lib/fuse.min.js" defer></script>
+  <script type="module" src="js/authGuard.js"></script>
   <script type="module" src="js/router.js" defer></script>
   <script type="module" src="js/dataService.js" defer></script>
   <script src="https://cdn.jsdelivr.net/npm/xlsx/dist/xlsx.full.min.js" defer></script>

--- a/js/authGuard.js
+++ b/js/authGuard.js
@@ -1,0 +1,27 @@
+import { getUser, logout, isAdmin, isGuest } from './session.js';
+
+const user = getUser();
+if (!user) {
+  location.href = 'login.html';
+}
+
+function applyRoleRules() {
+  if (isGuest()) {
+    document.querySelectorAll('.no-guest').forEach(el => el.style.display = 'none');
+  }
+  if (!isAdmin()) {
+    document.querySelectorAll('.admin-only').forEach(el => el.style.display = 'none');
+  }
+  document.querySelectorAll('.logout-link').forEach(btn => {
+    btn.addEventListener('click', () => {
+      logout();
+      location.href = 'login.html';
+    });
+  });
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', applyRoleRules);
+} else {
+  applyRoleRules();
+}

--- a/js/dataService.js
+++ b/js/dataService.js
@@ -54,6 +54,10 @@ if (Dexie) {
     sinoptico: 'id,parentId,nombre,orden',
     users: 'id,name,role',
   });
+  db.version(3).stores({
+    sinoptico: 'id,parentId,nombre,orden',
+    users: 'id,name,role,password',
+  });
   // migrate existing records that used numeric primary keys
   db.open()
     .then(async () => {
@@ -297,6 +301,11 @@ export async function deleteUser(id) {
   return remove('users', id);
 }
 
+export async function validateCredentials(name, password) {
+  const users = await getAll('users');
+  return users.find(u => u.name === name && u.password === password);
+}
+
 export async function replaceAll(arr) {
   if (!Array.isArray(arr)) return;
   const normalized = arr.map(item => {
@@ -388,6 +397,10 @@ const api = {
         sinoptico: 'id,parentId,nombre,orden',
         users: 'id,name,role',
       });
+      db.version(3).stores({
+        sinoptico: 'id,parentId,nombre,orden',
+        users: 'id,name,role,password',
+      });
     }
     for (const key of Object.keys(memory)) delete memory[key];
     _fallbackPersist();
@@ -403,4 +416,4 @@ if (hasWindow) {
 
 export default api;
 
-export { getAll, add, update, remove, exportJSON, importJSON, ready };
+export { getAll, add, update, remove, exportJSON, importJSON, ready, validateCredentials };

--- a/js/login.js
+++ b/js/login.js
@@ -1,0 +1,29 @@
+import { ready, validateCredentials } from './dataService.js';
+import { saveUser, getUser } from './session.js';
+
+const current = getUser();
+if (current) {
+  location.href = 'index.html';
+}
+
+const form = document.getElementById('loginForm');
+const guestBtn = document.getElementById('guestBtn');
+
+form.addEventListener('submit', async ev => {
+  ev.preventDefault();
+  const name = document.getElementById('loginUser').value.trim();
+  const pass = document.getElementById('loginPass').value;
+  await ready;
+  const user = await validateCredentials(name, pass);
+  if (user) {
+    saveUser(user);
+    location.href = 'index.html';
+  } else {
+    alert('Credenciales inválidas');
+  }
+});
+
+guestBtn.addEventListener('click', () => {
+  saveUser({ name: 'Invitado', role: 'guest' });
+  location.href = 'index.html';
+});

--- a/js/session.js
+++ b/js/session.js
@@ -1,0 +1,25 @@
+export function saveUser(user) {
+  sessionStorage.setItem('currentUser', JSON.stringify(user));
+}
+
+export function getUser() {
+  try {
+    return JSON.parse(sessionStorage.getItem('currentUser') || 'null');
+  } catch {
+    return null;
+  }
+}
+
+export function logout() {
+  sessionStorage.removeItem('currentUser');
+}
+
+export function isAdmin() {
+  const u = getUser();
+  return u && u.role === 'admin';
+}
+
+export function isGuest() {
+  const u = getUser();
+  return !u || u.role === 'guest';
+}

--- a/js/version.js
+++ b/js/version.js
@@ -1,4 +1,4 @@
-export const version = '354';
+export const version = '355';
 export const POLLING_INTERVAL = 60000;
 export function displayVersion() {
   const div = document.createElement('div');

--- a/js/views/home.js
+++ b/js/views/home.js
@@ -6,7 +6,7 @@ export function render(container) {
       <h1>Ingeniería Barack</h1>
       <p class="tagline">Soluciones modernas para tu negocio</p>
     <div class="quick-links">
-      <a href="sinoptico-editor.html" class="btn-link">Editar Sinóptico</a>
+      <a href="sinoptico-editor.html" class="btn-link no-guest">Editar Sinóptico</a>
       <a href="#/sinoptico" class="btn-link">Ver Sinóptico</a>
       <a href="#/amfe" class="btn-link">AMFE</a>
     </div>

--- a/js/views/sinoptico.js
+++ b/js/views/sinoptico.js
@@ -1,5 +1,6 @@
 import { getAll, remove } from '../dataService.js';
 import { createSinopticoEditor } from '../editors/sinopticoEditor.js';
+import { isGuest } from '../session.js';
 
 export async function render(container) {
   container.innerHTML = `
@@ -23,6 +24,9 @@ export async function render(container) {
       <tbody></tbody>
     </table>
   `;
+  if (isGuest()) {
+    container.querySelector('.toolbar').style.display = 'none';
+  }
 
   const data = await getAll('sinoptico');
   if (typeof window.renderSinoptico === 'function') {

--- a/js/views/users.js
+++ b/js/views/users.js
@@ -65,6 +65,7 @@ export async function render(container) {
           <option value="admin"${user.role === 'admin' ? ' selected' : ''}>Admin</option>
           <option value="user"${user.role === 'user' ? ' selected' : ''}>User</option>
         </select>
+        <input type="password" placeholder="Contraseña" />
       </td>
       <td>
         <button class="save">Guardar</button>
@@ -76,11 +77,13 @@ export async function render(container) {
       tbody.appendChild(tr);
     }
 
-    const nameInput = tr.querySelector('input');
+    const nameInput = tr.querySelector('input[type="text"]');
     const roleSelect = tr.querySelector('select');
+    const passwordInput = tr.querySelector('input[type="password"]');
 
     tr.querySelector('.save').addEventListener('click', async () => {
       const data = { name: nameInput.value.trim(), role: roleSelect.value };
+      if (passwordInput.value) data.password = passwordInput.value;
       if (!data.name) return;
       if (user.id) {
         await update('users', user.id, data);

--- a/login.html
+++ b/login.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Iniciar sesión</title>
+  <link rel="stylesheet" href="assets/styles.css">
+  <script>
+    if (localStorage.getItem('darkMode') === 'true') {
+      document.documentElement.classList.add('dark-mode');
+    }
+  </script>
+</head>
+<body>
+  <div class="login-container">
+    <form id="loginForm" class="login-form">
+      <label for="loginUser">Usuario:</label>
+      <input id="loginUser" type="text" required>
+      <label for="loginPass">Contraseña:</label>
+      <input id="loginPass" type="password" required>
+      <button type="submit">Ingresar</button>
+      <button type="button" id="guestBtn">Ingresar como invitado</button>
+    </form>
+  </div>
+  <script type="module" src="js/login.js"></script>
+</body>
+</html>

--- a/sinoptico-editor.html
+++ b/sinoptico-editor.html
@@ -15,8 +15,9 @@
   <nav class="main-nav">
     <a href="index.html">Inicio</a>
     <a href="sinoptico.html">Ver Sinóptico</a>
-    <a href="database.html">Base de Datos</a>
+    <a href="database.html" class="no-guest">Base de Datos</a>
     <button id="toggleDarkMode" type="button">🌙</button>
+    <button type="button" class="logout-link">Salir</button>
   </nav>
   <header class="editor-header">
     <h1 class="editor-title">Editor de Sinóptico</h1>
@@ -104,6 +105,7 @@
   </dialog>
   <script src="lib/dexie.min.js" defer></script>
   <script src="lib/fuse.min.js" defer></script>
+  <script type="module" src="js/authGuard.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/xlsx/dist/xlsx.full.min.js" defer></script>
   <script type="module" src="js/dataService.js" defer></script>
   <script type="module" src="js/views/sinoptico.js" defer></script>

--- a/sinoptico.html
+++ b/sinoptico.html
@@ -14,9 +14,10 @@
 <body>
   <nav class="main-nav">
     <a href="index.html">Inicio</a>
-    <a href="database.html">Base de Datos</a>
+    <a href="database.html" class="no-guest">Base de Datos</a>
     <!-- <a href="#/sinoptico">Sinóptico SPA</a> -->
     <button id="toggleDarkMode" type="button">🌙</button>
+    <button type="button" class="logout-link">Salir</button>
   </nav>
   <div class="filtro-contenedor">
     <div class="filtros-texto">
@@ -43,7 +44,7 @@
       <label><input type="checkbox" id="chkMostrarNivel1" checked> Nivel 1</label>
       <label><input type="checkbox" id="chkMostrarNivel2" checked> Nivel 2</label>
       <label><input type="checkbox" id="chkMostrarNivel3" checked> Nivel 3</label>
-      <button id="btnExcel">Exportar Excel</button>
+      <button id="btnExcel" class="no-guest">Exportar Excel</button>
     </div>
   </div>
   <div class="tabla-contenedor">
@@ -63,6 +64,7 @@
   </div>
   <script src="lib/dexie.min.js" defer></script>
   <script src="lib/fuse.min.js" defer></script>
+  <script type="module" src="js/authGuard.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/xlsx/dist/xlsx.full.min.js" defer></script>
   <script type="module" src="js/dataService.js" defer></script>
   <script type="module" src="js/views/sinoptico.js" defer></script>


### PR DESCRIPTION
## Summary
- implement authentication with new `login.html`
- restrict features for guest and non-admin users
- store session info and validate credentials in `dataService`
- hide editing options for guests
- bump version number to 355

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_684ee1bf6bcc832fb6961276265f3e6d