### PR TITLE
Add build script with error handling

### DIFF
--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -1,0 +1,40 @@
+$ErrorActionPreference = 'Stop'
+
+# Directory of this script
+$scriptRoot   = $PSScriptRoot
+$projectRoot  = Resolve-Path (Join-Path $scriptRoot '..')
+
+function Test-Admin {
+    $id         = [Security.Principal.WindowsIdentity]::GetCurrent()
+    $principal  = New-Object Security.Principal.WindowsPrincipal($id)
+    return $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+}
+
+if (-not (Test-Admin)) {
+    Write-Host "Requesting administrator privileges..."
+    $psArgs = @(
+        '-NoProfile'
+        '-ExecutionPolicy'
+        'Bypass'
+        '-File'
+        $MyInvocation.MyCommand.Path
+    )
+    Start-Process -FilePath 'powershell' -ArgumentList $psArgs -Verb RunAs
+    exit
+}
+
+Push-Location $projectRoot
+
+npm install
+if ($LASTEXITCODE -ne 0) {
+    Pop-Location
+    exit $LASTEXITCODE
+}
+
+npm run build-exe
+if ($LASTEXITCODE -ne 0) {
+    Pop-Location
+    exit $LASTEXITCODE
+}
+
+Pop-Location


### PR DESCRIPTION
## Summary
- add `scripts/build.ps1` with `$ErrorActionPreference = 'Stop'`

## Testing
- `npm test` *(fails: cannot find package 'express')*

------
https://chatgpt.com/codex/tasks/task_e_6850ca5a0fb0832fa30f88927264f187