### PR TITLE
Fix sinoptico localStorage retrieval

### DIFF
--- a/js/dataService.js
+++ b/js/dataService.js
@@ -372,7 +372,8 @@ export async function getAllSinoptico() {
     }
   }
   try {
-    return JSON.parse(localStorage.getItem(STORAGE_KEY) || '[]');
+    const obj = JSON.parse(localStorage.getItem(STORAGE_KEY) || '{}');
+    return Array.isArray(obj.sinoptico) ? obj.sinoptico : [];
   } catch (e) {
     return [];
   }


### PR DESCRIPTION
## Summary
- fix how `getAllSinoptico` reads localStorage when IndexedDB is unavailable

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684f3f2b1020832fbe0c0ada845f4d0c