### PR TITLE
Add configurable CORS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Proyecto Barack
 
-Versión actual: **371**
+Versión actual: **372**
 
 Esta es una pequeña SPA (Single Page Application) escrita en HTML, CSS y JavaScript.
 Incluye un módulo llamado *Sinóptico* para gestionar jerarquías de productos.
@@ -97,8 +97,9 @@ Para exponer los datos mediante una API REST se añadió un pequeño servidor ba
 
 1. Ejecuta `npm install` para descargar las dependencias.
 2. Inicia el servidor con `npm start` (puedes definir el puerto usando la variable `PORT`).
-3. Los datos se guardan en `server/data.json`.
-4. Están disponibles las rutas `/api/sinoptico` y `/api/users` para operaciones CRUD.
+3. Puedes controlar los orígenes permitidos con la variable `CORS_ORIGIN` (por defecto `*`).
+4. Los datos se guardan en `server/data.json`.
+5. Están disponibles las rutas `/api/sinoptico` y `/api/users` para operaciones CRUD.
 
 ### Configurar API_URL
 

--- a/js/version.js
+++ b/js/version.js
@@ -1,4 +1,4 @@
-export const version = '371';
+export const version = '372';
 export const POLLING_INTERVAL = 60000;
 export function displayVersion() {
   const div = document.createElement('div');

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "cors": "^2.8.5",
         "dexie": "^4.0.11",
         "express": "^4.21.2",
         "express-sse": "^1.0.0"
@@ -130,6 +131,19 @@
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
       "license": "MIT"
+    },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
     },
     "node_modules/debug": {
       "version": "2.6.9",
@@ -537,6 +551,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/object-inspect": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "proyecto-barack",
   "version": "1.0.0",
-  "description": "Versión actual: **371**",
+  "description": "Versión actual: **372**",
   "main": "index.js",
   "directories": {
     "lib": "lib"
@@ -15,6 +15,7 @@
   "license": "ISC",
   "type": "module",
   "dependencies": {
+    "cors": "^2.8.5",
     "dexie": "^4.0.11",
     "express": "^4.21.2",
     "express-sse": "^1.0.0"

--- a/server/index.js
+++ b/server/index.js
@@ -1,5 +1,6 @@
 import express from 'express';
 import SSE from 'express-sse';
+import cors from 'cors';
 import { readFile, writeFile } from 'fs/promises';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
@@ -23,6 +24,12 @@ async function writeData(data) {
 function createApp() {
   const app = express();
   const sse = new SSE();
+  const allowedOrigin = process.env.CORS_ORIGIN || '*';
+  if (allowedOrigin === '*') {
+    app.use(cors());
+  } else {
+    app.use(cors({ origin: allowedOrigin.split(',') }));
+  }
   app.use(express.json());
 
   app.get('/events', sse.init);


### PR DESCRIPTION
## Summary
- install `cors`
- allow configuring allowed origins in `server/index.js`
- document `CORS_ORIGIN` in README
- bump version to 372

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68507aff4590832fafa9654a6c143ae6