### PR TITLE
Update admin defaults and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Proyecto Barack
 
-Versión actual: **374**
+Versión actual: **375**
 
 Esta es una pequeña SPA (Single Page Application) escrita en HTML, CSS y JavaScript.
 Incluye un módulo llamado *Sinóptico* para gestionar jerarquías de productos.
@@ -12,6 +12,8 @@ Todos los cambios en este repositorio incrementarán dicho número.
 
 Recuerda actualizar el valor en `js/version.js` y esta documentación cada vez
 que realices un cambio.
+A partir de ahora este README se mantendrá actualizado con cada versión para
+reflejar el funcionamiento más reciente de la aplicación.
 
 La aplicación comprueba cada minuto si el archivo `js/version.js` ha
 cambiado. Si detecta una nueva versión se recarga automáticamente,
@@ -22,11 +24,9 @@ siempre y cuando no se esté ejecutando desde `file://`.
 1. Ejecuta un servidor local desde la carpeta del proyecto, por ejemplo
   con `python -m http.server`, y abre `http://localhost:8000/index.html` en
   tu navegador. Verás la pantalla de inicio de sesión donde puedes ingresar
-  con alguno de los administradores iniciales **admin**, **facundo**, **leo**, **pablo** o
-  **paulo** (todos con la misma contraseña predeterminada `1234`), o pulsar el botón
-  "Ingresar como invitado". Estos usuarios iniciales se pueden modificar o
-  eliminar desde la
-  sección "Usuarios".
+  con el usuario predeterminado **admin** y contraseña **admin**, o pulsar el botón
+  "Ingresar como invitado". Este usuario inicial se puede modificar o eliminar
+  desde la sección "Usuarios".
   El ingreso no distingue mayúsculas o minúsculas en el nombre de usuario.
 2. Navega a "Sinóptico" para visualizar la tabla con filtros.
    Los productos añadidos quedan sangrados a la derecha de su cliente y

--- a/js/dataService.js
+++ b/js/dataService.js
@@ -244,11 +244,7 @@ export async function ensureDefaultUsers() {
   const disableFlag = hasWindow && localStorage.getItem(DISABLE_DEFAULT_USER_KEY);
   if (!users.length && !disableFlag) {
     const defaults = [
-      { name: 'admin', password: '1234', role: 'admin' },
-      { name: 'facundo', password: '1234', role: 'admin' },
-      { name: 'leo', password: '1234', role: 'admin' },
-      { name: 'pablo', password: '1234', role: 'admin' },
-      { name: 'paulo', password: '1234', role: 'admin' },
+      { name: 'admin', password: 'admin', role: 'admin' },
     ];
     for (const u of defaults) await addUser(u);
     if (hasWindow) localStorage.setItem('defaultUserInit', '1');

--- a/js/version.js
+++ b/js/version.js
@@ -1,4 +1,4 @@
-export const version = '374';
+export const version = '375';
 export const POLLING_INTERVAL = 60000;
 export function displayVersion() {
   const div = document.createElement('div');

--- a/login.test.js
+++ b/login.test.js
@@ -1,9 +1,17 @@
-import dataService, { ready, ensureDefaultUsers, validateCredentials } from './js/dataService.js';
+import { startServer } from './server/index.js';
 import assert from 'node:assert/strict';
+
+process.env.API_URL = 'http://localhost:3000/api';
+// start the API server for the tests
+const server = await startServer(3000);
+
+const dataModule = await import('./js/dataService.js');
+const { default: dataService, ready, ensureDefaultUsers, validateCredentials } = dataModule;
 
 await ready;
 await dataService.reset();
 await ensureDefaultUsers();
-const user = await validateCredentials('facundo', '1234');
-assert.ok(user && user.name === 'facundo', 'default user should exist');
+const user = await validateCredentials('admin', 'admin');
+assert.ok(user && user.name === 'admin', 'default admin user should exist');
 console.log('Login test passed');
+server.close();

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "proyecto-barack",
   "version": "1.0.0",
-  "description": "Versión actual: **373**",
+  "description": "Versión actual: **375**",
   "main": "index.js",
   "directories": {
     "lib": "lib"

--- a/server/index.js
+++ b/server/index.js
@@ -25,11 +25,7 @@ async function ensureDefaultUsers() {
   const data = await readData();
   if (Array.isArray(data.users) && data.users.length === 0) {
     const defaults = [
-      { name: 'admin', password: '1234', role: 'admin' },
-      { name: 'facundo', password: '1234', role: 'admin' },
-      { name: 'leo', password: '1234', role: 'admin' },
-      { name: 'pablo', password: '1234', role: 'admin' },
-      { name: 'paulo', password: '1234', role: 'admin' },
+      { name: 'admin', password: 'admin', role: 'admin' },
     ];
     defaults.forEach((u, i) => {
       u.id = Date.now().toString() + i;


### PR DESCRIPTION
## Summary
- add `admin/admin` as the single default user
- update login test to start server and check admin credentials
- bump version numbers and refresh README text

## Testing
- `node login.test.js`

------
https://chatgpt.com/codex/tasks/task_e_685092aa8344832facb5dbcf6f6e8add