### PR TITLE
Add minimal Flask API

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+Flask
+flask_cors

--- a/server.py
+++ b/server.py
@@ -1,0 +1,42 @@
+import os
+import json
+from flask import Flask, request, jsonify
+from flask_cors import CORS
+
+app = Flask(__name__)
+CORS(app)
+
+DATA_FILE = os.path.join(os.path.dirname(__file__), 'BASE DE DATOS', 'base_datos.json')
+
+
+def read_data():
+    if os.path.exists(DATA_FILE):
+        with open(DATA_FILE, 'r', encoding='utf-8') as f:
+            try:
+                return json.load(f)
+            except json.JSONDecodeError:
+                return {}
+    return {}
+
+
+def write_data(data):
+    os.makedirs(os.path.dirname(DATA_FILE), exist_ok=True)
+    with open(DATA_FILE, 'w', encoding='utf-8') as f:
+        json.dump(data, f, ensure_ascii=False, indent=2)
+
+
+@app.route('/api/data', methods=['GET', 'POST'])
+def data():
+    if request.method == 'GET':
+        return jsonify(read_data())
+    else:
+        data = request.get_json(force=True, silent=True)
+        if data is None:
+            return jsonify({'error': 'Invalid JSON'}), 400
+        write_data(data)
+        return jsonify({'status': 'ok'})
+
+
+if __name__ == '__main__':
+    port = int(os.environ.get('PORT', 5000))
+    app.run(host='0.0.0.0', port=port)


### PR DESCRIPTION
## Summary
- create `server.py` with a small Flask app
- expose `/api/data` endpoint for reading and overwriting `BASE DE DATOS/base_datos.json`
- enable CORS
- document required packages in `requirements.txt`

## Testing
- `python -m py_compile server.py`
- `pip install -r requirements.txt`
- `python server.py` *(manual GET/POST with curl)*

------
https://chatgpt.com/codex/tasks/task_e_685165a87f90832fb4348332f16aca6c