### PR TITLE
Serve static files via Flask

### DIFF
--- a/server.py
+++ b/server.py
@@ -1,10 +1,15 @@
 import os
 import json
-from flask import Flask, request, jsonify
+from flask import Flask, request, jsonify, send_from_directory
 from flask_cors import CORS
 
-app = Flask(__name__)
+app = Flask(__name__, static_folder='static', static_url_path='')
 CORS(app)
+
+@app.route('/', defaults={'path': 'index.html'})
+@app.route('/<path:path>')
+def static_proxy(path):
+    return send_from_directory(app.static_folder, path)
 
 DATA_FILE = os.path.join(os.path.dirname(__file__), 'BASE DE DATOS', 'base_datos.json')
 


### PR DESCRIPTION
## Summary
- serve static content via Flask by importing `send_from_directory`
- configure the Flask instance with `static_folder` and `static_url_path`
- add a root route for serving the SPA

## Testing
- `python -m py_compile server.py`
- `pip install -r requirements.txt`
- `python server.py` *(started server and served requests)*

------
https://chatgpt.com/codex/tasks/task_e_68518942f5ac832f86e53c5fd5e83e62