### PR TITLE
Add data export/import buttons

### DIFF
--- a/BASE DE DATOS/README.md
+++ b/BASE DE DATOS/README.md
@@ -1,0 +1,2 @@
+Este directorio puede usarse para almacenar archivos JSON exportados con la aplicacion.
+Guarda aqui el archivo "base_datos.json" generado desde la pagina de inicio para tener siempre una copia que puedas versionar o eliminar con facilidad.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Proyecto Barack
 
-Versión actual: **357**
+Versión actual: **358**
 
 Esta es una pequeña SPA (Single Page Application) escrita en HTML, CSS y JavaScript.
 Incluye un módulo llamado *Sinóptico* para gestionar jerarquías de productos.
@@ -29,8 +29,13 @@ Los datos se guardan localmente mediante **Dexie/IndexedDB**.
 ### Exportar e importar datos
 
 Todas las vistas utilizan la misma base de datos `ProyectoBarackDB` a través del
-módulo `js/dataService.js`. Para realizar copias de seguridad manuales abre la
-consola del navegador y ejecuta lo siguiente:
+módulo `js/dataService.js`. A partir de la versión 358 puedes exportar e
+importar la información desde la página de inicio mediante dos botones. El
+archivo descargado se llama `base_datos.json` y puedes guardarlo en la carpeta
+`BASE DE DATOS` incluida en este repositorio.
+
+Para realizar copias de seguridad manuales desde la consola del navegador sigue
+si lo prefieres este procedimiento:
 
 ```js
 const json = await dataService.exportJSON();

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -797,6 +797,17 @@ body.amfe-page:not(.dark-mode) .logo {
   background-color: var(--color-accent-hover);
 }
 
+.db-actions {
+  display: flex;
+  gap: 0.5rem;
+  justify-content: center;
+  margin-top: 1rem;
+}
+.db-actions button {
+  padding: 0.5rem 1rem;
+  font-size: 1rem;
+}
+
 /* Animaciones */
 @keyframes fadeIn {
   from { opacity: 0; }

--- a/js/version.js
+++ b/js/version.js
@@ -1,4 +1,4 @@
-export const version = '357';
+export const version = '358';
 export function displayVersion() {
   const div = document.createElement('div');
   div.className = 'version-info';

--- a/js/views/home.js
+++ b/js/views/home.js
@@ -18,8 +18,36 @@ export function render(container) {
         <li>Visualización de sinóptico interactivo</li>
         <li>Modo oscuro integrado</li>
       </ul>
+      <div class="db-actions">
+        <button id="exportBtn">Exportar datos</button>
+        <button id="importBtn">Importar datos</button>
+        <input id="importFile" type="file" accept="application/json" hidden>
+      </div>
     </section>
   `;
 
-  // sin lógica adicional
+  const exportBtn = container.querySelector('#exportBtn');
+  const importBtn = container.querySelector('#importBtn');
+  const fileInput = container.querySelector('#importFile');
+
+  exportBtn.addEventListener('click', async () => {
+    const json = await window.dataService.exportJSON();
+    const blob = new Blob([json], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'base_datos.json';
+    a.click();
+    URL.revokeObjectURL(url);
+  });
+
+  importBtn.addEventListener('click', () => fileInput.click());
+  fileInput.addEventListener('change', async ev => {
+    const file = ev.target.files[0];
+    if (!file) return;
+    const text = await file.text();
+    await window.dataService.importJSON(text);
+    alert('Datos importados');
+    fileInput.value = '';
+  });
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "proyecto-barack",
-  "version": "357",
-  "description": "Versión actual: **357**",
+  "version": "358",
+  "description": "Versión actual: **358**",
   "main": "index.js",
   "directories": {
     "lib": "lib"


### PR DESCRIPTION
## Summary
- add export/import actions on home page
- update styles for new buttons
- document new workflow and bump version to 358
- store exported database files in `BASE DE DATOS`

## Testing
- `npm test` *(fails: Cannot find module 'login.test.js')*

------
https://chatgpt.com/codex/tasks/task_e_685154c24cdc832fa41f6748e586c36a