### PR TITLE
Add maestro SPA page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Proyecto Barack
 
-Versión actual: **373**
+Versión actual: **374**
 
 Esta es una pequeña SPA (Single Page Application) escrita en HTML, CSS y JavaScript.
 Incluye un módulo llamado *Sinóptico* para gestionar jerarquías de productos.
@@ -30,6 +30,7 @@ El script actualiza `package.json`, `package-lock.json`, `README.md` y
    distintas páginas.
    Los administradores tienen acceso completo a "Base de Datos" y "Editar
    Sinóptico".
+   También encontrarás el enlace "Listado Maestro" que abre `maestro.html`.
 4. Los datos pueden guardarse localmente en el navegador o en el servidor.
 5. La página `history.html` está reservada para administradores.
    Los invitados son redirigidos automáticamente al abrirla.

--- a/docs/index.html
+++ b/docs/index.html
@@ -17,6 +17,7 @@
     <a href="sinoptico-editor.html" class="no-guest">Editar Sinóptico</a>
     <a href="database.html" class="no-guest">Base de Datos</a>
     <a href="#/amfe">AMFE</a>
+    <a href="maestro.html">Listado Maestro</a>
     <a href="#/settings" class="no-guest">Modo Dev</a>
     <a href="history.html" class="admin-only">Historial</a>
     <button id="toggleDarkMode" type="button">🌙</button>
@@ -52,6 +53,7 @@
   <script type="module" src="js/views/home.js" defer></script>
   <script type="module" src="js/views/amfe.js" defer></script>
   <script type="module" src="js/views/settings.js" defer></script>
+  <script type="module" src="js/views/maestro.js" defer></script>
   <script type="module" src="js/version.js" defer></script>
 </body>
 </html>

--- a/docs/js/router.js
+++ b/docs/js/router.js
@@ -2,11 +2,13 @@ import { render as renderHome } from './views/home.js';
 import { render as renderSinoptico } from './views/sinoptico.js';
 import { render as renderAmfe } from './views/amfe.js';
 import { render as renderSettings } from './views/settings.js';
+import { render as renderMaestro } from './views/maestro.js';
 
 const routes = {
   '#/home': renderHome,
   '#/sinoptico': renderSinoptico,
   '#/amfe': renderAmfe,
+  '#/maestro': renderMaestro,
   '#/settings': renderSettings,
 };
 
@@ -14,6 +16,7 @@ const bodyClasses = {
   '#/home': 'home',
   '#/sinoptico': 'sinoptico-page',
   '#/amfe': 'amfe-page',
+  '#/maestro': 'maestro-page',
   '#/settings': 'settings-page',
 };
 
@@ -27,6 +30,7 @@ export function router() {
     'home',
     'sinoptico-page',
     'amfe-page',
+    'maestro-page',
     'settings-page'
   );
   const cls = bodyClasses[hash];

--- a/docs/js/version.js
+++ b/docs/js/version.js
@@ -1,4 +1,4 @@
-export const version = '373';
+export const version = '374';
 export function displayVersion() {
   const div = document.createElement('div');
   div.className = 'version-info';

--- a/docs/js/views/maestro.js
+++ b/docs/js/views/maestro.js
@@ -1,0 +1,83 @@
+import { getAll, ready } from '../dataService.js';
+
+export async function render(container) {
+  container.innerHTML = `
+    <h1>Listado Maestro</h1>
+    <div class="editor-menu">
+      <label for="search">Buscar:</label>
+      <input id="search" type="text">
+      <button id="exportExcel">Exportar Excel</button>
+    </div>
+    <div class="tabla-contenedor">
+      <table id="maestroTable" class="db-table">
+        <thead>
+          <tr>
+            <th>ID</th>
+            <th>Flujograma</th>
+            <th>AMFE</th>
+            <th>Hoja Op</th>
+            <th>Mylar</th>
+            <th>Planos</th>
+            <th>ULM</th>
+            <th>Ficha Emb.</th>
+            <th>Tizada</th>
+            <th>Notificado</th>
+          </tr>
+        </thead>
+        <tbody id="maestroBody"></tbody>
+      </table>
+    </div>
+  `;
+
+  const tbody = container.querySelector('#maestroBody');
+  const search = container.querySelector('#search');
+  const exportBtn = container.querySelector('#exportExcel');
+
+  await ready;
+  let rows = await getAll('maestro');
+  if (!Array.isArray(rows)) rows = [];
+
+  function renderRows() {
+    const term = search.value.trim().toLowerCase();
+    tbody.innerHTML = '';
+    rows
+      .filter(r => {
+        if (!term) return true;
+        return Object.values(r).some(v => String(v).toLowerCase().includes(term));
+      })
+      .forEach(r => {
+        const tr = document.createElement('tr');
+        tr.innerHTML = `
+          <td>${r.id || ''}</td>
+          <td>${r.flujograma || ''}</td>
+          <td>${r.amfe || ''}</td>
+          <td>${r.hojaOp || ''}</td>
+          <td>${r.mylar || ''}</td>
+          <td>${r.planos || ''}</td>
+          <td>${r.ulm || ''}</td>
+          <td>${r.fichaEmb || ''}</td>
+          <td>${r.tizada || ''}</td>
+          <td>${r.notificado ? 'Sí' : 'No'}</td>
+        `;
+        tbody.appendChild(tr);
+      });
+  }
+
+  search.addEventListener('input', renderRows);
+
+  exportBtn?.addEventListener('click', () => {
+    if (typeof XLSX === 'undefined') return;
+    const headers = Array.from(
+      container.querySelectorAll('#maestroTable thead th')
+    ).map(th => th.textContent);
+    const data = Array.from(
+      container.querySelectorAll('#maestroTable tbody tr')
+    ).map(tr => Array.from(tr.children).map(td => td.textContent));
+    const wb = XLSX.utils.book_new();
+    const ws = XLSX.utils.aoa_to_sheet([headers, ...data]);
+    XLSX.utils.book_append_sheet(wb, ws, 'Maestro');
+    XLSX.writeFile(wb, 'maestro.xlsx');
+  });
+
+  renderRows();
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "proyecto-barack",
-  "version": "373",
+  "version": "374",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "proyecto-barack",
-      "version": "373",
+      "version": "374",
       "license": "ISC",
       "devDependencies": {}
     }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "proyecto-barack",
-  "version": "373",
-  "description": "Versión actual: **373**",
+  "version": "374",
+  "description": "Versión actual: **374**",
   "main": "index.js",
   "directories": {
     "lib": "lib"


### PR DESCRIPTION
## Summary
- document `maestro.html` in README
- link to the new page from `index.html`
- implement SPA view for maestro and route `/maestro`
- bump version to 374

## Testing
- `./format_check.sh`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6853753a2bec832fad7243572b698ac5