### PR TITLE
Add product-based maestro module

### DIFF
--- a/docs/assets/styles.css
+++ b/docs/assets/styles.css
@@ -1474,3 +1474,40 @@ body.grid-overlay::before {
   z-index: 9999;
 }
 
+/* ===== New maestro table ===== */
+#maestro-table {
+  border-collapse: collapse;
+  width: 100%;
+}
+#maestro-table thead th {
+  background: #44546A;
+  color: #fff;
+  text-transform: uppercase;
+  position: sticky;
+  top: 0;
+}
+#maestro-table th:nth-child(1) { width: 40px; }
+#maestro-table th:nth-child(2) { width: 200px; }
+#maestro-table tbody tr:nth-child(even) { background: #F3F6F9; }
+#maestro-table tbody tr:nth-child(odd) { background: #fff; }
+.doc-link {
+  text-decoration: none;
+  position: relative;
+}
+.doc-link:hover::after {
+  content: attr(title);
+  position: absolute;
+  bottom: 100%;
+  left: 0;
+  background: #333;
+  color: #fff;
+  padding: 2px 4px;
+  font-size: 0.75rem;
+  white-space: nowrap;
+  border-radius: 3px;
+}
+
+.modal-historial table { width: 100%; border-collapse: collapse; }
+.modal-historial th, .modal-historial td { border: 1px solid #ccc; padding: 4px; }
+.modal-historial { padding: 10px; border: none; border-radius: 6px; }
+

--- a/docs/index.html
+++ b/docs/index.html
@@ -52,6 +52,7 @@
   <script type="module" src="js/newClientDialog.js" defer></script>
   <script type="module" src="js/views/home.js" defer></script>
   <script type="module" src="js/views/amfe.js" defer></script>
+  <script type="module" src="js/views/maestro.js" defer></script>
   <script type="module" src="js/views/settings.js" defer></script>
   <script type="module" src="js/version.js" defer></script>
 </body>

--- a/docs/js/dataService.js
+++ b/docs/js/dataService.js
@@ -130,6 +130,10 @@ if (Dexie) {
     maestro: 'id',
     maestroHist: 'hist_id,elemento_id'
   });
