### PR TITLE
Enable optional HTTPS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,18 @@ py -3 -m pip install -r requirements.txt
 py -3 server.py
 ```
 
+Para habilitar HTTPS puedes crear un certificado autofirmado con:
+
+```bash
+openssl req -x509 -newkey rsa:4096 -nodes -keyout key.pem -out cert.pem -days 365
+```
+
+Luego inicia el servidor indicando las rutas en `SSL_CERT` y `SSL_KEY`:
+
+```bash
+SSL_CERT=cert.pem SSL_KEY=key.pem python server.py
+```
+
 GitHub Pages solo aloja archivos estáticos y no puede ejecutar este servidor.
 Cuando uses varias PC debes indicar la URL del servidor. Puedes hacerlo con:
 

--- a/server.py
+++ b/server.py
@@ -100,4 +100,11 @@ if __name__ == "__main__":
     scheduler.start()
 
     # Usa socketio.run para incluir WebSocket y hot-reload
-    socketio.run(app, host="0.0.0.0", port=5000, debug=True)
+    run_args = {"host": "0.0.0.0", "port": 5000, "debug": True}
+    cert = os.getenv("SSL_CERT")
+    key = os.getenv("SSL_KEY")
+    if cert and key:
+        run_args["certfile"] = cert
+        run_args["keyfile"] = key
+
+    socketio.run(app, **run_args)


### PR DESCRIPTION
## Summary
- allow SSL_CERT and SSL_KEY environment vars to enable HTTPS
- document how to generate a self-signed certificate
- explain how to start the server using SSL_CERT and SSL_KEY

## Testing
- `bash format_check.sh`
- `python -m py_compile server.py`


------
https://chatgpt.com/codex/tasks/task_e_6852c3ebf718832fa68526600e818f56