### PR TITLE
Improve user management feedback

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Proyecto Barack
 
-Versión actual: **360**
+Versión actual: **361**
 
 Esta es una pequeña SPA (Single Page Application) escrita en HTML, CSS y JavaScript.
 Incluye un módulo llamado *Sinóptico* para gestionar jerarquías de productos.
@@ -20,7 +20,8 @@ siempre y cuando no se esté ejecutando desde `file://`.
    con `python -m http.server`, y abre `http://localhost:8000/index.html` en
    tu navegador. Verás la pantalla de inicio de sesión donde puedes ingresar
    con el usuario **facundo** (contraseña `1234`) o pulsar el botón "Ingresar
-   como invitado".
+   como invitado". Este usuario inicial se puede modificar o eliminar
+   desde la sección "Usuarios".
 2. Navega a "Sinóptico" para visualizar la tabla con filtros.
    Los productos añadidos quedan sangrados a la derecha de su cliente y
    muestran una flecha que indica la relación jerárquica.

--- a/js/dataService.js
+++ b/js/dataService.js
@@ -34,12 +34,14 @@ const ready = new Promise((res) => {
 export async function ensureDefaultUser() {
   await ready;
   const users = await getAll('users');
-  if (!users.length) {
+  const initFlag = hasWindow && localStorage.getItem('defaultUserInit');
+  if (!users.length && !initFlag) {
     await add('users', {
       name: 'facundo',
       password: '1234',
       role: 'admin',
     });
+    if (hasWindow) localStorage.setItem('defaultUserInit', '1');
   }
 }
 
@@ -415,6 +417,7 @@ const api = {
       });
     }
     for (const key of Object.keys(memory)) delete memory[key];
+    if (hasWindow) localStorage.removeItem('defaultUserInit');
     _fallbackPersist();
     notifyChange();
   },

--- a/js/version.js
+++ b/js/version.js
@@ -1,4 +1,4 @@
-export const version = '360';
+export const version = '361';
 export const POLLING_INTERVAL = 60000;
 export function displayVersion() {
   const div = document.createElement('div');

--- a/js/views/users.js
+++ b/js/views/users.js
@@ -46,6 +46,7 @@ export async function render(container) {
     if (btn.classList.contains('delete')) {
       if (confirm('¿Eliminar usuario?')) {
         await remove('users', id);
+        if (window.mostrarMensaje) window.mostrarMensaje('Usuario eliminado', 'success');
         await load();
       }
     } else if (btn.classList.contains('edit')) {
@@ -87,8 +88,10 @@ export async function render(container) {
       if (!data.name) return;
       if (user.id) {
         await update('users', user.id, data);
+        if (window.mostrarMensaje) window.mostrarMensaje('Usuario actualizado', 'success');
       } else {
         await add('users', data);
+        if (window.mostrarMensaje) window.mostrarMensaje('Usuario creado', 'success');
       }
       await load();
     });


### PR DESCRIPTION
## Summary
- show toast messages when creating, updating or deleting users
- make default 'facundo' account editable by only creating it once
- document that the default user can be modified
- bump version to 361

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_684f37593210832fa7e85a27df1ac1d3