### PR TITLE
Fix default user recreation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Proyecto Barack
 
-Versión actual: **362**
+Versión actual: **363**
 
 Esta es una pequeña SPA (Single Page Application) escrita en HTML, CSS y JavaScript.
 Incluye un módulo llamado *Sinóptico* para gestionar jerarquías de productos.

--- a/js/dataService.js
+++ b/js/dataService.js
@@ -3,6 +3,7 @@
 
 export const DATA_CHANGED = 'DATA_CHANGED';
 const STORAGE_KEY = 'genericData';
+const DISABLE_DEFAULT_USER_KEY = 'disableDefaultUser';
 
 // Dexie may be loaded via a script tag in the browser. Grab the global instance
 // if present. When running under Node we fallback to requiring the package so
@@ -35,7 +36,8 @@ export async function ensureDefaultUser() {
   await ready;
   const users = await getAll('users');
   const initFlag = hasWindow && localStorage.getItem('defaultUserInit');
-  if (!users.length && !initFlag) {
+  const disableFlag = hasWindow && localStorage.getItem(DISABLE_DEFAULT_USER_KEY);
+  if (!users.length && !initFlag && !disableFlag) {
     await add('users', {
       name: 'facundo',
       password: '1234',
@@ -417,7 +419,10 @@ const api = {
       });
     }
     for (const key of Object.keys(memory)) delete memory[key];
-    if (hasWindow) localStorage.removeItem('defaultUserInit');
+    if (hasWindow) {
+      localStorage.removeItem('defaultUserInit');
+      localStorage.removeItem(DISABLE_DEFAULT_USER_KEY);
+    }
     _fallbackPersist();
     notifyChange();
   },

--- a/js/version.js
+++ b/js/version.js
@@ -1,4 +1,4 @@
-export const version = '362';
+export const version = '363';
 export const POLLING_INTERVAL = 60000;
 export function displayVersion() {
   const div = document.createElement('div');

--- a/js/views/users.js
+++ b/js/views/users.js
@@ -47,6 +47,10 @@ export async function render(container) {
       if (confirm('¿Eliminar usuario?')) {
         await remove('users', id);
         if (window.mostrarMensaje) window.mostrarMensaje('Usuario eliminado', 'success');
+        const remaining = await getAll('users');
+        if (!remaining.length && typeof localStorage !== 'undefined') {
+          localStorage.setItem('disableDefaultUser', '1');
+        }
         await load();
       }
     } else if (btn.classList.contains('edit')) {


### PR DESCRIPTION
## Summary
- prevent auto creation of the default user when all users have been deleted
- keep the flag when removing users and reset it on `reset()`
- bump version to 363

## Testing
- `npm test` *(fails: ENOENT cannot find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684f3c7dbaf4832fb6d069e784bf475e