### PR TITLE
Fix Sinoptico edit toggle

### DIFF
--- a/docs/js/ui/renderer.js
+++ b/docs/js/ui/renderer.js
@@ -372,5 +372,8 @@ document.addEventListener('DOMContentLoaded', () => {
 
   loadData();
 
+  // refresh view when edit mode toggles
+  document.addEventListener('sinoptico-mode', loadData);
+
   if(dataService.subscribeToChanges) dataService.subscribeToChanges(loadData);
 });


### PR DESCRIPTION
## Summary
- refresh sinoptico table when toggling edit mode

## Testing
- `bash format_check.sh`


------
https://chatgpt.com/codex/tasks/task_e_6853ef592600832f911e27eaa7b6e3b2