### PR TITLE
Add maestro listing

### DIFF
--- a/docs/js/maestro.js
+++ b/docs/js/maestro.js
@@ -1,0 +1,58 @@
+'use strict';
+import { getAll, ready } from './dataService.js';
+
+document.addEventListener('DOMContentLoaded', async () => {
+  const tbody = document.getElementById('maestroBody');
+  const search = document.getElementById('search');
+  const exportBtn = document.getElementById('exportExcel');
+
+  await ready;
+  let rows = await getAll('maestro');
+  if (!Array.isArray(rows)) rows = [];
+
+  function render() {
+    const term = search.value.trim().toLowerCase();
+    tbody.innerHTML = '';
+    rows
+      .filter(r => {
+        if (!term) return true;
+        return Object.values(r).some(v =>
+          String(v).toLowerCase().includes(term)
+        );
+      })
+      .forEach(r => {
+        const tr = document.createElement('tr');
+        tr.innerHTML = `
+          <td>${r.id || ''}</td>
+          <td>${r.flujograma || ''}</td>
+          <td>${r.amfe || ''}</td>
+          <td>${r.hojaOp || ''}</td>
+          <td>${r.mylar || ''}</td>
+          <td>${r.planos || ''}</td>
+          <td>${r.ulm || ''}</td>
+          <td>${r.fichaEmb || ''}</td>
+          <td>${r.tizada || ''}</td>
+          <td>${r.notificado ? 'Sí' : 'No'}</td>
+        `;
+        tbody.appendChild(tr);
+      });
+  }
+
+  search.addEventListener('input', render);
+
+  exportBtn?.addEventListener('click', () => {
+    if (typeof XLSX === 'undefined') return;
+    const headers = Array.from(
+      document.querySelectorAll('#maestroTable thead th')
+    ).map(th => th.textContent);
+    const data = Array.from(
+      document.querySelectorAll('#maestroTable tbody tr')
+    ).map(tr => Array.from(tr.children).map(td => td.textContent));
+    const wb = XLSX.utils.book_new();
+    const ws = XLSX.utils.aoa_to_sheet([headers, ...data]);
+    XLSX.utils.book_append_sheet(wb, ws, 'Maestro');
+    XLSX.writeFile(wb, 'maestro.xlsx');
+  });
+
+  render();
+});

--- a/docs/maestro.html
+++ b/docs/maestro.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Listado Maestro</title>
+  <link rel="stylesheet" href="assets/styles.css">
+  <script>
+    if (localStorage.getItem('darkMode') === 'true') {
+      document.documentElement.classList.add('dark-mode');
+    }
+  </script>
+</head>
+<body>
+  <nav class="main-nav">
+    <a href="index.html">Inicio</a>
+    <button id="toggleDarkMode" type="button">🌙</button>
+    <button type="button" class="logout-link">Salir</button>
+  </nav>
+  <h1>Listado Maestro</h1>
+  <div class="editor-menu">
+    <label for="search">Buscar:</label>
+    <input id="search" type="text">
+    <button id="exportExcel">Exportar Excel</button>
+  </div>
+  <div class="tabla-contenedor">
+    <table id="maestroTable" class="db-table">
+      <thead>
+        <tr>
+          <th>ID</th>
+          <th>Flujograma</th>
+          <th>AMFE</th>
+          <th>Hoja Op</th>
+          <th>Mylar</th>
+          <th>Planos</th>
+          <th>ULM</th>
+          <th>Ficha Emb.</th>
+          <th>Tizada</th>
+          <th>Notificado</th>
+        </tr>
+      </thead>
+      <tbody id="maestroBody"></tbody>
+    </table>
+  </div>
+  <script src="lib/dexie.min.js" defer></script>
+  <script src="./socket.io/socket.io.js" defer></script>
+  <script type="module" src="js/dataService.js" defer></script>
+  <script src="lib/xlsx.full.noeval.js" defer></script>
+  <script type="module" src="js/maestro.js" defer></script>
+  <script type="module" src="js/darkMode.js" defer></script>
+  <script type="module" src="js/pageSettings.js" defer></script>
+  <script type="module" src="js/version.js" defer></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a new page `maestro.html` to view the master list
- implement `maestro.js` to load data from IndexedDB and display with search
- enable Excel export using the local `xlsx.full.noeval.js`

## Testing
- `bash format_check.sh`

------
https://chatgpt.com/codex/tasks/task_e_68537467c21c832fa0e33f68ef5698ff