### PR TITLE
Add history page with admin link

### DIFF
--- a/docs/history.html
+++ b/docs/history.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Historial</title>
+  <link rel="stylesheet" href="assets/styles.css">
+  <script>
+    if (localStorage.getItem('darkMode') === 'true') {
+      document.documentElement.classList.add('dark-mode');
+    }
+  </script>
+</head>
+<body>
+  <nav class="main-nav">
+    <a href="index.html">Inicio</a>
+    <a href="history.html" class="admin-only">Historial</a>
+    <button id="toggleDarkMode" type="button">🌙</button>
+    <button type="button" class="logout-link">Salir</button>
+  </nav>
+  <h1>Historial reciente</h1>
+  <div class="tabla-contenedor">
+    <table id="historyTable">
+      <thead>
+        <tr>
+          <th>Timestamp</th>
+          <th>IP</th>
+          <th>Resumen</th>
+        </tr>
+      </thead>
+      <tbody></tbody>
+    </table>
+  </div>
+  <script type="module" src="js/authGuard.js"></script>
+  <script type="module" src="js/history.js"></script>
+  <script type="module" src="js/ui/animations.js" defer></script>
+  <script type="module" src="js/darkMode.js" defer></script>
+  <script type="module" src="js/pageSettings.js" defer></script>
+  <script type="module" src="js/version.js" defer></script>
+</body>
+</html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -19,6 +19,7 @@
     <a href="#/amfe">AMFE</a>
     <a href="#/maestro">Listado Maestro</a>
     <a href="#/settings" class="no-guest">Ajustes</a>
+    <a href="history.html" class="admin-only">Historial</a>
     <button id="toggleDarkMode" type="button">🌙</button>
     <button type="button" class="logout-link">Salir</button>
   </nav>

--- a/docs/js/history.js
+++ b/docs/js/history.js
@@ -1,0 +1,31 @@
+'use strict';
+
+document.addEventListener('DOMContentLoaded', async () => {
+  const tbody = document.querySelector('#historyTable tbody');
+  try {
+    const resp = await fetch('/api/history');
+    if (!resp.ok) throw new Error('Request failed');
+    const data = await resp.json();
+    tbody.innerHTML = '';
+    data.slice().reverse().forEach(entry => {
+      const tr = document.createElement('tr');
+      let summary = entry.summary;
+      if (!summary && entry.changes) {
+        try {
+          summary = entry.changes.summary || JSON.stringify(entry.changes).slice(0, 60);
+        } catch {
+          summary = '';
+        }
+      }
+      tr.innerHTML =
+        `<td>${entry.timestamp || ''}</td>` +
+        `<td>${entry.ip || ''}</td>` +
+        `<td>${summary || ''}</td>`;
+      tbody.appendChild(tr);
+    });
+  } catch (e) {
+    console.error(e);
+    tbody.innerHTML = '<tr><td colspan="3">Error al cargar historial</td></tr>';
+  }
+});
+


### PR DESCRIPTION
## Summary
- create `history.html` page showing recent `/api/history` entries
- add script `history.js` to fetch and render history table
- link new page from the admin navigation in `index.html`

## Testing
- `python3 -m py_compile server.py`

------
https://chatgpt.com/codex/tasks/task_e_6851ad5887c0832f8229acbe488cb8f8