### PR TITLE
Update sinoptico-editor and version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Proyecto Barack
 
-Versión actual: **375**
+Versión actual: **376**
 
 Esta es una pequeña SPA (Single Page Application) escrita en HTML, CSS y JavaScript.
 Incluye un módulo llamado *Sinóptico* para gestionar jerarquías de productos.

--- a/docs/js/version.js
+++ b/docs/js/version.js
@@ -1,4 +1,4 @@
-export const version = '375';
+export const version = '376';
 export function displayVersion() {
   const div = document.createElement('div');
   div.className = 'version-info';

--- a/docs/sinoptico-editor.html
+++ b/docs/sinoptico-editor.html
@@ -144,11 +144,25 @@
       </div>
     </form>
   </dialog>
+  <div id="fileWarning" class="file-warning" style="display:none">
+    Para utilizar la aplicación abre el archivo en un navegador moderno.
+  </div>
+  <script>
+    if (location.protocol === 'file:') {
+      document.getElementById('fileWarning').style.display = 'block';
+    }
+  </script>
+  <noscript>
+    <p class="noscript-warning">
+      Esta página necesita JavaScript para funcionar. Si la estás viendo desde
+      GitHub, descárgala y ábrela localmente con un navegador.
+    </p>
+  </noscript>
   <script src="lib/dexie.min.js" defer></script>
   <script src="lib/fuse.min.js" defer></script>
   <script src="./socket.io/socket.io.js" defer></script>
   <script type="module" src="js/authGuard.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/xlsx/dist/xlsx.full.min.js" defer></script>
+  <script src="lib/xlsx.full.noeval.js" defer></script>
   <script type="module" src="js/dataService.js" defer></script>
   <script type="module" src="js/views/sinoptico.js" defer></script>
   <script type="module" src="js/ui/renderer.js" defer></script>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "proyecto-barack",
-  "version": "375",
+  "version": "376",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "proyecto-barack",
-      "version": "375",
+      "version": "376",
       "license": "ISC",
       "devDependencies": {}
     }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "proyecto-barack",
-  "version": "375",
-  "description": "Versión actual: **375**",
+  "version": "376",
+  "description": "Versión actual: **376**",
   "main": "index.js",
   "directories": {
     "lib": "lib"


### PR DESCRIPTION
## Summary
- load xlsx from local bundle in `sinoptico-editor.html`
- display a warning when loaded using the file protocol
- show a noscript notice when JavaScript is disabled
- bump version to 376

## Testing
- `./format_check.sh`

------
https://chatgpt.com/codex/tasks/task_e_6853e3ec0f1c832f937ba51b4537e07a