### PR TITLE
Centralize maestro version check

### DIFF
--- a/docs/js/maestro.js
+++ b/docs/js/maestro.js
@@ -1,7 +1,15 @@
+import { version, displayVersion } from './version.js';
+
 const columns = ['producto','amfe','flujograma','hojaOp','mylar','planos','ulm','fichaEmb','tizada'];
 let data = [];
 let history = [];
 const searchInput = document.getElementById('searchInput');
+
+const stored = localStorage.getItem('maestroVivoVersion');
+if (stored !== version) {
+  localStorage.removeItem('maestroVivo');
+  localStorage.setItem('maestroVivoVersion', version);
+}
 
 function load() {
   const raw = localStorage.getItem('maestroVivo');
@@ -70,4 +78,5 @@ document.getElementById('showHistory').onclick = openHistory;
 load();
 render();
 searchInput.addEventListener('input', filterRows);
+displayVersion();
 

--- a/docs/js/maestro_vivo.js
+++ b/docs/js/maestro_vivo.js
@@ -1,7 +1,15 @@
+import { version, displayVersion } from './version.js';
+
 const columns = ['producto','amfe','flujograma','hojaOp','mylar','planos','ulm','fichaEmb','tizada'];
 let data = [];
 let history = [];
 const searchInput = document.getElementById('searchInput');
+
+const stored = localStorage.getItem('maestroVivoVersion');
+if (stored !== version) {
+  localStorage.removeItem('maestroVivo');
+  localStorage.setItem('maestroVivoVersion', version);
+}
 
 function load() {
   const raw = localStorage.getItem('maestroVivo');
@@ -136,3 +144,4 @@ tbodyEl.addEventListener('click', handleClick);
 load();
 render();
 searchInput.addEventListener('input', filterRows);
+displayVersion();

--- a/docs/maestro.html
+++ b/docs/maestro.html
@@ -44,15 +44,6 @@
 </div>
 </dialog>
 <script src="https://cdn.jsdelivr.net/npm/xlsx/dist/xlsx.full.min.js"></script>
-<script type="module">
-import { version } from './js/version.js';
-const stored = localStorage.getItem('maestroVivoVersion');
-if (stored !== version) {
-  localStorage.removeItem('maestroVivo');
-  localStorage.setItem('maestroVivoVersion', version);
-}
-</script>
-<script type="module" src="js/maestro.js"></script>
-<script type="module" src="js/version.js" defer></script>
+<script type="module" src="js/maestro.js" defer></script>
 </body>
 </html>

--- a/docs/maestro_editor.html
+++ b/docs/maestro_editor.html
@@ -46,15 +46,6 @@
 </div>
 </dialog>
 <script src="https://cdn.jsdelivr.net/npm/xlsx/dist/xlsx.full.min.js"></script>
-<script type="module">
-import { version } from './js/version.js';
-const stored = localStorage.getItem('maestroVivoVersion');
-if (stored !== version) {
-  localStorage.removeItem('maestroVivo');
-  localStorage.setItem('maestroVivoVersion', version);
-}
-</script>
-<script type="module" src="js/maestro_vivo.js"></script>
-<script type="module" src="js/version.js" defer></script>
+<script type="module" src="js/maestro_vivo.js" defer></script>
 </body>
 </html>

--- a/docs/maestro_vivo.html
+++ b/docs/maestro_vivo.html
@@ -46,15 +46,6 @@
 </div>
 </dialog>
 <script src="https://cdn.jsdelivr.net/npm/xlsx/dist/xlsx.full.min.js"></script>
-<script type="module">
-import { version } from './js/version.js';
-const stored = localStorage.getItem('maestroVivoVersion');
-if (stored !== version) {
-  localStorage.removeItem('maestroVivo');
-  localStorage.setItem('maestroVivoVersion', version);
-}
-</script>
-<script type="module" src="js/maestro_vivo.js"></script>
-<script type="module" src="js/version.js" defer></script>
+<script type="module" src="js/maestro_vivo.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- import version utilities inside maestro modules
- perform stored version comparison in JS instead of HTML
- invoke `displayVersion()` from the modules
- simplify maestro-related HTML pages to include one script tag

## Testing
- `./format_check.sh`


------
https://chatgpt.com/codex/tasks/task_e_6852fd77c97c832f970e5f8f8d46433e