### PR TITLE
Fix product mapping in maestro_vivo

### DIFF
--- a/docs/js/maestro_vivo.js
+++ b/docs/js/maestro_vivo.js
@@ -9,7 +9,7 @@ const searchInput = document.getElementById('searchInput');
 function rowFromStore(rec = {}) {
   return {
     id: rec.id || Date.now().toString(),
-    producto: rec.id || '',
+    producto: rec.producto || '',
     amfe: rec.amfe || '',
     flujograma: rec.flujograma || '',
     hojaOp: rec.hojaOp || '',


### PR DESCRIPTION
## Summary
- read `producto` from `rec.producto` when loading maestro data

## Testing
- `bash format_check.sh`

------
https://chatgpt.com/codex/tasks/task_e_6853057ac31c832fbac4a1efa44bba6b