### PR TITLE
Fix SSE endpoint and clean dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Proyecto Barack
 
-Versión actual: **372**
+Versión actual: **373**
 
 Esta es una pequeña SPA (Single Page Application) escrita en HTML, CSS y JavaScript.
 Incluye un módulo llamado *Sinóptico* para gestionar jerarquías de productos.

--- a/js/version.js
+++ b/js/version.js
@@ -1,4 +1,4 @@
-export const version = '372';
+export const version = '373';
 export const POLLING_INTERVAL = 60000;
 export function displayVersion() {
   const div = document.createElement('div');

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "ISC",
       "dependencies": {
         "cors": "^2.8.5",
-        "dexie": "^4.0.11",
         "express": "^4.21.2",
         "express-sse": "^1.0.0"
       }
@@ -172,12 +171,6 @@
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
       }
-    },
-    "node_modules/dexie": {
-      "version": "4.0.11",
-      "resolved": "https://registry.npmjs.org/dexie/-/dexie-4.0.11.tgz",
-      "integrity": "sha512-SOKO002EqlvBYYKQSew3iymBoN2EQ4BDw/3yprjh7kAfFzjBYkaMNa/pZvcA7HSWlcKSQb9XhPe3wKyQ0x4A8A==",
-      "license": "Apache-2.0"
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "proyecto-barack",
   "version": "1.0.0",
-  "description": "Versión actual: **372**",
+  "description": "Versión actual: **373**",
   "main": "index.js",
   "directories": {
     "lib": "lib"
@@ -16,7 +16,6 @@
   "type": "module",
   "dependencies": {
     "cors": "^2.8.5",
-    "dexie": "^4.0.11",
     "express": "^4.21.2",
     "express-sse": "^1.0.0"
   }

--- a/server/index.js
+++ b/server/index.js
@@ -32,7 +32,7 @@ function createApp() {
   }
   app.use(express.json());
 
-  app.get('/events', sse.init);
+  app.get('/api/events', sse.init);
 
   // Sinoptico routes
   app.get('/api/sinoptico', async (req, res) => {


### PR DESCRIPTION
## Summary
- fix server to expose SSE under `/api/events`
- remove unused Dexie dependency
- bump version to 373

## Testing
- `npm install`
- `npm test` *(fails: Error: no test specified)*
- `PORT=3000 node server/index.js`

------
https://chatgpt.com/codex/tasks/task_e_6850660b8a34832f8ea7797550d65451