### PR TITLE
Handle empty sinoptico data

### DIFF
--- a/js/ui/renderer.js
+++ b/js/ui/renderer.js
@@ -358,6 +358,15 @@ document.addEventListener('DOMContentLoaded', () => {
     await ready;
     try { sinopticoData = await dataService.getAll(); } catch { sinopticoData = []; }
     await ready;
+    if (!sinopticoData.length) {
+      const msg = document.getElementById('appMessage');
+      if (msg) {
+        msg.textContent = 'No hay datos en el sinóptico';
+        msg.style.display = 'block';
+      }
+      hideLoader();
+      return;
+    }
     // Si la base está vacía simplemente mostramos una tabla sin datos. Ya no
     // generamos registros de demostración para permitir que el usuario elimine
     // por completo los valores iniciales.


### PR DESCRIPTION
## Summary
- show a message when there is no sinoptico data

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684f3f2d5abc832fb6d4901e2dfd9e75