### PR TITLE
Fix guest view buttons and update version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Proyecto Barack
 
-Versión actual: **358**
+Versión actual: **359**
 
 Esta es una pequeña SPA (Single Page Application) escrita en HTML, CSS y JavaScript.
 Incluye un módulo llamado *Sinóptico* para gestionar jerarquías de productos.

--- a/js/authGuard.js
+++ b/js/authGuard.js
@@ -3,7 +3,7 @@ import { logout, isAdmin, isGuest } from './session.js';
 // guests shouldn't access certain pages directly
 const guestOnlyPages = ['sinoptico-editor.html', 'database.html', 'arbol.html'];
 if (isGuest() && guestOnlyPages.some(p => location.pathname.endsWith(p))) {
-  location.href = 'index.html#/sinoptico';
+  location.href = 'sinoptico.html';
 }
 
 function applyRoleRules() {

--- a/js/version.js
+++ b/js/version.js
@@ -1,4 +1,4 @@
-export const version = '358';
+export const version = '359';
 export function displayVersion() {
   const div = document.createElement('div');
   div.className = 'version-info';

--- a/js/views/home.js
+++ b/js/views/home.js
@@ -6,8 +6,8 @@ export function render(container) {
       <h1>Ingeniería Barack</h1>
       <p class="tagline">Soluciones modernas para tu negocio</p>
     <div class="quick-links">
-      <a href="sinoptico-editor.html" class="btn-link">Editar Sinóptico</a>
-      <a href="#/sinoptico" class="btn-link">Ver Sinóptico</a>
+      <a href="sinoptico-editor.html" class="btn-link no-guest">Editar Sinóptico</a>
+      <a href="sinoptico.html" class="btn-link">Ver Sinóptico</a>
       <a href="#/amfe" class="btn-link">AMFE</a>
     </div>
     </section>
@@ -18,7 +18,7 @@ export function render(container) {
         <li>Visualización de sinóptico interactivo</li>
         <li>Modo oscuro integrado</li>
       </ul>
-      <div class="db-actions">
+      <div class="db-actions no-guest">
         <button id="exportBtn">Exportar datos</button>
         <button id="importBtn">Importar datos</button>
         <input id="importFile" type="file" accept="application/json" hidden>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "proyecto-barack",
-  "version": "358",
-  "description": "Versión actual: **358**",
+  "version": "359",
+  "description": "Versión actual: **359**",
   "main": "index.js",
   "directories": {
     "lib": "lib"


### PR DESCRIPTION
## Summary
- hide database import/export options and Edit link when logged in as guest
- redirect guests to `sinoptico.html`
- use `sinoptico.html` for "Ver Sinóptico" links
- bump application version to 359

## Testing
- `npm test` *(fails: Cannot find module 'login.test.js')*

------
https://chatgpt.com/codex/tasks/task_e_685157a7d200832f95b43edc7d32a6b5