### PR TITLE
Fix README data paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,11 +56,12 @@ Si ya conoces estas páginas, puedes trabajar solo con `docs/sinoptico-editor.ht
 - Finalmente confirma para guardar todo el árbol.
 ## Sincronización de datos
 
-Este proyecto incluye un pequeño servidor Flask (`server.py`) para almacenar la base de datos en `BASE DE DATOS/base_datos.json`.
+Este proyecto incluye un pequeño servidor Flask (`server.py`) para almacenar la base de datos en `data/latest.json`.
 A partir de esta versión el mismo script también sirve la interfaz web desde la carpeta `docs`, de modo que todas las páginas quedan disponibles en `http://<IP>:5000/` (por ejemplo, `http://192.168.1.154:5000/`).
 El servidor debe ejecutarse en un único equipo o servidor accesible por la red para que todos los usuarios compartan la misma información.
 
 El archivo activo se guarda en `data/latest.json` y cada día se crea una copia automática en `data/backups/AAAA-MM-DD.json`. Los respaldos con más de seis meses se eliminan al iniciar el servidor.
+Los respaldos se encuentran en la carpeta `data/backups/`. Si eliminas el repositorio también se borrará esta carpeta a menos que la conserves aparte.
 
 Para iniciar el servicio ejecuta:
 


### PR DESCRIPTION
## Summary
- fix outdated database path in README
- explain how backups are stored and remind users that deleting the repository removes them

## Testing
- `bash format_check.sh`


------
https://chatgpt.com/codex/tasks/task_e_6851bc279d68832f9f36c5e695206473