### PR TITLE
Add manual version columns to maestro

### DIFF
--- a/docs/assets/styles.css
+++ b/docs/assets/styles.css
@@ -693,6 +693,19 @@ tr[data-level] td:first-child {
   margin-bottom: 20px;
 }
 
+.maestro-header button {
+  padding: 6px 12px;
+  background-color: var(--color-primary);
+  color: var(--color-light);
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.maestro-header button:hover {
+  background-color: var(--color-primary-hover);
+}
+
 .maestro-help {
   text-align: center;
   color: #555;


### PR DESCRIPTION
## Summary
- support per-document version columns in maestro table
- allow editing the product code and add rows without prompt
- export full maestro with versions
- style maestro header buttons so they're not grey

## Testing
- `./format_check.sh`


------
https://chatgpt.com/codex/tasks/task_e_6852dc13e854832fb2f072fd2922d8ba