### PR TITLE
Fix default user creation on empty DB

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/js/dataService.js
+++ b/js/dataService.js
@@ -35,9 +35,10 @@ const ready = new Promise((res) => {
 export async function ensureDefaultUsers() {
   await ready;
   const users = await getAll('users');
-  const initFlag = hasWindow && localStorage.getItem('defaultUserInit');
+  // check optional local storage flag to disable automatic user creation
   const disableFlag = hasWindow && localStorage.getItem(DISABLE_DEFAULT_USER_KEY);
-  if (!users.length && !initFlag && !disableFlag) {
+  // recreate default users if none exist regardless of initialization flag
+  if (!users.length && !disableFlag) {
     const defaults = [
       { name: 'admin', password: '1234', role: 'admin' },
       { name: 'facundo', password: '1234', role: 'admin' },
@@ -445,4 +446,4 @@ ensureDefaultUsers();
 
 export default api;
 
-export { getAll, add, update, remove, exportJSON, importJSON, ready, ensureDefaultUsers };
+export { getAll, add, update, remove, exportJSON, importJSON, ready };

--- a/login.test.js
+++ b/login.test.js
@@ -1,0 +1,9 @@
+import dataService, { ready, ensureDefaultUsers, validateCredentials } from './js/dataService.js';
+import assert from 'node:assert/strict';
+
+await ready;
+await dataService.reset();
+await ensureDefaultUsers();
+const user = await validateCredentials('facundo', '1234');
+assert.ok(user && user.name === 'facundo', 'default user should exist');
+console.log('Login test passed');

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,22 @@
+{
+  "name": "proyecto-barack",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "proyecto-barack",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "dexie": "^4.0.11"
+      }
+    },
+    "node_modules/dexie": {
+      "version": "4.0.11",
+      "resolved": "https://registry.npmjs.org/dexie/-/dexie-4.0.11.tgz",
+      "integrity": "sha512-SOKO002EqlvBYYKQSew3iymBoN2EQ4BDw/3yprjh7kAfFzjBYkaMNa/pZvcA7HSWlcKSQb9XhPe3wKyQ0x4A8A==",
+      "license": "Apache-2.0"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "proyecto-barack",
+  "version": "1.0.0",
+  "description": "Versión actual: **366**",
+  "main": "index.js",
+  "directories": {
+    "lib": "lib"
+  },
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "module",
+  "dependencies": {
+    "dexie": "^4.0.11"
+  }
+}


### PR DESCRIPTION
## Summary
- ensure default users are recreated if user list is empty
- remove duplicate named export from `dataService.js`
- add a simple login test
- add `package.json` with Dexie dependency and ignore `node_modules`

## Testing
- `npm install`
- `node login.test.js`

------
https://chatgpt.com/codex/tasks/task_e_684f6fd2b76c832fa2235eed991a816c