### PR TITLE
Update maestro route to use live view

### DIFF
--- a/docs/js/router.js
+++ b/docs/js/router.js
@@ -2,6 +2,7 @@ import { render as renderHome } from './views/home.js';
 import { render as renderSinoptico } from './views/sinoptico.js';
 import { render as renderAmfe } from './views/amfe.js';
 import { render as renderSettings } from './views/settings.js';
+// Use the live view implementation for the Maestro list
 import { render as renderMaestro } from './views/maestroLive.js';
 
 const routes = {


### PR DESCRIPTION
## Summary
- clarify import of `maestroLive.js` in router

## Testing
- `./format_check.sh`
- `python -m http.server 8000` *(manual request)*

------
https://chatgpt.com/codex/tasks/task_e_6852bc797560832fb5cab8a24155fc5d