### PR TITLE
Implement realtime data storage with history

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 server/data.json
 data.json
+data/

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Proyecto Barack
 
-Versión actual: **361**
+Versión actual: **362**
 
 Esta es una pequeña SPA (Single Page Application) escrita en HTML, CSS y JavaScript.
 Incluye un módulo llamado *Sinóptico* para gestionar jerarquías de productos.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "proyecto-barack",
-  "version": "361",
+  "version": "362",
   "description": "Versión actual: **361**",
   "main": "index.js",
   "directories": {

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 Flask
 flask_cors
+flask_socketio

--- a/static/arbol.html
+++ b/static/arbol.html
@@ -87,6 +87,7 @@
     </div>
   </div>
   <script src="lib/dexie.min.js" defer></script>
+  <script src="/socket.io/socket.io.js" defer></script>
   <script type="module" src="js/authGuard.js"></script>
   <script type="module" src="js/dataService.js" defer></script>
   <script type="module" src="js/arbol.js" defer></script>

--- a/static/database.html
+++ b/static/database.html
@@ -113,6 +113,7 @@
     </details>
   </div>
   <script src="lib/dexie.min.js" defer></script>
+  <script src="/socket.io/socket.io.js" defer></script>
   <script type="module" src="js/authGuard.js"></script>
   <script type="module" src="js/dataService.js" defer></script>
   <script type="module" src="js/dbPage.js" defer></script>

--- a/static/index.html
+++ b/static/index.html
@@ -37,6 +37,7 @@
   </dialog>
   <script src="lib/dexie.min.js" defer></script>
   <script src="lib/fuse.min.js" defer></script>
+  <script src="/socket.io/socket.io.js" defer></script>
   <script type="module" src="js/authGuard.js"></script>
   <script type="module" src="js/router.js" defer></script>
   <script type="module" src="js/dataService.js" defer></script>

--- a/static/js/version.js
+++ b/static/js/version.js
@@ -1,4 +1,4 @@
-export const version = '361';
+export const version = '362';
 export function displayVersion() {
   const div = document.createElement('div');
   div.className = 'version-info';

--- a/static/sinoptico-editor.html
+++ b/static/sinoptico-editor.html
@@ -105,6 +105,7 @@
   </dialog>
   <script src="lib/dexie.min.js" defer></script>
   <script src="lib/fuse.min.js" defer></script>
+  <script src="/socket.io/socket.io.js" defer></script>
   <script type="module" src="js/authGuard.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/xlsx/dist/xlsx.full.min.js" defer></script>
   <script type="module" src="js/dataService.js" defer></script>

--- a/static/sinoptico.html
+++ b/static/sinoptico.html
@@ -64,6 +64,7 @@
   </div>
   <script src="lib/dexie.min.js" defer></script>
   <script src="lib/fuse.min.js" defer></script>
+  <script src="/socket.io/socket.io.js" defer></script>
   <script type="module" src="js/authGuard.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/xlsx/dist/xlsx.full.min.js" defer></script>
   <script type="module" src="js/dataService.js" defer></script>


### PR DESCRIPTION
## Summary
- add Socket.IO dependency
- persist data to `data/latest.json` with history tracking
- emit `data_updated` events when data changes
- hook frontend to realtime updates via Socket.IO
- bump app version to 362

## Testing
- `python3 -m py_compile server.py`
- `node -e "console.log('package name:', require('./package.json').name)"`
- `npm test` *(fails: Missing script)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685190d7ae88832fb7700d1438348764