### PR TITLE
Clarify Node.js requirement for Windows build

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,13 @@ Obtendrás tres archivos en la carpeta `dist/`. En macOS y Linux puedes iniciar 
 ## Compilar aplicación
 
 Se requiere **Node.js 18 o superior** para empaquetar la aplicación con `pkg`.
+Antes de ejecutarlo asegúrate de que Node.js esté instalado y que el comando
+`node` se encuentre en el `PATH`. Puedes comprobar la versión con:
+
+```bash
+node -v
+```
+
 En sistemas Windows se proporciona el script `scripts/build.ps1` que automatiza
 el proceso. Puedes ejecutarlo de dos formas:
 


### PR DESCRIPTION
## Summary
- expand Windows build instructions to mention Node.js requirement
- show how to check the installed version

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6850b9d3aa4c832f806b18de7dae1760