### PR TITLE
Remove obsolete test script

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,9 +6,6 @@
   "directories": {
     "lib": "lib"
   },
-  "scripts": {
-    "test": "node login.test.js"
-  },
   "keywords": [],
   "author": "",
   "license": "ISC",


### PR DESCRIPTION
## Summary
- remove `scripts.test` from `package.json` since `login.test.js` doesn't exist

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685175bb1824832fa02c9a77887f8957