### PR TITLE
Make API URL configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Proyecto Barack
 
-Versión actual: **362**
+Versión actual: **363**
 
 Esta es una pequeña SPA (Single Page Application) escrita en HTML, CSS y JavaScript.
 Incluye un módulo llamado *Sinóptico* para gestionar jerarquías de productos.
@@ -76,7 +76,12 @@ py -3 server.py
 ```
 
 GitHub Pages solo aloja archivos estáticos y no puede ejecutar este servidor.
-Cuando uses varias PC, configura la constante `API_URL` de `js/dataService.js` con la dirección IP o dominio del equipo donde corre `server.py`.
+Cuando uses varias PC debes indicar la URL del servidor. Puedes hacerlo con:
+
+1. Guardar la dirección en `localStorage` usando `localStorage.setItem('apiUrl', 'http://<IP>:5000/api/data')` desde la consola del navegador.
+2. O bien establecer la variable de entorno `API_URL` antes de iniciar la aplicación.
+
+Si no se define ningún valor se usará `http://localhost:5000/api/data` por defecto.
 
 
 ## Desarrollo

--- a/docs/js/dataService.js
+++ b/docs/js/dataService.js
@@ -4,7 +4,25 @@
 export const DATA_CHANGED = 'DATA_CHANGED';
 const STORAGE_KEY = 'genericData';
 // URL of the backend API used to store and retrieve data
-const API_URL = 'http://192.168.1.154:5000/api/data';
+const DEFAULT_API_URL = 'http://localhost:5000/api/data';
+let API_URL = DEFAULT_API_URL;
+
+// Prefer value from localStorage
+if (typeof localStorage !== 'undefined') {
+  try {
+    const stored = localStorage.getItem('apiUrl');
+    if (stored) API_URL = stored;
+  } catch {
+    // ignore
+  }
+}
+
+// Fallback to environment variable when running under Node
+if (API_URL === DEFAULT_API_URL && typeof process !== 'undefined' && process.env) {
+  const envUrl = process.env.API_URL || process.env.apiUrl;
+  if (envUrl) API_URL = envUrl;
+}
+
 const SOCKET_URL = API_URL.replace(/\/api\/data$/, '');
 
 async function applyServerData(data) {

--- a/docs/js/version.js
+++ b/docs/js/version.js
@@ -1,4 +1,4 @@
-export const version = '362';
+export const version = '363';
 export function displayVersion() {
   const div = document.createElement('div');
   div.className = 'version-info';

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "proyecto-barack",
-  "version": "362",
-  "description": "Versión actual: **361**",
+  "version": "363",
+  "description": "Versión actual: **363**",
   "main": "index.js",
   "directories": {
     "lib": "lib"


### PR DESCRIPTION
## Summary
- read API base URL from localStorage `apiUrl` or `API_URL` env var with fallback to localhost
- document how to configure the API URL when deploying
- bump project version to 363

## Testing
- `npm test` *(fails: Missing script)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6851b00b4afc832fbe061e2f465cbff2