### PR TITLE
Fix login case-sensitivity and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Proyecto Barack
 
-Versión actual: **364**
+Versión actual: **365**
 
 Esta es una pequeña SPA (Single Page Application) escrita en HTML, CSS y JavaScript.
 Incluye un módulo llamado *Sinóptico* para gestionar jerarquías de productos.
@@ -20,9 +20,11 @@ siempre y cuando no se esté ejecutando desde `file://`.
   con `python -m http.server`, y abre `http://localhost:8000/index.html` en
   tu navegador. Verás la pantalla de inicio de sesión donde puedes ingresar
   con alguno de los administradores iniciales **facundo**, **leo**, **pablo** o
-  **paulo** (todos con contraseña `1234`), o pulsar el botón "Ingresar como
-  invitado". Estos usuarios iniciales se pueden modificar o eliminar desde la
+  **paulo** (todos con la misma contraseña predeterminada), o pulsar el botón
+  "Ingresar como invitado". Estos usuarios iniciales se pueden modificar o
+  eliminar desde la
   sección "Usuarios".
+  El ingreso no distingue mayúsculas o minúsculas en el nombre de usuario.
 2. Navega a "Sinóptico" para visualizar la tabla con filtros.
    Los productos añadidos quedan sangrados a la derecha de su cliente y
    muestran una flecha que indica la relación jerárquica.

--- a/js/dataService.js
+++ b/js/dataService.js
@@ -321,7 +321,10 @@ export async function deleteUser(id) {
 
 export async function validateCredentials(name, password) {
   const users = await getAll('users');
-  return users.find(u => u.name === name && u.password === password);
+  const normalized = String(name || '').trim().toLowerCase();
+  return users.find(
+    u => u.name && u.name.toLowerCase() === normalized && u.password === password
+  );
 }
 
 export async function replaceAll(arr) {

--- a/js/version.js
+++ b/js/version.js
@@ -1,4 +1,4 @@
-export const version = '364';
+export const version = '365';
 export const POLLING_INTERVAL = 60000;
 export function displayVersion() {
   const div = document.createElement('div');


### PR DESCRIPTION
## Summary
- update README so default password isn't visible
- clarify that usernames are case-insensitive
- bump version to 365
- make login names case-insensitive

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684f48766158832f83de558de417a4c7