### PR TITLE
Allow DATA_DIR override

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ El servidor debe ejecutarse en un único equipo o servidor accesible por la red 
 El archivo activo se guarda en `data/latest.json` y cada día se crea una copia automática en `data/backups/AAAA-MM-DD.json`. Los respaldos con más de seis meses se eliminan al iniciar el servidor.
 Los respaldos se encuentran en la carpeta `data/backups/`. Si eliminas el repositorio también se borrará esta carpeta a menos que la conserves aparte.
 
+Si quieres guardar la base de datos en otra ubicación puedes definir la variable de entorno `DATA_DIR` antes de iniciar el servidor y apuntar a la carpeta deseada.
+
 Para iniciar el servicio ejecuta:
 
 ```bash

--- a/server.py
+++ b/server.py
@@ -8,7 +8,7 @@ from flask import Flask, request, jsonify, send_from_directory
 from flask_cors import CORS
 from apscheduler.schedulers.background import BackgroundScheduler
 
-DATA_DIR = "data"
+DATA_DIR = os.getenv("DATA_DIR", "data")
 DATA_FILE = os.path.join(DATA_DIR, "latest.json")
 HISTORY_FILE = os.path.join(DATA_DIR, "history.json")
 BACKUP_DIR = os.path.join(DATA_DIR, "backups")


### PR DESCRIPTION
## Summary
- let `server.py` read `DATA_DIR` from env var
- document `DATA_DIR` usage in the README

## Testing
- `./format_check.sh`

------
https://chatgpt.com/codex/tasks/task_e_6851bdd49c54832f83960a72b465b895