+  db.version(4).stores({
+    productos: 'producto',
+    productosHist: 'hist_id,producto'
+  });
   // migrate existing records that used numeric primary keys
   db.open()
     .then(async () => {
@@ -483,6 +487,10 @@ const api = {
       db.version(3).stores({
         maestro: 'id',
         maestroHist: 'hist_id,elemento_id'
+      });
+      db.version(4).stores({
+        productos: 'producto',
+        productosHist: 'hist_id,producto'
       });
     }
     for (const key of Object.keys(memory)) delete memory[key];

--- a/docs/js/views/maestro.js
+++ b/docs/js/views/maestro.js
@@ -1,324 +1,227 @@
-import { getAll, add, update, remove, ready } from '../dataService.js';
+import { ready, getAll, add, update, remove } from '../dataService.js';
 import { getUser } from '../session.js';
 
-let maestroData = [];
-
-// Dependencies between document types. When a document revision changes
-// the related documents listed here will be marked as pending review.
-const dependencies = {
-  'Flujograma': ['AMFE', 'Hoja de Operaciones'],
-  AMFE: [],
-  'Hoja de Operaciones': [],
-  Mylar: [],
-  Planos: [],
-  ULM: [],
-  'Ficha de Embalaje': [],
-  Tizada: []
+const DEPENDENCIES = {
+  flujograma: ['amfe', 'hojaOp'],
+  amfe: [],
+  hojaOp: [],
+  mylar: [],
+  planos: [],
+  ulm: [],
+  fichaEmb: [],
+  tizada: []
 };
 
-function formatDate(dateStr) {
-  if (!dateStr) return '';
-  try {
-    const d = new Date(dateStr);
-    return d.toLocaleDateString('es-ES');
-  } catch {
-    return dateStr;
-  }
+const DOC_KEYS = ['amfe','flujograma','hojaOp','mylar','planos','ulm','fichaEmb','tizada'];
+let productos = [];
+let historial = [];
+const SHARED_LINK = 'rutaCompartida';
+const filters = {};
+
+function crearFilaVacia(){
+  const obj = {producto:'', notificado:false};
+  for(const k of DOC_KEYS) obj[k] = '';
+  return obj;
 }
 
-function nuevaFila() {
-  return {
-    id: Date.now().toString(),
-    tipo: '',
-    nro: '',
-    codigo_producto: '',
-    revision: '',
-    link: '',
-    fecha_ultima_revision: new Date().toISOString(),
-    notificado: true
-  };
-}
-
-function crearCeldaInput(valor) {
-  const inp = document.createElement('input');
-  inp.value = valor || '';
-  return inp;
-}
-
-function renderTabla(container) {
-  const tbody = container.querySelector('#maestro tbody');
-  tbody.innerHTML = '';
-  if (!maestroData.length) {
-    const tr = document.createElement('tr');
-    tr.id = 'maestro-empty';
-    const td = document.createElement('td');
-    td.colSpan = 8;
-    td.textContent = 'No hay datos disponibles';
-    tr.appendChild(td);
-    tbody.appendChild(tr);
-    return;
-  }
-  maestroData.forEach(item => {
-    const tr = document.createElement('tr');
-    tr.dataset.id = item.id;
-    tr.innerHTML = `
-      <td>${item.notificado ? '🟢' : '🔴'}</td>
-      <td>${item.tipo || ''}</td>
-      <td>${item.nro || ''}</td>
-      <td>${item.codigo_producto || ''}</td>
-      <td>${item.revision || ''}</td>
-      <td>${formatDate(item.fecha_ultima_revision)}</td>
-      <td>${item.link ? `<a href="${item.link}" target="_blank">📂</a>` : ''}</td>
-      <td>
-        <button class="edit-row">✏️</button>
-        <button class="del-row">🗑️</button>
-        <button class="ok-row">✔</button>
-      </td>`;
-    tbody.appendChild(tr);
-  });
-}
-
-function agregarHistorial(id, campo, antes, despues) {
-  const usuario = (getUser() || {}).name || 'Admin';
-  const hasCrypto = typeof crypto !== 'undefined';
+function crearEntradaHistorial(producto,campo,antes,despues){
+  const usuario = (getUser()||{}).name || 'Anon';
   const entry = {
-    hist_id:
-      hasCrypto && crypto.randomUUID
-        ? crypto.randomUUID()
-        : Date.now().toString(),
-    elemento_id: id,
+    hist_id: (crypto&&crypto.randomUUID)? crypto.randomUUID(): Date.now().toString(),
+    producto,
     timestamp: new Date().toISOString(),
     usuario,
     campo,
     antes,
     despues
   };
-  add('maestroHist', entry);
+  historial.push(entry);
+  add('productosHist', entry);
 }
 
-// When a document revision changes, mark dependent documents of the same
-// product as pending by clearing their revision and setting notificado=false.
-async function aplicarDependencias(item, cambios) {
-  if (!cambios.revision) return;
-  const dependents = dependencies[item.tipo] || [];
-  if (!dependents.length) return;
-  for (const depTipo of dependents) {
-    const depRow = maestroData.find(
-      r => r.codigo_producto === item.codigo_producto && r.tipo === depTipo
-    );
-    if (depRow) {
-      const oldRev = depRow.revision || '';
-      if (oldRev !== '') {
-        agregarHistorial(depRow.id, 'revision', oldRev, '');
-      }
-      depRow.revision = '';
-      depRow.notificado = false;
-      await update('maestro', depRow.id, { revision: '', notificado: false });
+function aplicaDependencias(item,campo){
+  const deps = DEPENDENCIES[campo] || [];
+  for(const d of deps){
+    if(item[d]){
+      crearEntradaHistorial(item.producto,d,item[d],'');
+      item[d] = '';
     }
   }
 }
 
-async function onCellEdit(rowId, columnKey, newValue) {
-  const row = maestroData.find(r => r.id === rowId);
-  if (!row) return;
-  const oldValue = row[columnKey] || '';
-  if (oldValue === newValue) return;
-  row[columnKey] = newValue;
-  row.fecha_ultima_revision = new Date().toISOString();
-  row.notificado = false;
-  agregarHistorial(rowId, columnKey, oldValue, newValue);
-  await update('maestro', rowId, {
-    [columnKey]: newValue,
-    fecha_ultima_revision: row.fecha_ultima_revision,
-    notificado: false
-  });
-  if (columnKey === 'revision') {
-    const dependents = dependencies[row.tipo] || [];
-    for (const depTipo of dependents) {
-      const depRow = maestroData.find(
-        r => r.codigo_producto === row.codigo_producto && r.tipo === depTipo
-      );
-      if (depRow) {
-        const oldRev = depRow.revision || '';
-        if (oldRev !== '') agregarHistorial(depRow.id, 'revision', oldRev, '');
-        depRow.revision = '';
-        depRow.notificado = false;
-        await update('maestro', depRow.id, { revision: '', notificado: false });
-        refreshSemaphore(depRow.id);
-      }
-    }
+function verificarNotificado(item){
+  for(const k of DOC_KEYS){
+    if(!item[k]){ item.notificado=false; return; }
   }
-  refreshSemaphore(rowId);
+  item.notificado=true;
 }
 
-async function setNotification(rowId, state) {
-  const row = maestroData.find(r => r.id === rowId);
-  if (!row) return;
-  row.notificado = state;
-  await update('maestro', rowId, { notificado: state });
-}
-
-function refreshSemaphore(rowId) {
-  const tr = document.querySelector(`#maestro tbody tr[data-id="${rowId}"]`);
-  if (!tr) return;
-  const row = maestroData.find(r => r.id === rowId);
-  if (!row) return;
-  const cell = tr.querySelector('td');
-  if (cell) cell.textContent = row.notificado ? '🟢' : '🔴';
-}
-
-function startEdit(tr, item) {
-  if (tr.classList.contains('editing')) return;
-  tr.classList.add('editing');
-  const cells = tr.querySelectorAll('td');
-  cells[1].textContent = '';
-  const tipo = crearCeldaInput(item.tipo);
-  cells[1].appendChild(tipo);
-  cells[2].textContent = '';
-  const nro = crearCeldaInput(item.nro);
-  cells[2].appendChild(nro);
-  cells[3].textContent = '';
-  const codigo = crearCeldaInput(item.codigo_producto);
-  cells[3].appendChild(codigo);
-  cells[4].textContent = '';
-  const rev = crearCeldaInput(item.revision);
-  cells[4].appendChild(rev);
-  cells[5].textContent = '';
-  const fecha = crearCeldaInput(formatDate(item.fecha_ultima_revision));
-  cells[5].appendChild(fecha);
-  cells[6].textContent = '';
-  const link = crearCeldaInput(item.link);
-  cells[6].appendChild(link);
-  const actions = cells[7];
-  actions.innerHTML = '';
-  const save = document.createElement('button');
-  save.textContent = 'Guardar';
-  actions.appendChild(save);
-  const cancel = document.createElement('button');
-  cancel.textContent = 'Cancelar';
-  actions.appendChild(cancel);
-
-  tipo.addEventListener('change', () => onCellEdit(item.id, 'tipo', tipo.value.trim()));
-  nro.addEventListener('change', () => onCellEdit(item.id, 'nro', nro.value.trim()));
-  codigo.addEventListener('change', () => onCellEdit(item.id, 'codigo_producto', codigo.value.trim()));
-  rev.addEventListener('change', () => onCellEdit(item.id, 'revision', rev.value.trim()));
-  fecha.addEventListener('change', () => onCellEdit(item.id, 'fecha_ultima_revision', fecha.value.trim()));
-  link.addEventListener('change', () => onCellEdit(item.id, 'link', link.value.trim()));
-
-  save.addEventListener('click', () => {
-    tr.classList.remove('editing');
-    renderTabla(tr.closest('table').closest('.tabla-contenedor').parentNode);
+function renderTabla(container){
+  const tbody = container.querySelector('#maestro-table tbody');
+  tbody.innerHTML='';
+  const datos = productos.filter(row=>{
+    for(const key in filters){
+      if(filters[key] && !String(row[key]||'').toLowerCase().includes(filters[key])) return false;
+    }
+    return true;
   });
-  cancel.addEventListener('click', () => {
-    renderTabla(tr.closest('table').closest('.tabla-contenedor').parentNode);
+  datos.forEach(item=>{
+    const tr = document.createElement('tr');
+    tr.dataset.producto=item.producto;
+    tr.innerHTML = `
+      <td class="semaforo">${item.notificado?'🟢':'🔴'}</td>
+      <td class="editable" data-key="producto">${item.producto}</td>
+      ${DOC_KEYS.map(k=>`<td class="editable" data-key="${k}">${item[k]||''} <a href="${SHARED_LINK}" target="_blank" class="doc-link" title="Abrir">📂</a></td>`).join('')}
+      <td><button class="del">🗑️</button></td>`;
+    tbody.appendChild(tr);
   });
 }
 
-export async function render(container) {
-  container.innerHTML = `
+function startEdit(td){
+  const key = td.dataset.key;
+  if(!key) return;
+  const tr = td.parentElement;
+  const valor = td.textContent.trim();
+  td.innerHTML='';
+  const inp = document.createElement('input');
+  inp.value=valor;
+  td.appendChild(inp);
+  inp.focus();
+  inp.addEventListener('keydown',e=>{ if(e.key==='Enter') inp.blur(); });
+  inp.addEventListener('blur', async ()=>{
+    const nuevo = inp.value.trim();
+    const prod = tr.dataset.producto;
+    let item = productos.find(p=>p.producto===prod);
+    if(!item) return;
+    const antes = item[key] || '';
+    if(nuevo!==antes){
+      item[key]=nuevo;
+      item.notificado=false;
+      crearEntradaHistorial(item.producto,key,antes,nuevo);
+      aplicaDependencias(item,key);
+      verificarNotificado(item);
+      await update('productos', item.producto, item);
+    }
+    renderTabla(td.closest('.maestro-container'));
+  });
+}
+
+function setupEventos(container){
+  const tbody = container.querySelector('#maestro-table tbody');
+  tbody.addEventListener('dblclick',ev=>{
+    const td = ev.target.closest('td.editable');
+    if(td) startEdit(td);
+  });
+  tbody.addEventListener('click', async ev=>{
+    const btn = ev.target.closest('button.del');
+    if(!btn) return;
+    const tr = btn.closest('tr');
+    const prod = tr.dataset.producto;
+    if(confirm('¿Eliminar producto?')){
+      await remove('productos', prod);
+      productos = productos.filter(p=>p.producto!==prod);
+      renderTabla(container);
+    }
+  });
+  container.querySelector('#btnNuevo').addEventListener('click', async ()=>{
+    const row = crearFilaVacia();
+    productos.push(row);
+    await add('productos', row);
+    renderTabla(container);
+  });
+  container.querySelector('#btnExcel').addEventListener('click', exportarExcel);
+  container.querySelector('#btnHistorial').addEventListener('click',()=>{
+    mostrarHistorial(container);
+  });
+  container.querySelectorAll('thead input').forEach(inp=>{
+    inp.addEventListener('input',()=>{
+      filters[inp.dataset.key]=inp.value.toLowerCase();
+      renderTabla(container);
+    });
+  });
+}
+
+function exportarExcel(){
+  if(typeof XLSX==='undefined') return;
+  const headers = ['Producto', ...DOC_KEYS.map(k=>k.toUpperCase())];
+  const rows = productos.map(p=>[p.producto,...DOC_KEYS.map(k=>p[k])]);
+  const wb = XLSX.utils.book_new();
+  const ws = XLSX.utils.aoa_to_sheet([headers,...rows]);
+  XLSX.utils.book_append_sheet(wb, ws, 'Maestro');
+  const histHead = ['Fecha','Usuario','Producto','Campo','Antes','Después'];
+  const histRows = historial.map(h=>[new Date(h.timestamp).toLocaleString('es-ES'),h.usuario,h.producto,h.campo,h.antes,h.despues]);
+  const wsHist = XLSX.utils.aoa_to_sheet([histHead,...histRows]);
+  XLSX.utils.book_append_sheet(wb, wsHist, 'Historial');
+  XLSX.writeFile(wb,'maestro.xlsx');
+}
+
+function mostrarHistorial(container){
+  const dlg = container.querySelector('#historialDlg');
+  renderHistorial(dlg);
+  dlg.showModal();
+  dlg.querySelector('.close').addEventListener('click',()=>dlg.close());
+  dlg.querySelectorAll('input').forEach(inp=>{
+    inp.addEventListener('input',()=>renderHistorial(dlg));
+  });
+}
+
+function renderHistorial(dlg){
+  const tbody = dlg.querySelector('tbody');
+  const fDesde = dlg.querySelector('#fDesde').value;
+  const fHasta = dlg.querySelector('#fHasta').value;
+  const usuario = dlg.querySelector('#fUsuario').value.toLowerCase();
+  const prod = dlg.querySelector('#fProducto').value.toLowerCase();
+  tbody.innerHTML='';
+  historial.filter(h=>{
+    if(fDesde && h.timestamp < fDesde) return false;
+    if(fHasta && h.timestamp > fHasta+'T23:59:59') return false;
+    if(usuario && !h.usuario.toLowerCase().includes(usuario)) return false;
+    if(prod && !h.producto.toLowerCase().includes(prod)) return false;
+    return true;
+  }).forEach(h=>{
+    const tr=document.createElement('tr');
+    tr.innerHTML=`<td>${new Date(h.timestamp).toLocaleString('es-ES')}</td><td>${h.usuario}</td><td>${h.producto}</td><td>${h.campo}</td><td>${h.antes}</td><td>${h.despues}</td>`;
+    tbody.appendChild(tr);
+  });
+}
+
+export async function render(container){
+  container.innerHTML=`
     <h1>Listado Maestro</h1>
     <div class="maestro-header">
-      <button id="btnNuevoMaestro">+ Nuevo</button>
-      <button id="btnExportMaestro">Exportar Excel</button>
+      <button id="btnNuevo">+ Nuevo</button>
+      <button id="btnExcel">Exportar Excel</button>
       <button id="btnHistorial">Historial</button>
     </div>
     <div class="tabla-contenedor maestro-container">
-      <table id="maestro">
+      <table id="maestro-table">
         <thead>
           <tr>
-            <th>⚠️</th>
-            <th>Tipo</th>
-            <th>Nro</th>
-            <th>Código producto</th>
-            <th>Revisión</th>
-            <th>Fecha última revisión</th>
-            <th>Link</th>
+            <th style="width:40px">semáforo</th>
+            <th style="width:200px">Producto/Código<br><input data-key="producto" class="filtro"></th>
+            ${DOC_KEYS.map(k=>`<th>${k.toUpperCase()}<br><input data-key="${k}" class="filtro"></th>`).join('')}
             <th></th>
           </tr>
         </thead>
         <tbody></tbody>
       </table>
     </div>
-    <dialog id="historialDlg">
+    <dialog id="historialDlg" class="modal-historial">
+      <div class="filtros">
+        <input type="date" id="fDesde"> <input type="date" id="fHasta">
+        <input placeholder="Usuario" id="fUsuario">
+        <input placeholder="Producto" id="fProducto">
+        <button class="close">Cerrar</button>
+      </div>
       <table>
-        <thead>
-          <tr>
-            <th>Fecha/hora</th>
-            <th>Usuario</th>
-            <th>Tipo</th>
-            <th>Nro</th>
-            <th>Campo</th>
-            <th>Antes</th>
-            <th>Después</th>
-          </tr>
-        </thead>
-        <tbody id="historialBody"></tbody>
+        <thead><tr><th>Fecha</th><th>Usuario</th><th>Producto</th><th>Campo</th><th>Antes</th><th>Después</th></tr></thead>
+        <tbody></tbody>
       </table>
-      <button id="cerrarHistorial">Cerrar</button>
     </dialog>
   `;
   await ready;
-  maestroData = await getAll('maestro');
+  productos = await getAll('productos');
+  historial = await getAll('productosHist');
   renderTabla(container);
-
-  const tbody = container.querySelector('#maestro tbody');
-  tbody.addEventListener('click', async ev => {
-    const btn = ev.target.closest('button');
-    if (!btn) return;
-    const tr = btn.closest('tr');
-    const id = tr.dataset.id;
-    const idx = maestroData.findIndex(x => x.id === id);
-    const item = maestroData[idx];
-    if (btn.classList.contains('del-row')) {
-      if (confirm('¿Eliminar fila?')) {
-        await remove('maestro', id);
-        maestroData.splice(idx, 1);
-        renderTabla(container);
-      }
-    } else if (btn.classList.contains('edit-row')) {
-      startEdit(tr, item);
-    } else if (btn.classList.contains('ok-row')) {
-      await setNotification(id, true);
-      renderTabla(container);
-    }
-  });
-
-  container.querySelector('#btnNuevoMaestro').addEventListener('click', async () => {
-    const row = nuevaFila();
-    maestroData.push(row);
-    await add('maestro', row);
-    renderTabla(container);
-  });
-
-  container.querySelector('#btnExportMaestro').addEventListener('click', () => {
-    if (typeof XLSX === 'undefined') return;
-    const headers = Array.from(container.querySelectorAll('#maestro thead th')).map(th => th.textContent);
-    const rows = maestroData.map(r => [r.notificado ? 'OK' : 'ALERTA', r.tipo, r.nro, r.codigo_producto, r.revision, formatDate(r.fecha_ultima_revision), r.link]);
-    const wb = XLSX.utils.book_new();
-    const ws = XLSX.utils.aoa_to_sheet([headers.slice(0,7), ...rows]);
-    XLSX.utils.book_append_sheet(wb, ws, 'Maestro');
-    XLSX.writeFile(wb, 'maestro.xlsx');
-  });
-
-  const dlg = container.querySelector('#historialDlg');
-  container.querySelector('#btnHistorial').addEventListener('click', async () => {
-    const body = dlg.querySelector('#historialBody');
-    const historial = await getAll('maestroHist');
-    body.innerHTML = '';
-    historial.sort((a,b)=>new Date(a.timestamp)-new Date(b.timestamp));
-    historial.forEach(h => {
-      const tr = document.createElement('tr');
-      tr.innerHTML = `
-        <td>${new Date(h.timestamp).toLocaleString('es-ES')}</td>
-        <td>${h.usuario}</td>
-        <td>${maestroData.find(x=>x.id===h.elemento_id)?.tipo||''}</td>
-        <td>${maestroData.find(x=>x.id===h.elemento_id)?.nro||''}</td>
-        <td>${h.campo}</td>
-        <td>${h.antes}</td>
-        <td>${h.despues}</td>`;
-      body.appendChild(tr);
-    });
-    dlg.showModal();
-  });
-  dlg.querySelector('#cerrarHistorial').addEventListener('click',()=>dlg.close());
+  setupEventos(container);
 }


### PR DESCRIPTION
## Summary
- bump IndexedDB version and add stores for product documents/history
- reimplement `maestro.js` with editable table, filters and Excel export
- style maestro table with new color scheme and tooltip links
- load maestro module in home page

## Testing
- `./format_check.sh`

------
https://chatgpt.com/codex/tasks/task_e_6851fe56be14832faeb54ac20e75ad8d