### PR TITLE
Fix maestro row defaults and layout

### DIFF
--- a/docs/assets/styles.css
+++ b/docs/assets/styles.css
@@ -508,6 +508,12 @@ tr[data-level] td:first-child {
   padding: 8px;
   z-index: 1;
 }
+#maestro th.ver-col,
+#maestro td.ver-col {
+  width: 70px;
+  max-width: 70px;
+  text-align: center;
+}
 
 #maestro tbody tr:nth-child(even) {
   background-color: var(--maestro-row-alt);

--- a/docs/js/views/maestro.js
+++ b/docs/js/views/maestro.js
@@ -94,7 +94,7 @@ export function clearDependentRevisions(row, data) {
 
 function nuevaFila(codigo) {
   return {
-    id: codigo || Date.now().toString(),
+    id: codigo || '',
     flujograma: '',
     flujogramaVer: '',
     amfe: '',
@@ -186,6 +186,7 @@ function renderTabla(container) {
         td.className = 'notify-cell';
         td.textContent = row.notificado ? '🟢' : '🔴';
       } else {
+        if (col.key.endsWith('Ver')) td.classList.add('ver-col');
         td.textContent = row[col.key] || '';
       }
       tr.appendChild(td);
@@ -304,7 +305,9 @@ export async function render(container) {
       <table id="maestro">
         <thead>
           <tr>
-            ${columns.map(c => `<th>${c.label}</th>`).join('')}
+            ${columns
+              .map(c => `<th${c.key.endsWith('Ver') ? ' class="ver-col"' : ''}>${c.label}</th>`)
+              .join('')}
           </tr>
           <tr>
             ${columns
@@ -312,7 +315,8 @@ export async function render(container) {
                 if (c.key === 'notificado') {
                   return `<th><select id="filter_${c.key}" class="maestro-filter"><option value=""></option><option value="ok">🟢</option><option value="alerta">🔴</option></select></th>`;
                 }
-                return `<th><input id="filter_${c.key}" class="maestro-filter" type="text"></th>`;
+                const cls = c.key.endsWith('Ver') ? ' class="ver-col"' : '';
+                return `<th${cls}><input id="filter_${c.key}" class="maestro-filter" type="text"></th>`;
               })
               .join('')}
           </tr>


### PR DESCRIPTION
## Summary
- avoid timestamp codes in Listado Maestro by leaving new ID blank
- style version columns to be narrower

## Testing
- `./format_check.sh`
- `black --check server.py`


------
https://chatgpt.com/codex/tasks/task_e_6852df42d470832f992cc6a081f85ecf