### PR TITLE
Use maestroLive renderer for maestro route

### DIFF
--- a/docs/js/router.js
+++ b/docs/js/router.js
@@ -3,14 +3,14 @@ import { render as renderSinoptico } from './views/sinoptico.js';
 import { render as renderAmfe } from './views/amfe.js';
 import { render as renderSettings } from './views/settings.js';
 // Use the live view implementation for the Maestro list
-import { render as renderMaestro } from './views/maestroLive.js';
+import { render } from './views/maestroLive.js';
 
 const routes = {
   '#/home': renderHome,
   '#/sinoptico': renderSinoptico,
   '#/amfe': renderAmfe,
   '#/settings': renderSettings,
-  '#/maestro': renderMaestro,
+  '#/maestro': render,
 };
 
 const bodyClasses = {


### PR DESCRIPTION
## Summary
- swap maestro route implementation to use the `maestroLive` render function

## Testing
- `bash format_check.sh`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6852c054dc80832fb83dc85b222531b6