### PR TITLE
Separate maestro viewer and editor pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ await dataService.importJSON(json); // Restaura la copia
 ```
 
 
-Si ya conoces estas páginas, puedes trabajar solo con `docs/sinoptico-editor.html` y consultar los datos desde `docs/sinoptico.html`. La SPA (`index.html`) queda como opción adicional.
+Si ya conoces estas páginas, puedes trabajar solo con `docs/sinoptico-editor.html` y consultar los datos desde `docs/sinoptico.html`. Para el listado maestro utiliza `docs/maestro_editor.html` o consulta `docs/maestro.html`. La SPA (`index.html`) queda como opción adicional.
 
 ### Crear un nuevo producto con `docs/arbol.html`
 
@@ -67,12 +67,13 @@ Si ya conoces estas páginas, puedes trabajar solo con `docs/sinoptico-editor.ht
 
 ## Listado Maestro
 
-El proyecto incluye una versión simplificada llamada **Listado Maestro Vivo**
-disponible en `docs/maestro_vivo.html`. La antigua vista con **AG‑Grid** que se
-abría desde la SPA (`index.html`) está en desuso y ya no se mantiene.
+El Listado Maestro ahora se divide en dos páginas:
+- `docs/maestro.html` muestra la tabla en modo solo lectura.
+- `docs/maestro_editor.html` permite crear y editar filas.
 
-1. Haz clic en una celda para editarla en línea.
-2. Pulsa **Ver Historial** para revisar las modificaciones realizadas.
+1. Abre `maestro_editor.html` para modificar las celdas en línea.
+2. `maestro.html` mantiene la búsqueda, el historial y la exportación sin
+   opciones de edición.
 3. Con **Exportar Excel** obtendrás un archivo `ListadoMaestro.xlsx` con los
    datos actuales y el historial.
 4. Si la versión de la aplicación cambia se vacía la tabla guardada y su

--- a/docs/index.html
+++ b/docs/index.html
@@ -17,7 +17,8 @@
     <a href="sinoptico-editor.html" class="no-guest">Editar Sinóptico</a>
     <a href="database.html" class="no-guest">Base de Datos</a>
     <a href="#/amfe">AMFE</a>
-    <a href="#/maestro">Listado Maestro</a>
+    <a href="maestro.html">Listado Maestro</a>
+    <a href="maestro_editor.html" class="no-guest">Editar Maestro</a>
     <a href="#/settings" class="no-guest">Ajustes</a>
     <a href="history.html" class="admin-only">Historial</a>
     <button id="toggleDarkMode" type="button">🌙</button>

--- a/docs/js/maestro.js
+++ b/docs/js/maestro.js
@@ -1,0 +1,73 @@
+const columns = ['producto','amfe','flujograma','hojaOp','mylar','planos','ulm','fichaEmb','tizada'];
+let data = [];
+let history = [];
+const searchInput = document.getElementById('searchInput');
+
+function load() {
+  const raw = localStorage.getItem('maestroVivo');
+  if (raw) {
+    try {
+      const obj = JSON.parse(raw);
+      data = Array.isArray(obj.data) ? obj.data : [];
+      history = Array.isArray(obj.history) ? obj.history : [];
+    } catch {}
+  }
+}
+
+function render() {
+  const tbody = document.querySelector('#maestro tbody');
+  tbody.innerHTML = '';
+  data.forEach(row => {
+    const tr = document.createElement('tr');
+    if (row.pending) tr.classList.add('pending');
+    const cells = ['', row.producto || '', row.amfe || '', row.flujograma || '', row.hojaOp || '', row.mylar || '', row.planos || '', row.ulm || '', row.fichaEmb || '', row.tizada || ''];
+    cells.forEach(val => {
+      const td = document.createElement('td');
+      td.textContent = val;
+      tr.appendChild(td);
+    });
+    tbody.appendChild(tr);
+  });
+  filterRows();
+}
+
+function exportExcel() {
+  if (typeof XLSX === 'undefined') return;
+  const headers = ['Producto / Código','AMFE','Flujograma','Hoja de Operaciones','Mylar','Planos','ULM','Ficha de Embalaje','Tizada','Estado'];
+  const rows = data.map(r => [r.producto || '', r.amfe || '', r.flujograma || '', r.hojaOp || '', r.mylar || '', r.planos || '', r.ulm || '', r.fichaEmb || '', r.tizada || '', r.pending ? 'ALERTA' : 'OK']);
+  const wb = XLSX.utils.book_new();
+  const ws = XLSX.utils.aoa_to_sheet([headers, ...rows]);
+  XLSX.utils.book_append_sheet(wb, ws, 'Maestro');
+  const histHeaders = ['Fecha/hora','Producto','Columna','Antes','Después'];
+  const histRows = history.map(h => [new Date(h.timestamp).toLocaleString('es-ES'), h.producto, h.columna, h.antes, h.despues]);
+  const wsHist = XLSX.utils.aoa_to_sheet([histHeaders, ...histRows]);
+  XLSX.utils.book_append_sheet(wb, wsHist, 'Historial');
+  XLSX.writeFile(wb, 'ListadoMaestro.xlsx');
+}
+
+function openHistory() {
+  const tbody = document.getElementById('historyBody');
+  tbody.innerHTML = '';
+  history.forEach(h => {
+    const tr = document.createElement('tr');
+    tr.innerHTML = `<td>${new Date(h.timestamp).toLocaleString('es-ES')}</td><td>${h.producto}</td><td>${h.columna}</td><td>${h.antes}</td><td>${h.despues}</td>`;
+    tbody.appendChild(tr);
+  });
+  document.getElementById('historyDialog').showModal();
+}
+
+function filterRows() {
+  const term = (searchInput.value || '').toLowerCase();
+  document.querySelectorAll('#maestro tbody tr').forEach(tr => {
+    const text = tr.textContent.toLowerCase();
+    tr.style.display = text.includes(term) ? '' : 'none';
+  });
+}
+
+document.getElementById('closeHist').onclick = () => document.getElementById('historyDialog').close();
+document.getElementById('export').onclick = exportExcel;
+document.getElementById('showHistory').onclick = openHistory;
+load();
+render();
+searchInput.addEventListener('input', filterRows);
+

