### PR TITLE
Switch maestro route to live view

### DIFF
--- a/docs/js/router.js
+++ b/docs/js/router.js
@@ -2,8 +2,8 @@ import { render as renderHome } from './views/home.js';
 import { render as renderSinoptico } from './views/sinoptico.js';
 import { render as renderAmfe } from './views/amfe.js';
 import { render as renderSettings } from './views/settings.js';
-// Use the live view implementation for the Maestro list
-import { render as renderMaestro } from './views/maestro.js';
+// Use the simplified implementation for the Maestro list
+import { render as renderMaestro } from './views/maestroLive.js';
 
 const routes = {
   '#/home': renderHome,


### PR DESCRIPTION
## Summary
- route `#/maestro` to use `maestroLive.js`

## Testing
- `./format_check.sh`


------
https://chatgpt.com/codex/tasks/task_e_6852d1335374832faf0420596b0d1783