### PR TITLE
Add admin default user

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ siempre y cuando no se esté ejecutando desde `file://`.
 1. Ejecuta un servidor local desde la carpeta del proyecto, por ejemplo
   con `python -m http.server`, y abre `http://localhost:8000/index.html` en
   tu navegador. Verás la pantalla de inicio de sesión donde puedes ingresar
-  con alguno de los administradores iniciales **facundo**, **leo**, **pablo** o
+  con alguno de los administradores iniciales **admin**, **facundo**, **leo**, **pablo** o
   **paulo** (todos con la misma contraseña predeterminada `1234`), o pulsar el botón
   "Ingresar como invitado". Estos usuarios iniciales se pueden modificar o
   eliminar desde la

--- a/js/dataService.js
+++ b/js/dataService.js
@@ -39,6 +39,7 @@ export async function ensureDefaultUsers() {
   const disableFlag = hasWindow && localStorage.getItem(DISABLE_DEFAULT_USER_KEY);
   if (!users.length && !initFlag && !disableFlag) {
     const defaults = [
+      { name: 'admin', password: '1234', role: 'admin' },
       { name: 'facundo', password: '1234', role: 'admin' },
       { name: 'leo', password: '1234', role: 'admin' },
       { name: 'pablo', password: '1234', role: 'admin' },

--- a/js/version.js
+++ b/js/version.js
@@ -1,4 +1,4 @@
-export const version = '366';
+export const version = '367';
 export const POLLING_INTERVAL = 60000;
 export function displayVersion() {
   const div = document.createElement('div');


### PR DESCRIPTION
## Summary
- create a default **admin** account
- document the new account in README
- bump version

## Testing
- `node --check js/dataService.js`
- `node --check js/login.js`
- `node --check js/version.js`

------
https://chatgpt.com/codex/tasks/task_e_684f6093f5cc832f89a4135d3042006d