### PR TITLE
Add admin-only editor sinoptico page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Proyecto Barack
 
-Versión actual: **376**
+Versión actual: **377**
 
 Esta es una pequeña SPA (Single Page Application) escrita en HTML, CSS y JavaScript.
 Incluye un módulo llamado *Sinóptico* para gestionar jerarquías de productos.

--- a/docs/arbol.html
+++ b/docs/arbol.html
@@ -14,7 +14,7 @@
 <body>
   <nav class="main-nav">
     <a href="index.html">Inicio</a>
-    <a href="sinoptico-editor.html" class="no-guest">Editor Sinóptico</a>
+    <a href="editar-sinoptico.html" class="admin-only">Editor Sinóptico</a>
     <button id="toggleDarkMode" type="button">🌙</button>
     <button type="button" class="logout-link">Salir</button>
   </nav>

--- a/docs/assets/styles.css
+++ b/docs/assets/styles.css
@@ -1660,3 +1660,9 @@ tr:not(.pending) td:first-child::before {
   padding: 4px 6px;
 }
 
+
+.steps-container{display:flex;flex-direction:column;gap:6px;margin-top:12px;}
+.step-row{display:flex;gap:4px;align-items:center;}
+.step-row input[type="number"]{width:60px;}
+.step-row button{padding:2px 6px;border:none;border-radius:4px;background:var(--color-accent);color:var(--color-light);cursor:pointer;}
+.step-row button:hover{background:var(--color-accent-hover);}

--- a/docs/database.html
+++ b/docs/database.html
@@ -15,7 +15,7 @@
   <nav class="main-nav">
     <a href="index.html">Inicio</a>
     <a href="sinoptico.html">Sinóptico</a>
-    <a href="sinoptico-editor.html" class="no-guest">Editor</a>
+    <a href="editar-sinoptico.html" class="admin-only">Editor</a>
     <button id="toggleDarkMode" type="button">🌙</button>
     <button type="button" class="logout-link">Salir</button>
   </nav>

--- a/docs/editar-sinoptico.html
+++ b/docs/editar-sinoptico.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Editor Sinóptico</title>
+  <link rel="stylesheet" href="assets/styles.css">
+  <script>
+    if (localStorage.getItem('darkMode') === 'true') {
+      document.documentElement.classList.add('dark-mode');
+    }
+  </script>
+</head>
+<body>
+  <nav class="main-nav">
+    <a href="index.html">Inicio</a>
+    <button id="toggleDarkMode" type="button">🌙</button>
+    <button type="button" class="logout-link">Salir</button>
+  </nav>
+  <h1 class="editor-title">Editor Sinóptico</h1>
+  <div class="editor-menu">
+    <label for="productSelector">Producto:</label>
+    <select id="productSelector"></select>
+    <button id="addStep" type="button">Agregar paso</button>
+  </div>
+  <div id="stepsContainer" class="steps-container"></div>
+  <button id="saveBtn" type="button">Guardar</button>
+  <div id="fileWarning" class="file-warning" style="display:none">
+    Para utilizar la aplicación abre el archivo en un navegador moderno.
+  </div>
+  <script>
+    if (location.protocol === 'file:') {
+      document.getElementById('fileWarning').style.display = 'block';
+    }
+  </script>
+  <noscript>
+    <p class="noscript-warning">
+      Esta página necesita JavaScript para funcionar. Si la estás viendo desde GitHub, descárgala y ábrela localmente con un navegador.
+    </p>
+  </noscript>
+  <script type="module" src="js/authGuard.js"></script>
+  <script type="module" src="js/dataService.js"></script>
+  <script type="module" src="js/editarSinoptico.js"></script>
+  <script type="module" src="js/darkMode.js"></script>
+  <script type="module" src="js/pageSettings.js"></script>
+  <script type="module" src="js/version.js"></script>
+</body>
+</html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -14,7 +14,7 @@
 <body>
   <nav class="main-nav">
     <a href="#/home">Inicio</a>
