### PR TITLE
Add API URL configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,3 +98,13 @@ Para exponer los datos mediante una API REST se añadió un pequeño servidor ba
 3. Los datos se guardan en `server/data.json`.
 4. Están disponibles las rutas `/api/sinoptico` y `/api/users` para operaciones CRUD.
 
+### Configurar API_URL
+
+Puedes indicar la URL base de la API para que el frontend se conecte al servidor.
+
+1. Define `window.API_URL` antes de cargar los scripts de la aplicación.
+2. O bien guarda el valor en `localStorage` bajo la clave `API_URL`.
+
+La sección **Ajustes** incluye un campo para modificar este valor. Al cambiarlo
+se recargará la página y `dataService` usará la nueva dirección.
+

--- a/js/views/settings.js
+++ b/js/views/settings.js
@@ -17,7 +17,12 @@ export async function render(container) {
         <input type="checkbox" id="toggleGridOverlay">
         Mostrar cuadrícula
       </label>
-    </section>`;
+      <label>
+        URL de la API:
+        <input id="apiUrlInput" type="text">
+      </label>
+    </section>
+    <p id="apiUrlDisplay"></p>`;
 
   await ready;
   const data = await getAll('sinoptico');
@@ -29,6 +34,17 @@ export async function render(container) {
   const valueLabel = container.querySelector('#brightnessValue');
   const versionChk = container.querySelector('#toggleVersionOverlay');
   const gridChk = container.querySelector('#toggleGridOverlay');
+  const apiInput = container.querySelector('#apiUrlInput');
+  const apiDisplay = container.querySelector('#apiUrlDisplay');
+
+  const currentApi =
+    localStorage.getItem('API_URL') || (typeof window !== 'undefined' && window.API_URL) || '';
+  apiInput.value = currentApi;
+  apiDisplay.textContent = 'URL actual: ' + (currentApi || '(vacía)');
+  apiInput.addEventListener('change', ev => {
+    localStorage.setItem('API_URL', ev.target.value.trim());
+    location.reload();
+  });
 
   const storedBrightness = localStorage.getItem('pageBrightness') || '100';
   range.value = storedBrightness;


### PR DESCRIPTION
## Summary
- describe how to set API_URL in README
- add input for API URL in settings view
- show current API URL and reload when changed

## Testing
- `node login.test.js`

------
https://chatgpt.com/codex/tasks/task_e_685076d46524832fb0e56946996f78be