### PR TITLE
Add version bump script and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,15 @@ Todo se ejecuta en el navegador y no requiere servidor.
 Cada nueva versión debe incluir un número visible junto a la fecha y hora en la parte inferior derecha de la interfaz para confirmar que el cambio ha sido aplicado.
 Todos los cambios en este repositorio incrementarán dicho número.
 
+Para automatizar este proceso puedes usar `tools/bump_version.py`:
+
+```bash
+python tools/bump_version.py <nuevo-numero>
+```
+
+El script actualiza `package.json`, `package-lock.json`, `README.md` y
+`docs/js/version.js` con la versión indicada.
+
 ## Uso
 
 1. Abre `docs/login.html` en tu navegador.

--- a/tools/bump_version.py
+++ b/tools/bump_version.py
@@ -1,0 +1,53 @@
+import argparse
+import json
+import re
+from pathlib import Path
+
+
+def update_json_version(path: Path, version: str) -> None:
+    with path.open("r", encoding="utf-8") as f:
+        data = json.load(f)
+
+    data["version"] = version
+    if "packages" in data and "" in data["packages"]:
+        data["packages"][""]["version"] = version
+
+    with path.open("w", encoding="utf-8") as f:
+        json.dump(data, f, indent=2, ensure_ascii=False)
+        f.write("\n")
+
+
+def replace_line(path: Path, prefix: str, new_line: str) -> None:
+    lines = path.read_text(encoding="utf-8").splitlines()
+    for i, line in enumerate(lines):
+        if line.startswith(prefix):
+            lines[i] = new_line
+            break
+    else:
+        raise ValueError(f"'{prefix}' not found in {path}")
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def update_version_js(path: Path, version: str) -> None:
+    pattern = re.compile(r"export const version = ['\"](\d+)['\"];")
+    text = path.read_text(encoding="utf-8")
+    new_text, count = pattern.subn(f"export const version = '{version}';", text)
+    if count == 0:
+        raise ValueError(f"version declaration not found in {path}")
+    path.write_text(new_text, encoding="utf-8")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Bump project version")
+    parser.add_argument("version", help="New version number")
+    args = parser.parse_args()
+
+    version = args.version
+    update_json_version(Path("package.json"), version)
+    update_json_version(Path("package-lock.json"), version)
+    replace_line(Path("README.md"), "Versión actual:", f"Versión actual: **{version}**")
+    update_version_js(Path("docs/js/version.js"), version)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `tools/bump_version.py` for updating version numbers across the project
- document how to use the script in the README

## Testing
- `./format_check.sh`
- `black --check server.py tools/bump_version.py`


------
https://chatgpt.com/codex/tasks/task_e_6851c64cefe0832f839470ecb18c0314