### PR TITLE
Fix guest login initialization and enforce user password requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Proyecto Barack
 
-Versión actual: **361**
+Versión actual: **362**
 
 Esta es una pequeña SPA (Single Page Application) escrita en HTML, CSS y JavaScript.
 Incluye un módulo llamado *Sinóptico* para gestionar jerarquías de productos.

--- a/js/login.js
+++ b/js/login.js
@@ -24,7 +24,8 @@ form.addEventListener('submit', async ev => {
   }
 });
 
-guestBtn.addEventListener('click', () => {
+guestBtn.addEventListener('click', async () => {
+  await ensureDefaultUser();
   saveUser({ name: 'Invitado', role: 'guest' });
   location.href = 'index.html';
 });

--- a/js/version.js
+++ b/js/version.js
@@ -1,4 +1,4 @@
-export const version = '361';
+export const version = '362';
 export const POLLING_INTERVAL = 60000;
 export function displayVersion() {
   const div = document.createElement('div');

--- a/js/views/users.js
+++ b/js/views/users.js
@@ -59,6 +59,8 @@ export async function render(container) {
 
   function showEditor(user = {}, refRow) {
     const tr = document.createElement('tr');
+    const pwdPlaceholder = user.id ? 'Nueva contraseña' : 'Contraseña';
+    const pwdRequired = user.id ? '' : ' required';
     tr.innerHTML = `
       <td><input type="text" value="${user.name || ''}" /></td>
       <td>
@@ -66,7 +68,7 @@ export async function render(container) {
           <option value="admin"${user.role === 'admin' ? ' selected' : ''}>Admin</option>
           <option value="user"${user.role === 'user' ? ' selected' : ''}>User</option>
         </select>
-        <input type="password" placeholder="Contraseña" />
+        <input type="password" placeholder="${pwdPlaceholder}"${pwdRequired} />
       </td>
       <td>
         <button class="save">Guardar</button>


### PR DESCRIPTION
## Summary
- ensure default user initialization when logging in as guest
- require password for new users in Users view
- bump version number

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_684f39c52e88832f8d2cd5f5db0c9996