### PR TITLE
Simplify login flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Proyecto Barack
 
-Versión actual: **356**
+Versión actual: **357**
 
 Esta es una pequeña SPA (Single Page Application) escrita en HTML, CSS y JavaScript.
 Incluye un módulo llamado *Sinóptico* para gestionar jerarquías de productos.

--- a/js/dataService.js
+++ b/js/dataService.js
@@ -51,8 +51,7 @@ if (Dexie) {
     sinoptico: 'id,parentId,nombre,orden',
   });
   db.version(2).stores({
-    sinoptico: 'id,parentId,nombre,orden',
-    users: 'id,name,role',
+    sinoptico: 'id,parentId,nombre,orden'
   });
   // migrate existing records that used numeric primary keys
   db.open()
@@ -366,8 +365,7 @@ const api = {
       db = new Dexie('ProyectoBarackDB');
       db.version(1).stores({ sinoptico: 'id,parentId,nombre,orden' });
       db.version(2).stores({
-        sinoptico: 'id,parentId,nombre,orden',
-        users: 'id,name,role',
+        sinoptico: 'id,parentId,nombre,orden'
       });
     }
     for (const key of Object.keys(memory)) delete memory[key];

--- a/js/login.js
+++ b/js/login.js
@@ -5,27 +5,19 @@ if (current) {
   location.href = 'index.html';
 }
 
-const form = document.getElementById('loginForm');
+const adminBtn = document.getElementById('adminBtn');
 const guestBtn = document.getElementById('guestBtn');
-const toggleBtn = document.getElementById('togglePass');
-const passInput = document.getElementById('loginPass');
 
-if (toggleBtn && passInput) {
-  toggleBtn.addEventListener('click', () => {
-    const isHidden = passInput.type === 'password';
-    passInput.type = isHidden ? 'text' : 'password';
-    toggleBtn.textContent = isHidden ? '🙈' : '👁️';
+if (adminBtn) {
+  adminBtn.addEventListener('click', () => {
+    saveUser({ name: 'Administrador', role: 'admin' });
+    location.href = 'index.html';
   });
 }
 
-form.addEventListener('submit', ev => {
-  ev.preventDefault();
-  const name = document.getElementById('loginUser').value.trim();
-  saveUser({ name, role: 'admin' });
-  location.href = 'index.html';
-});
-
-guestBtn.addEventListener('click', () => {
-  saveUser({ name: 'Invitado', role: 'guest' });
-  location.href = 'index.html';
-});
+if (guestBtn) {
+  guestBtn.addEventListener('click', () => {
+    saveUser({ name: 'Invitado', role: 'guest' });
+    location.href = 'index.html';
+  });
+}

--- a/js/version.js
+++ b/js/version.js
@@ -1,4 +1,4 @@
-export const version = '356';
+export const version = '357';
 export function displayVersion() {
   const div = document.createElement('div');
   div.className = 'version-info';

--- a/login.html
+++ b/login.html
@@ -14,15 +14,10 @@
 <body>
   <div class="login-container">
     <h1 class="login-title">Acceso</h1>
-    <form id="loginForm" class="login-form">
-      <input id="loginUser" type="text" required placeholder="Usuario">
-      <div class="password-wrapper">
-        <input id="loginPass" type="password" required placeholder="Contraseña">
-        <button id="togglePass" type="button" class="toggle-password" aria-label="Mostrar contraseña">👁️</button>
-      </div>
-      <button type="submit">Ingresar</button>
+    <div class="login-form">
+      <button type="button" id="adminBtn">Ingresar como administrador</button>
       <button type="button" id="guestBtn">Ingresar como invitado</button>
-    </form>
+    </div>
   </div>
   <div id="fileWarning" class="file-warning" style="display:none">
     Para utilizar la aplicación abre el archivo en un navegador moderno.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "proyecto-barack",
-  "version": "356",
-  "description": "Versión actual: **356**",
+  "version": "357",
+  "description": "Versión actual: **357**",
   "main": "index.js",
   "directories": {
     "lib": "lib"


### PR DESCRIPTION
## Summary
- drop user accounts by removing `users` table from the database
- replace login form with simple admin/guest buttons
- update login logic for new buttons
- bump version to 357

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685152dd8fcc832fafb1e3f9b4cc7661