-    <a href="sinoptico-editor.html" class="no-guest">Editar Sinóptico</a>
+    <a href="editar-sinoptico.html" class="admin-only">Editor Sinóptico</a>
     <a href="database.html" class="no-guest">Base de Datos</a>
     <a href="#/amfe">AMFE</a>
     <a href="maestro.html">Listado Maestro</a>

--- a/docs/js/arbol.js
+++ b/docs/js/arbol.js
@@ -184,7 +184,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     );
     await persist(product, [], []);
     if (window.mostrarMensaje) window.mostrarMensaje('Producto creado con éxito', 'success');
-    window.location.href = 'sinoptico-editor.html';
+    window.location.href = 'editar-sinoptico.html';
   });
 
   continueBtn?.addEventListener('click', () => {
@@ -311,6 +311,6 @@ document.addEventListener('DOMContentLoaded', async () => {
     );
     await persist(product, subcomponents, insumos);
     if (window.mostrarMensaje) window.mostrarMensaje('Árbol creado con éxito', 'success');
-    window.location.href = 'sinoptico-editor.html';
+    window.location.href = 'editar-sinoptico.html';
   });
 });

--- a/docs/js/authGuard.js
+++ b/docs/js/authGuard.js
@@ -6,6 +6,12 @@ if (isGuest() && guestOnlyPages.some(p => location.pathname.endsWith(p))) {
   location.href = 'sinoptico.html';
 }
 
