### PR TITLE
Add hover pencil indicator for maestro table cells

### DIFF
--- a/docs/assets/styles.css
+++ b/docs/assets/styles.css
@@ -1546,3 +1546,9 @@ td[contenteditable="true"]:focus::before {
   content: '✏️ ';
 }
 
+#maestro td:not(.notify-cell):hover::after {
+  content: '✏️';
+  margin-left: 4px;
+  opacity: 0.6;
+}
+


### PR DESCRIPTION
## Summary
- show a pencil icon when hovering over Maestro table cells
- keep the existing focus styling intact

## Testing
- `./format_check.sh`


------
https://chatgpt.com/codex/tasks/task_e_6852f3155318832fa477bebe0ffedaee