### PR TITLE
Fix login race condition

### DIFF
--- a/js/dataService.js
+++ b/js/dataService.js
@@ -31,7 +31,7 @@ const ready = new Promise((res) => {
   readyResolve = res;
 });
 
-async function ensureDefaultUser() {
+export async function ensureDefaultUser() {
   await ready;
   const users = await getAll('users');
   if (!users.length) {
@@ -430,4 +430,4 @@ ensureDefaultUser();
 
 export default api;
 
-export { getAll, add, update, remove, exportJSON, importJSON, ready, validateCredentials };
+export { getAll, add, update, remove, exportJSON, importJSON, ready, validateCredentials, ensureDefaultUser };

--- a/js/login.js
+++ b/js/login.js
@@ -1,4 +1,4 @@
-import { ready, validateCredentials } from './dataService.js';
+import { ready, validateCredentials, ensureDefaultUser } from './dataService.js';
 import { saveUser, getUser } from './session.js';
 
 const current = getUser();
@@ -14,6 +14,7 @@ form.addEventListener('submit', async ev => {
   const name = document.getElementById('loginUser').value.trim();
   const pass = document.getElementById('loginPass').value;
   await ready;
+  await ensureDefaultUser();
   const user = await validateCredentials(name, pass);
   if (user) {
     saveUser(user);

--- a/js/version.js
+++ b/js/version.js
@@ -1,4 +1,4 @@
-export const version = '356';
+export const version = '357';
 export const POLLING_INTERVAL = 60000;
 export function displayVersion() {
   const div = document.createElement('div');


### PR DESCRIPTION
## Summary
- export `ensureDefaultUser` from `dataService`
- wait for user initialization when logging in
- bump version to 357

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684ef0c85a38832f94de4e84794752b3