### PR TITLE
Move Maestro Vivo CSS to stylesheet

### DIFF
--- a/docs/assets/styles.css
+++ b/docs/assets/styles.css
@@ -1552,3 +1552,78 @@ td[contenteditable="true"]:focus::before {
   opacity: 0.6;
 }
 
+/* Maestro Vivo page */
+body {
+  font-family: sans-serif;
+  font-size: 14px;
+  margin: 20px;
+}
+
+#actions {
+  margin-bottom: 10px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+#actions input {
+  padding: 4px 8px;
+  border: 1px solid #bbb;
+  border-radius: 4px;
+}
+
+#actions button {
+  padding: 4px 8px;
+  background: #0066cc;
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+#actions button:hover {
+  background: #004c99;
+}
+
+#maestro {
+  border-collapse: collapse;
+  width: 100%;
+}
+
+#maestro th,
+#maestro td {
+  padding: 8px;
+  border: 1px solid #ccc;
+}
+
+#maestro thead th {
+  background: #44546A;
+  color: #fff;
+  text-transform: uppercase;
+}
+
+#maestro tbody tr:nth-child(even) {
+  background: #F3F6F9;
+}
+
+tr.pending td:first-child::before {
+  content: "\1F534";
+}
+
+tr:not(.pending) td:first-child::before {
+  content: "\1F7E2";
+}
+
+#historyDialog table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 14px;
+  margin-top: 10px;
+}
+
+#historyDialog th,
+#historyDialog td {
+  border: 1px solid #ccc;
+  padding: 4px 6px;
+}
+

--- a/docs/maestro_vivo.html
+++ b/docs/maestro_vivo.html
@@ -5,21 +5,6 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Listado Maestro Vivo</title>
 <link rel="stylesheet" href="assets/styles.css">
-<style>
-body{font-family:sans-serif;font-size:14px;margin:20px;}
-#actions{margin-bottom:10px;display:flex;align-items:center;gap:8px;}
-#actions input{padding:4px 8px;border:1px solid #bbb;border-radius:4px;}
-#actions button{padding:4px 8px;background:#0066cc;color:#fff;border:none;border-radius:4px;cursor:pointer;}
-#actions button:hover{background:#004c99;}
-#maestro{border-collapse:collapse;width:100%;}
-#maestro th, #maestro td{padding:8px;border:1px solid #ccc;}
-#maestro thead th{background:#44546A;color:#fff;text-transform:uppercase;}
-#maestro tbody tr:nth-child(even){background:#F3F6F9;}
-tr.pending td:first-child::before{content:"\1F534";}
-tr:not(.pending) td:first-child::before{content:"\1F7E2";}
-#historyDialog table{width:100%;border-collapse:collapse;font-size:14px;margin-top:10px;}
-#historyDialog th,#historyDialog td{border:1px solid #ccc;padding:4px 6px;}
-</style>
 </head>
 <body>
 <h1>Listado Maestro Vivo</h1>


### PR DESCRIPTION
## Summary
- shift Maestro Vivo inline style rules into global stylesheet
- keep maestro_vivo.html referencing the stylesheet

## Testing
- `bash format_check.sh`
- `w3m -dump docs/maestro_vivo.html | head`

------
https://chatgpt.com/codex/tasks/task_e_6852f824f5c8832faf03139e1784a8dd