### PR TITLE
Add delete confirmation dialog

### DIFF
--- a/docs/js/views/maestro.js
+++ b/docs/js/views/maestro.js
@@ -1,5 +1,6 @@
 import { getAll, add, update, remove, ready } from '../dataService.js';
 import { getUser } from '../session.js';
+import { showDeleteDialog } from './maestro_vivo.js';
 
 let maestroData = [];
 
@@ -270,7 +271,8 @@ export async function render(container) {
     const idx = maestroData.findIndex(x => x.id === id);
     const item = maestroData[idx];
     if (btn.classList.contains('del-row')) {
-      if (confirm('¿Eliminar fila?')) {
+      const ok = await showDeleteDialog();
+      if (ok) {
         await remove('maestro', id);
         maestroData.splice(idx, 1);
         renderTabla(container);

--- a/docs/js/views/maestro_vivo.js
+++ b/docs/js/views/maestro_vivo.js
@@ -1,0 +1,31 @@
+export function showDeleteDialog() {
+  let dlg = document.getElementById('dlgConfirmDelete');
+  if (!dlg) {
+    dlg = document.createElement('dialog');
+    dlg.id = 'dlgConfirmDelete';
+    dlg.className = 'modal';
+    dlg.innerHTML = `
+      <form method="dialog">
+        <p>¿Eliminar fila?</p>
+        <div class="form-actions">
+          <button type="button" id="cancelDelRow">Cancelar</button>
+          <button id="confirmDelRow" value="confirm">Eliminar</button>
+        </div>
+      </form>`;
+    document.body.appendChild(dlg);
+  }
+  return new Promise(resolve => {
+    const cancelBtn = dlg.querySelector('#cancelDelRow');
+    const confirmBtn = dlg.querySelector('#confirmDelRow');
+    const close = res => {
+      dlg.close();
+      resolve(res);
+    };
+    cancelBtn.onclick = () => close(false);
+    confirmBtn.onclick = ev => {
+      ev.preventDefault();
+      close(true);
+    };
+    dlg.showModal();
+  });
+}


### PR DESCRIPTION
## Summary
- add `showDeleteDialog` component
- use `showDeleteDialog` when deleting a row from Maestro

## Testing
- `./format_check.sh`


------
https://chatgpt.com/codex/tasks/task_e_6851fe62c4a4832f951d56987812a94f