### PR TITLE
Fix login by adding default users on server start

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Proyecto Barack
 
-Versión actual: **373**
+Versión actual: **374**
 
 Esta es una pequeña SPA (Single Page Application) escrita en HTML, CSS y JavaScript.
 Incluye un módulo llamado *Sinóptico* para gestionar jerarquías de productos.

--- a/js/version.js
+++ b/js/version.js
@@ -1,4 +1,4 @@
-export const version = '373';
+export const version = '374';
 export const POLLING_INTERVAL = 60000;
 export function displayVersion() {
   const div = document.createElement('div');

--- a/server/index.js
+++ b/server/index.js
@@ -21,6 +21,24 @@ async function writeData(data) {
   await writeFile(DATA_FILE, JSON.stringify(data, null, 2));
 }
 
+async function ensureDefaultUsers() {
+  const data = await readData();
+  if (Array.isArray(data.users) && data.users.length === 0) {
+    const defaults = [
+      { name: 'admin', password: '1234', role: 'admin' },
+      { name: 'facundo', password: '1234', role: 'admin' },
+      { name: 'leo', password: '1234', role: 'admin' },
+      { name: 'pablo', password: '1234', role: 'admin' },
+      { name: 'paulo', password: '1234', role: 'admin' },
+    ];
+    defaults.forEach((u, i) => {
+      u.id = Date.now().toString() + i;
+      data.users.push(u);
+    });
+    await writeData(data);
+  }
+}
+
 function createApp() {
   const app = express();
   const sse = new SSE();
@@ -110,6 +128,7 @@ function createApp() {
 }
 
 export async function startServer(port = process.env.PORT || 3000) {
+  await ensureDefaultUsers();
   const app = createApp();
   return new Promise(resolve => {
     const server = app.listen(port, () => {


### PR DESCRIPTION
## Summary
- ensure server populates default admin accounts on startup
- bump version to 374

## Testing
- `API_URL=http://localhost:3000/api node login.test.js`

------
https://chatgpt.com/codex/tasks/task_e_6850906e58a0832f9587ec119a41b133