### PR TITLE
Add product creation link in maestro view

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Proyecto Barack
 
-Versión actual: **370**
+Versión actual: **371**
 
 Esta es una pequeña SPA (Single Page Application) escrita en HTML, CSS y JavaScript.
 Incluye un módulo llamado *Sinóptico* para gestionar jerarquías de productos.

--- a/docs/js/version.js
+++ b/docs/js/version.js
@@ -1,4 +1,4 @@
-export const version = '370';
+export const version = '371';
 export function displayVersion() {
   const div = document.createElement('div');
   div.className = 'version-info';

--- a/docs/js/views/maestro.js
+++ b/docs/js/views/maestro.js
@@ -311,6 +311,7 @@ export async function render(container) {
     <p class="maestro-help">Doble clic en una celda para editarla</p>
     <div class="maestro-header">
       <button id="btnNuevoMaestro">Agregar documento</button>
+      <button id="btnCrearProducto">Crear producto</button>
       <button id="btnExportMaestro">Exportar Excel</button>
       <button id="btnHistorial">Historial</button>
       <input id="searchMaestro" type="text" placeholder="Buscar...">
@@ -391,6 +392,10 @@ export async function render(container) {
     await add('maestro', row);
     renderTabla(container);
     startEdit(row.id, 'id');
+  });
+
+  container.querySelector('#btnCrearProducto')?.addEventListener('click', () => {
+    location.href = 'arbol.html';
   });
 
   container.querySelector('#btnExportMaestro').addEventListener('click', async () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "proyecto-barack",
-  "version": "370",
+  "version": "371",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "proyecto-barack",
-      "version": "370",
+      "version": "371",
       "license": "ISC",
       "devDependencies": {}
     }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "proyecto-barack",
-  "version": "370",
-  "description": "Versión actual: **370**",
+  "version": "371",
+  "description": "Versión actual: **371**",
   "main": "index.js",
   "directories": {
     "lib": "lib"


### PR DESCRIPTION
## Summary
- bump to version 371
- link to product tree creation from Maestro page

## Testing
- `./format_check.sh`


------
https://chatgpt.com/codex/tasks/task_e_6852f3b29ff4832f8d761b6b2aee87a3