### PR TITLE
Fix sinoptico links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Proyecto Barack
 
-Versión actual: **366**
+Versión actual: **367**
 
 Esta es una pequeña SPA (Single Page Application) escrita en HTML, CSS y JavaScript.
 Incluye un módulo llamado *Sinóptico* para gestionar jerarquías de productos.

--- a/js/views/home.js
+++ b/js/views/home.js
@@ -7,7 +7,7 @@ export function render(container) {
       <p class="tagline">Soluciones modernas para tu negocio</p>
     <div class="quick-links">
       <a href="sinoptico-editor.html" class="btn-link no-guest">Editar Sinóptico</a>
-      <a href="#/sinoptico" class="btn-link">Ver Sinóptico</a>
+      <a href="sinoptico.html" class="btn-link">Ver Sinóptico</a>
       <a href="#/amfe" class="btn-link">AMFE</a>
     </div>
     </section>

--- a/js/views/sinoptico.js
+++ b/js/views/sinoptico.js
@@ -4,6 +4,7 @@ import { isGuest } from '../session.js';
 
 export async function render(container) {
   container.innerHTML = `
+    <h1 class="editor-title">Sinóptico</h1>
     <div class="toolbar">
       <button id="sin-edit">Editar</button>
       <button id="btnNuevoCliente">Nuevo cliente</button>


### PR DESCRIPTION
## Summary
- route to sinoptico page via `sinoptico.html` on home
- add a heading to sinoptico view
- bump version

## Testing
- `node login.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68504dc591dc832fb2c730f6c9595cf5