### PR TITLE
Switch maestro route to live view

### DIFF
--- a/docs/js/router.js
+++ b/docs/js/router.js
@@ -3,14 +3,14 @@ import { render as renderSinoptico } from './views/sinoptico.js';
 import { render as renderAmfe } from './views/amfe.js';
 import { render as renderSettings } from './views/settings.js';
 // Use the live view implementation for the Maestro list
-import { render } from './views/maestroLive.js';
+import { render as renderMaestro } from './views/maestroLive.js';
 
 const routes = {
   '#/home': renderHome,
   '#/sinoptico': renderSinoptico,
   '#/amfe': renderAmfe,
   '#/settings': renderSettings,
-  '#/maestro': render,
+  '#/maestro': renderMaestro,
 };
 
 const bodyClasses = {


### PR DESCRIPTION
## Summary
- update router.js to import maestroLive renderer with alias
- keep route mapping to use the alias
- confirm index.html no longer preloads maestroLive.js

## Testing
- `./format_check.sh`


------
https://chatgpt.com/codex/tasks/task_e_6852c796d510832f812d038328dba8a9