+// pages reserved only for administrators
+const adminPages = ['editar-sinoptico.html'];
+if (!isAdmin() && adminPages.some(p => location.pathname.endsWith(p))) {
+  location.href = 'index.html';
+}
+
 function applyRoleRules() {
   if (isGuest()) {
     document.querySelectorAll('.no-guest').forEach(el => el.style.display = 'none');

--- a/docs/js/editarSinoptico.js
+++ b/docs/js/editarSinoptico.js
@@ -1,0 +1,135 @@
+import { getAll } from './dataService.js';
+import { isAdmin } from './session.js';
+
+if (!isAdmin()) {
+  location.href = 'index.html';
+}
+
+const selector = document.getElementById('productSelector');
+const stepsContainer = document.getElementById('stepsContainer');
+const addBtn = document.getElementById('addStep');
+const saveBtn = document.getElementById('saveBtn');
+
+let currentId = '';
+let currentSteps = [];
+
+function loadFromStorage() {
+  try {
+    return JSON.parse(localStorage.getItem('sinopticoPasos') || '{}');
+  } catch {
+    return {};
+  }
+}
+
+function saveToStorage(obj) {
+  localStorage.setItem('sinopticoPasos', JSON.stringify(obj));
+}
+
+function fetchSinoptico(productoId) {
+  const all = loadFromStorage();
+  return Array.isArray(all[productoId]) ? all[productoId] : [];
+}
+
+function saveSinoptico(productoId, data) {
+  const all = loadFromStorage();
+  all[productoId] = Array.isArray(data) ? data : [];
+  saveToStorage(all);
+}
+
+function registrarHistorial(entry) {
+  const hist = JSON.parse(localStorage.getItem('sinopticoHist') || '[]');
+  hist.push({ ...entry, timestamp: new Date().toISOString() });
+  localStorage.setItem('sinopticoHist', JSON.stringify(hist));
+}
+
+function renderSteps() {
+  stepsContainer.innerHTML = '';
+  currentSteps
+    .sort((a, b) => a.orden - b.orden)
+    .forEach((step, idx) => {
+      const row = document.createElement('div');
+      row.className = 'step-row';
+      row.innerHTML = `
+        <input type="number" class="orden" value="${step.orden}" />
+        <input type="text" class="nombre" placeholder="Nombre" value="${
+          step.nombre || ''
+        }">
+        <input type="text" class="descripcion" placeholder="Descripción" value="${
+          step.descripcion || ''
+        }">
+        <input type="text" class="tipo" placeholder="Tipo" value="${
+          step.tipo || ''
+        }">
+        <input type="text" class="link" placeholder="Link" value="${
+          step.link || ''
+        }">
+        <button class="up" type="button">↑</button>
+        <button class="down" type="button">↓</button>
+        <button class="del" type="button">🗑</button>
+      `;
+      stepsContainer.appendChild(row);
+      row.querySelector('.up').addEventListener('click', () => {
+        if (idx === 0) return;
+        [currentSteps[idx - 1], currentSteps[idx]] = [
+          currentSteps[idx],
+          currentSteps[idx - 1],
+        ];
+        renderSteps();
+      });
+      row.querySelector('.down').addEventListener('click', () => {
+        if (idx === currentSteps.length - 1) return;
+        [currentSteps[idx + 1], currentSteps[idx]] = [
+          currentSteps[idx],
+          currentSteps[idx + 1],
+        ];
+        renderSteps();
+      });
+      row.querySelector('.del').addEventListener('click', () => {
+        currentSteps.splice(idx, 1);
+        renderSteps();
+      });
+    });
+}
+
+addBtn.addEventListener('click', () => {
+  const next = currentSteps.length + 1;
+  currentSteps.push({
+    orden: next,
+    nombre: '',
+    descripcion: '',
+    tipo: '',
+    link: '',
+  });
+  renderSteps();
+});
+
+selector.addEventListener('change', async () => {
+  currentId = selector.value;
+  currentSteps = fetchSinoptico(currentId).slice();
+  renderSteps();
+});
+
+saveBtn.addEventListener('click', () => {
+  currentSteps = Array.from(stepsContainer.children).map((row, i) => ({
+    orden: parseInt(row.querySelector('.orden').value, 10) || i + 1,
+    nombre: row.querySelector('.nombre').value,
+    descripcion: row.querySelector('.descripcion').value,
+    tipo: row.querySelector('.tipo').value,
+    link: row.querySelector('.link').value,
+  }));
+  saveSinoptico(currentId, currentSteps);
+  registrarHistorial({ productoId: currentId });
+  alert('Sinóptico guardado');
+});
+
+(async function loadProducts() {
+  const data = await getAll('sinoptico');
+  const productos = Array.isArray(data)
+    ? data.filter(n => n.Tipo === 'Pieza final' || n.Tipo === 'Producto')
+    : [];
+  selector.innerHTML =
+    '<option value="">Seleccione…</option>' +
+    productos
+      .map(p => `<option value="${p.ID}">${p.Descripcion || p.Descripción}</option>`)
+      .join('');
+})();

--- a/docs/js/version.js
+++ b/docs/js/version.js
@@ -1,4 +1,4 @@
-export const version = '376';
+export const version = '377';
 export function displayVersion() {
   const div = document.createElement('div');
   div.className = 'version-info';

--- a/docs/js/views/home.js
+++ b/docs/js/views/home.js
@@ -8,7 +8,7 @@ export function render(container) {
     </section>
     <section class="home-menu">
       <div class="menu-grid">
-        <a href="sinoptico-editor.html" class="menu-item no-guest">Editar Sinóptico</a>
+        <a href="editar-sinoptico.html" class="menu-item admin-only">Editor Sinóptico</a>
         <a href="sinoptico.html" class="menu-item">Ver Sinóptico</a>
         <a href="#/amfe" class="menu-item">AMFE</a>
         <a href="maestro.html" class="menu-item">Listado Maestro</a>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "proyecto-barack",
-  "version": "376",
+  "version": "377",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "proyecto-barack",
-      "version": "376",
+      "version": "377",
       "license": "ISC",
       "devDependencies": {}
     }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "proyecto-barack",
-  "version": "376",
-  "description": "Versión actual: **376**",
+  "version": "377",
+  "description": "Versión actual: **377**",
   "main": "index.js",
   "directories": {
     "lib": "lib"


### PR DESCRIPTION
## Summary
- add new Editor Sinóptico page for admins at `/editar-sinoptico`
- implement client-side editor logic in `editarSinoptico.js`
- restrict page via `authGuard`
- update links to point to the new editor
- style step editor
- bump version to 377

## Testing
- `./format_check.sh`

------
https://chatgpt.com/codex/tasks/task_e_6853ebdfde28832fb1d9c0437d474dd1