### PR TITLE
Fix maestro blank screen with error overlay

### DIFF
--- a/docs/js/maestro.js
+++ b/docs/js/maestro.js
@@ -1,5 +1,23 @@
 import { version } from './version.js';
 
+function showError(msg) {
+  const div = document.createElement('div');
+  div.style.position = 'fixed';
+  div.style.top = '0';
+  div.style.left = '0';
+  div.style.right = '0';
+  div.style.background = '#fdd';
+  div.style.color = '#900';
+  div.style.padding = '10px';
+  div.style.fontFamily = 'sans-serif';
+  div.textContent = msg;
+  document.body.prepend(div);
+}
+
+window.addEventListener('error', e => {
+  showError('Error en la página: ' + e.message);
+});
+
 const columns = ['producto','amfe','flujograma','hojaOp','mylar','planos','ulm','fichaEmb','tizada'];
 let data = [];
 let history = [];

--- a/docs/js/maestro_vivo.js
+++ b/docs/js/maestro_vivo.js
@@ -1,6 +1,24 @@
 import './version.js';
 import { getAll, add, update, remove, ready } from './dataService.js';
 
+function showError(msg) {
+  const div = document.createElement('div');
+  div.style.position = 'fixed';
+  div.style.top = '0';
+  div.style.left = '0';
+  div.style.right = '0';
+  div.style.background = '#fdd';
+  div.style.color = '#900';
+  div.style.padding = '10px';
+  div.style.fontFamily = 'sans-serif';
+  div.textContent = msg;
+  document.body.prepend(div);
+}
+
+window.addEventListener('error', e => {
+  showError('Error en la página: ' + e.message);
+});
+
 const columns = ['producto','amfe','flujograma','hojaOp','mylar','planos','ulm','fichaEmb','tizada'];
 let data = [];
 let history = [];


### PR DESCRIPTION
## Summary
- add error overlay handler for maestro.js
- add error overlay handler for maestro_vivo.js

## Testing
- `./format_check.sh`

------
https://chatgpt.com/codex/tasks/task_e_68536d9cee1c832fa14047b255a86536