### PR TITLE
Add editing help text to maestro_vivo

### DIFF
--- a/docs/maestro_vivo.html
+++ b/docs/maestro_vivo.html
@@ -8,6 +8,7 @@
 </head>
 <body>
 <h1>Listado Maestro Vivo</h1>
+<p class="maestro-help">Haga clic en una celda para editar. Los cambios se guardan automáticamente.</p>
 <div id="actions">
 <input id="searchInput" type="text" placeholder="Buscar...">
 <button id="addRow">+ Nuevo</button>


### PR DESCRIPTION
## Summary
- add inline editing tip under the Maestro Vivo heading

## Testing
- `bash format_check.sh`

------
https://chatgpt.com/codex/tasks/task_e_6852f8f353f0832f8f2646a9df96290c