### PR TITLE
Update authGuard for history restriction

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ Todos los cambios en este repositorio incrementarán dicho número.
    Los administradores tienen acceso completo a "Base de Datos" y "Editar
    Sinóptico".
 4. Los datos pueden guardarse localmente en el navegador o en el servidor.
+5. La página `history.html` está reservada para administradores.
+   Los invitados son redirigidos automáticamente al abrirla.
 
 Hay tres puntos de entrada al Sinóptico: la página standalone `docs/sinoptico.html`, la vista SPA accesible desde `index.html` y el `docs/sinoptico-editor.html` para modificaciones.
 Por defecto se usa **Dexie/IndexedDB** para el almacenamiento local, pero `js/dataService.js` puede sincronizar los datos con un servidor.

--- a/docs/js/authGuard.js
+++ b/docs/js/authGuard.js
@@ -1,7 +1,7 @@
 import { logout, isAdmin, isGuest } from './session.js';
 
 // guests shouldn't access certain pages directly
-const guestOnlyPages = ['sinoptico-editor.html', 'database.html', 'arbol.html'];
+const guestOnlyPages = ['sinoptico-editor.html', 'database.html', 'arbol.html', 'history.html'];
 if (isGuest() && guestOnlyPages.some(p => location.pathname.endsWith(p))) {
   location.href = 'sinoptico.html';
 }


### PR DESCRIPTION
## Summary
- redirect guests away from `history.html`
- mention admin-only access in the documentation

## Testing
- `./format_check.sh`


------
https://chatgpt.com/codex/tasks/task_e_6851b9c5b618832fa95b27fafe4e81b5