### PR TITLE
Implement live sync via SSE

### DIFF
--- a/js/dataService.js
+++ b/js/dataService.js
@@ -184,6 +184,15 @@ function notifyChange() {
   }
 }
 
+// connect to server-sent events for live updates
+const eventSource =
+  hasWindow && typeof EventSource !== 'undefined'
+    ? new EventSource(API_URL + '/events')
+    : null;
+if (eventSource) {
+  eventSource.addEventListener('message', () => notifyChange());
+}
+
 async function getAll(store = 'sinoptico') {
   const name = String(store);
   if (db && db[name]) {

--- a/js/version.js
+++ b/js/version.js
@@ -1,4 +1,4 @@
-export const version = '369';
+export const version = '370';
 export const POLLING_INTERVAL = 60000;
 export function displayVersion() {
   const div = document.createElement('div');

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "license": "ISC",
       "dependencies": {
         "dexie": "^4.0.11",
-        "express": "^4.21.2"
+        "express": "^4.21.2",
+        "express-sse": "^1.0.0"
       }
     },
     "node_modules/accepts": {
@@ -282,6 +283,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-sse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/express-sse/-/express-sse-1.0.0.tgz",
+      "integrity": "sha512-ny3nCXjrWwQki8edZe0DwuXjLbw0ga3pc0CZX19VOB0GKuUnlIH2fqPBwTJcGHZPtmjJ2EVNPVeCgORpX6Nsrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/finalhandler": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "type": "module",
   "dependencies": {
     "dexie": "^4.0.11",
-    "express": "^4.21.2"
+    "express": "^4.21.2",
+    "express-sse": "^1.0.0"
   }
 }

--- a/server/index.js
+++ b/server/index.js
@@ -1,4 +1,5 @@
 import express from 'express';
+import SSE from 'express-sse';
 import { readFile, writeFile } from 'fs/promises';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
@@ -21,7 +22,10 @@ async function writeData(data) {
 
 function createApp() {
   const app = express();
+  const sse = new SSE();
   app.use(express.json());
+
+  app.get('/events', sse.init);
 
   // Sinoptico routes
   app.get('/api/sinoptico', async (req, res) => {
@@ -35,6 +39,7 @@ function createApp() {
     if (!item.id) item.id = Date.now().toString();
     data.sinoptico.push(item);
     await writeData(data);
+    sse.send({ type: 'update' });
     res.status(201).json(item);
   });
 
@@ -44,6 +49,7 @@ function createApp() {
     if (idx === -1) return res.status(404).end();
     data.sinoptico[idx] = { ...data.sinoptico[idx], ...req.body, id: data.sinoptico[idx].id };
     await writeData(data);
+    sse.send({ type: 'update' });
     res.json(data.sinoptico[idx]);
   });
 
@@ -53,6 +59,7 @@ function createApp() {
     if (idx === -1) return res.status(404).end();
     const removed = data.sinoptico.splice(idx, 1)[0];
     await writeData(data);
+    sse.send({ type: 'update' });
     res.json(removed);
   });
 
@@ -68,6 +75,7 @@ function createApp() {
     if (!user.id) user.id = Date.now().toString();
     data.users.push(user);
     await writeData(data);
+    sse.send({ type: 'update' });
     res.status(201).json(user);
   });
 
@@ -77,6 +85,7 @@ function createApp() {
     if (idx === -1) return res.status(404).end();
     data.users[idx] = { ...data.users[idx], ...req.body, id: data.users[idx].id };
     await writeData(data);
+    sse.send({ type: 'update' });
     res.json(data.users[idx]);
   });
 
@@ -86,6 +95,7 @@ function createApp() {
     if (idx === -1) return res.status(404).end();
     const removed = data.users.splice(idx, 1)[0];
     await writeData(data);
+    sse.send({ type: 'update' });
     res.json(removed);
   });
 


### PR DESCRIPTION
## Summary
- add express-sse and wire up /events endpoint
- broadcast update events from REST actions
- listen for server-sent events in dataService
- bump version number

## Testing
- `node login.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68506c1a098c832fbabd7621906adc91