### PR TITLE
Clarify GitHub hosting limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,5 +70,11 @@ verifica lo siguiente:
 3. Revisa la consola de desarrollo del navegador en busca de errores de
    permisos o bloqueos.
 
+   > **Nota:** abrir los HTML directamente desde _GitHub_ (por ejemplo
+   utilizando la vista **Raw**) tampoco permitirá ejecutar los scripts debido a
+   la política de seguridad que aplica ese servicio. No es un problema de tu
+   navegador: para que funcionen las páginas debes usar un servidor local o
+   publicarlas mediante **GitHub Pages**.
+
 Tras corregir cualquier problema relacionado con el almacenamiento, vuelve a
 intentar la edición.

--- a/login.html
+++ b/login.html
@@ -19,9 +19,15 @@
       <label for="loginPass">Contraseña:</label>
       <input id="loginPass" type="password" required>
       <button type="submit">Ingresar</button>
-      <button type="button" id="guestBtn">Ingresar como invitado</button>
+    <button type="button" id="guestBtn">Ingresar como invitado</button>
     </form>
   </div>
+  <noscript>
+    <p class="noscript-warning">
+      Esta página necesita JavaScript para funcionar. Si la estás viendo desde
+      GitHub, utiliza un servidor local o publica el proyecto con GitHub Pages.
+    </p>
+  </noscript>
   <script type="module" src="js/ui/animations.js" defer></script>
   <script type="module" src="js/login.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- warn about opening HTML directly from GitHub
- show warning when JS is blocked

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684ee9da96a8832fb3dda64805b2768f