### PR TITLE
Allow adding subproducts and supplies without product

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Proyecto Barack
 
-Versión actual: **372**
+Versión actual: **373**
 
 Esta es una pequeña SPA (Single Page Application) escrita en HTML, CSS y JavaScript.
 Incluye un módulo llamado *Sinóptico* para gestionar jerarquías de productos.

--- a/docs/js/arbol.js
+++ b/docs/js/arbol.js
@@ -128,7 +128,7 @@ document.addEventListener('DOMContentLoaded', async () => {
       const node = {
         ID: Date.now().toString() + Math.random().toString(16).slice(2),
         ParentID: parentId,
-        Tipo: 'Subcomponente',
+        Tipo: 'Subproducto',
         Descripción: sub.desc,
         Cliente: product.Cliente,
         Vehículo: '',

--- a/docs/js/newInsumoDialog.js
+++ b/docs/js/newInsumoDialog.js
@@ -1,0 +1,68 @@
+'use strict';
+import { addNode, getAll, ready } from './dataService.js';
+
+export function initNewInsumoDialog() {
+  const dialog = document.getElementById('dlgNuevoInsumo');
+  const openBtn = document.getElementById('btnNuevoInsumo');
+  if (!dialog || !openBtn) return;
+
+  const parentSelect = dialog.querySelector('#nuevoInsumoParent');
+  const unidadInput = dialog.querySelector('#nuevoInsumoUnidad');
+  const proveedorInput = dialog.querySelector('#nuevoInsumoProveedor');
+  const descInput = dialog.querySelector('#nuevoInsumoDescripcion');
+  const codeInput = dialog.querySelector('#nuevoInsumoCodigo');
+  const materialInput = dialog.querySelector('#nuevoInsumoMaterial');
+  const obsInput = dialog.querySelector('#nuevoInsumoObservaciones');
+  const origenInput = dialog.querySelector('#nuevoInsumoOrigen');
+
+  openBtn.addEventListener('click', async () => {
+    await ready;
+    if (parentSelect) {
+      const nodes = await getAll('sinoptico');
+      const padres = nodes.filter(n => n.Tipo === 'Producto' || n.Tipo === 'Subproducto');
+      parentSelect.innerHTML = padres
+        .map(p => `<option value="${p.ID}">${p.Descripción}</option>`)
+        .join('');
+    }
+    dialog.showModal();
+  });
+
+  dialog.querySelector('#cancelNuevoInsumo')?.addEventListener('click', () => dialog.close());
+
+  const form = dialog.querySelector('form');
+  form?.addEventListener('submit', async ev => {
+    ev.preventDefault();
+    const parentId = parentSelect?.value;
+    const desc = descInput?.value.trim();
+    if (!parentId || !desc) return;
+    await addNode({
+      ID: Date.now().toString(),
+      ParentID: parentId,
+      Tipo: 'Insumo',
+      Descripción: desc,
+      Cliente: '',
+      Vehículo: '',
+      RefInterno: '',
+      versión: '',
+      Imagen: '',
+      Consumo: '',
+      Unidad: unidadInput?.value.trim() || '',
+      Proveedor: proveedorInput?.value.trim() || '',
+      Material: materialInput?.value.trim() || '',
+      Observaciones: obsInput?.value.trim() || '',
+      Sourcing: origenInput?.value.trim() || '',
+      Código: codeInput?.value.trim() || ''
+    });
+    if (typeof window.mostrarMensaje === 'function') {
+      window.mostrarMensaje('Insumo creado con éxito', 'success');
+    }
+    if (form) form.reset();
+    dialog.close();
+    document.dispatchEvent(new Event('sinopticoUpdated'));
+  });
+}
+
+if (typeof window !== 'undefined') {
+  window.initNewInsumoDialog = initNewInsumoDialog;
+  document.addEventListener('DOMContentLoaded', initNewInsumoDialog);
+}

--- a/docs/js/newSubDialog.js
+++ b/docs/js/newSubDialog.js
@@ -1,0 +1,60 @@
+'use strict';
+import { addNode, getAll, ready } from './dataService.js';
+
+export function initNewSubDialog() {
+  const dialog = document.getElementById('dlgNuevoSub');
+  const openBtn = document.getElementById('btnNuevoSub');
+  if (!dialog || !openBtn) return;
+
+  const parentSelect = dialog.querySelector('#nuevoSubParent');
+  const descInput = dialog.querySelector('#nuevoSubDescripcion');
+  const codeInput = dialog.querySelector('#nuevoSubCodigo');
+
+  openBtn.addEventListener('click', async () => {
+    await ready;
+    if (parentSelect) {
+      const nodes = await getAll('sinoptico');
+      const padres = nodes.filter(n => n.Tipo === 'Producto' || n.Tipo === 'Subproducto');
+      parentSelect.innerHTML = padres
+        .map(p => `<option value="${p.ID}">${p.Descripción}</option>`)
+        .join('');
+    }
+    dialog.showModal();
+  });
+
+  dialog.querySelector('#cancelNuevoSub')?.addEventListener('click', () => dialog.close());
+
+  const form = dialog.querySelector('form');
+  form?.addEventListener('submit', async ev => {
+    ev.preventDefault();
+    const parentId = parentSelect?.value;
+    const desc = descInput?.value.trim();
+    if (!parentId || !desc) return;
+    await addNode({
+      ID: Date.now().toString(),
+      ParentID: parentId,
+      Tipo: 'Subproducto',
+      Descripción: desc,
+      Cliente: '',
+      Vehículo: '',
+      RefInterno: '',
+      versión: '',
+      Imagen: '',
+      Consumo: '',
+      Unidad: '',
+      Sourcing: '',
+      Código: codeInput?.value.trim() || ''
+    });
+    if (typeof window.mostrarMensaje === 'function') {
+      window.mostrarMensaje('Subproducto creado con éxito', 'success');
+    }
+    if (form) form.reset();
+    dialog.close();
+    document.dispatchEvent(new Event('sinopticoUpdated'));
+  });
+}
+
+if (typeof window !== 'undefined') {
+  window.initNewSubDialog = initNewSubDialog;
+  document.addEventListener('DOMContentLoaded', initNewSubDialog);
+}

--- a/docs/js/version.js
+++ b/docs/js/version.js
@@ -1,4 +1,4 @@
-export const version = '372';
+export const version = '373';
 export function displayVersion() {
   const div = document.createElement('div');
   div.className = 'version-info';

--- a/docs/sinoptico-editor.html
+++ b/docs/sinoptico-editor.html
@@ -25,6 +25,8 @@
   <div class="editor-menu">
     <button id="btnNuevoCliente">Nuevo cliente</button>
     <button id="btnNuevoProducto">Nuevo producto</button>
+    <button id="btnNuevoSub">Nuevo subproducto</button>
+    <button id="btnNuevoInsumo">Nuevo insumo</button>
     <button id="btnEliminar">Eliminar</button>
     <a id="linkArbol" href="arbol.html">Crear árbol</a>
   </div>
@@ -104,6 +106,44 @@
       </div>
     </form>
   </dialog>
+  <dialog id="dlgNuevoSub" class="modal">
+    <form method="dialog">
+      <label for="nuevoSubParent">Padre:</label>
+      <select id="nuevoSubParent" required></select>
+      <label for="nuevoSubDescripcion">Descripción del subproducto:</label>
+      <input id="nuevoSubDescripcion" type="text" required>
+      <label for="nuevoSubCodigo">Código:</label>
+      <input id="nuevoSubCodigo" type="text">
+      <div class="form-actions">
+        <button type="submit">Crear</button>
+        <button id="cancelNuevoSub" type="button">Cancelar</button>
+      </div>
+    </form>
+  </dialog>
+  <dialog id="dlgNuevoInsumo" class="modal">
+    <form method="dialog">
+      <label for="nuevoInsumoParent">Padre:</label>
+      <select id="nuevoInsumoParent" required></select>
+      <label for="nuevoInsumoUnidad">Unidad:</label>
+      <input id="nuevoInsumoUnidad" type="text">
+      <label for="nuevoInsumoProveedor">Proveedor:</label>
+      <input id="nuevoInsumoProveedor" type="text">
+      <label for="nuevoInsumoDescripcion">Descripción del insumo:</label>
+      <input id="nuevoInsumoDescripcion" type="text" required>
+      <label for="nuevoInsumoCodigo">Código:</label>
+      <input id="nuevoInsumoCodigo" type="text">
+      <label for="nuevoInsumoMaterial">Material:</label>
+      <input id="nuevoInsumoMaterial" type="text">
+      <label for="nuevoInsumoObservaciones">Observaciones:</label>
+      <input id="nuevoInsumoObservaciones" type="text">
+      <label for="nuevoInsumoOrigen">Origen:</label>
+      <input id="nuevoInsumoOrigen" type="text">
+      <div class="form-actions">
+        <button type="submit">Crear</button>
+        <button id="cancelNuevoInsumo" type="button">Cancelar</button>
+      </div>
+    </form>
+  </dialog>
   <script src="lib/dexie.min.js" defer></script>
   <script src="lib/fuse.min.js" defer></script>
   <script src="./socket.io/socket.io.js" defer></script>
@@ -119,6 +159,8 @@
   <script type="module" src="js/editorUI.js" defer></script>
   <script type="module" src="js/newClientDialog.js" defer></script>
   <script type="module" src="js/newProductDialog.js" defer></script>
+  <script type="module" src="js/newSubDialog.js" defer></script>
+  <script type="module" src="js/newInsumoDialog.js" defer></script>
   <script type="module" src="js/version.js" defer></script>
   <script>
     sessionStorage.setItem('sinopticoEdit', 'true');

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "proyecto-barack",
-  "version": "372",
+  "version": "373",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "proyecto-barack",
-      "version": "372",
+      "version": "373",
       "license": "ISC",
       "devDependencies": {}
     }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "proyecto-barack",
-  "version": "372",
-  "description": "Versión actual: **372**",
+  "version": "373",
+  "description": "Versión actual: **373**",
   "main": "index.js",
   "directories": {
     "lib": "lib"


### PR DESCRIPTION
## Summary
- bump version to 373
- support "Subproducto" instead of "Subcomponente" in `arbol.js`
- add dialogs to create subproducts and insumos standalone
- wire up new dialogs in `sinoptico-editor.html`

## Testing
- `./format_check.sh`

------
https://chatgpt.com/codex/tasks/task_e_6853613dfcf0832f8adb78d415ab4c75