### PR TITLE
Synchronize package description with version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "proyecto-barack",
   "version": "365",
-  "description": "Versión actual: **363**",
+  "description": "Versión actual: **365**",
   "main": "index.js",
   "directories": {
     "lib": "lib"

--- a/tools/bump_version.py
+++ b/tools/bump_version.py
@@ -9,6 +9,8 @@ def update_json_version(path: Path, version: str) -> None:
         data = json.load(f)
 
     data["version"] = version
+    if path.name == "package.json" and "description" in data:
+        data["description"] = f"Versión actual: **{version}**"
     if "packages" in data and "" in data["packages"]:
         data["packages"][""]["version"] = version
 


### PR DESCRIPTION
## Summary
- keep `package.json` description in sync with the version
- update `tools/bump_version.py` so bumping the version also updates the description

## Testing
- `bash format_check.sh`

------
https://chatgpt.com/codex/tasks/task_e_6852a118df4c832f988181129bf8f4e4