### PR TITLE
Improve maestro table scrolling

### DIFF
--- a/docs/assets/styles.css
+++ b/docs/assets/styles.css
@@ -494,10 +494,18 @@ tr[data-level] td:first-child {
   margin: 0 auto;
 }
 
+@media (max-width: 600px) {
+  .maestro-container {
+    width: 100%;
+  }
+}
+
 
 #maestro {
   max-height: 70vh;
   overflow-y: auto;
+  overflow-x: auto;
+  display: block;
 }
 
 #maestro thead th {


### PR DESCRIPTION
## Summary
- allow horizontal scrolling for the `maestro` table
- improve responsiveness of the maestro container on small screens

## Testing
- `bash format_check.sh`


------
https://chatgpt.com/codex/tasks/task_e_6852f97332fc832fbb4bf788171dc4c5