### PR TITLE
Fix duplicate version display

### DIFF
--- a/docs/js/maestro.js
+++ b/docs/js/maestro.js
@@ -1,4 +1,4 @@
-import { version, displayVersion } from './version.js';
+import { version } from './version.js';
 
 const columns = ['producto','amfe','flujograma','hojaOp','mylar','planos','ulm','fichaEmb','tizada'];
 let data = [];
@@ -78,5 +78,4 @@ document.getElementById('showHistory').onclick = openHistory;
 load();
 render();
 searchInput.addEventListener('input', filterRows);
-displayVersion();
 

--- a/docs/js/maestro_vivo.js
+++ b/docs/js/maestro_vivo.js
@@ -1,4 +1,4 @@
-import { version, displayVersion } from './version.js';
+import './version.js';
 import { getAll, add, update, remove, ready } from './dataService.js';
 
 const columns = ['producto','amfe','flujograma','hojaOp','mylar','planos','ulm','fichaEmb','tizada'];
@@ -191,4 +191,3 @@ tbodyEl.addEventListener('click', handleClick);
   render();
 })();
 searchInput.addEventListener('input', filterRows);
-displayVersion();


### PR DESCRIPTION
## Summary
- avoid duplicate version numbers on Maestro pages by only loading `version.js`

## Testing
- `bash format_check.sh`

------
https://chatgpt.com/codex/tasks/task_e_685306c75244832fb08ce4362f5179e8