--- a/docs/maestro.html
+++ b/docs/maestro.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Listado Maestro</title>
+<link rel="stylesheet" href="assets/styles.css">
+</head>
+<body>
+<h1>Listado Maestro</h1>
+<p class="maestro-help">Vista de solo lectura. Utiliza las opciones de búsqueda, historial y exportación.</p>
+<div id="actions">
+<input id="searchInput" type="text" placeholder="Buscar...">
+<button id="export">Exportar Excel</button>
+<button id="showHistory">Ver Historial</button>
+</div>
+<table id="maestro">
+<thead>
+<tr>
+<th></th>
+<th>Producto / Código</th>
+<th>AMFE</th>
+<th>Flujograma</th>
+<th>Hoja de Operaciones</th>
+<th>Mylar</th>
+<th>Planos</th>
+<th>ULM</th>
+<th>Ficha de Embalaje</th>
+<th>Tizada</th>
+</tr>
+</thead>
+<tbody></tbody>
+</table>
+<dialog id="historyDialog">
+<h3>Historial</h3>
+<table>
+<thead>
+<tr><th>Fecha/hora</th><th>Producto</th><th>Columna</th><th>Antes</th><th>Después</th></tr>
+</thead>
+<tbody id="historyBody"></tbody>
+</table>
+<div style="text-align:right;margin-top:10px;">
+<button id="closeHist">Cerrar</button>
+</div>
+</dialog>
+<script src="https://cdn.jsdelivr.net/npm/xlsx/dist/xlsx.full.min.js"></script>
+<script type="module">
+import { version } from './js/version.js';
+const stored = localStorage.getItem('maestroVivoVersion');
+if (stored !== version) {
+  localStorage.removeItem('maestroVivo');
+  localStorage.setItem('maestroVivoVersion', version);
+}
+</script>
+<script type="module" src="js/maestro.js"></script>
+<script type="module" src="js/version.js" defer></script>
+</body>
+</html>

--- a/docs/maestro_editor.html
+++ b/docs/maestro_editor.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Editar Listado Maestro</title>
+<link rel="stylesheet" href="assets/styles.css">
+</head>
+<body>
+<h1>Editar Listado Maestro</h1>
+<p class="maestro-help">Haga clic en una celda para editar. Los cambios se guardan automáticamente.</p>
+<div id="actions">
+<input id="searchInput" type="text" placeholder="Buscar...">
+<button id="addRow">+ Nuevo</button>
+<button id="export">Exportar Excel</button>
+<button id="showHistory">Ver Historial</button>
+</div>
+<table id="maestro">
+<thead>
+<tr>
+<th></th>
+<th>Producto / Código</th>
+<th>AMFE</th>
+<th>Flujograma</th>
+<th>Hoja de Operaciones</th>
+<th>Mylar</th>
+<th>Planos</th>
+<th>ULM</th>
+<th>Ficha de Embalaje</th>
+<th>Tizada</th>
+<th>Acciones</th>
+</tr>
+</thead>
+<tbody></tbody>
+</table>
+<dialog id="historyDialog">
+<h3>Historial</h3>
+<table>
+<thead>
+<tr><th>Fecha/hora</th><th>Producto</th><th>Columna</th><th>Antes</th><th>Después</th></tr>
+</thead>
+<tbody id="historyBody"></tbody>
+</table>
+<div style="text-align:right;margin-top:10px;">
+<button id="closeHist">Cerrar</button>
+</div>
+</dialog>
+<script src="https://cdn.jsdelivr.net/npm/xlsx/dist/xlsx.full.min.js"></script>
+<script type="module">
+import { version } from './js/version.js';
+const stored = localStorage.getItem('maestroVivoVersion');
+if (stored !== version) {
+  localStorage.removeItem('maestroVivo');
+  localStorage.setItem('maestroVivoVersion', version);
+}
+</script>
+<script type="module" src="js/maestro_vivo.js"></script>
+<script type="module" src="js/version.js" defer></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- duplicate `maestro_vivo.html` into `maestro_editor.html` for editing
- add a new read-only viewer `maestro.html` with corresponding script
- expose both pages from the SPA navigation
- document usage of both pages in the README

## Testing
- `bash format_check.sh`

------
https://chatgpt.com/codex/tasks/task_e_6852fc22cd44832f9cb744b20eec73cc