### PR TITLE
Implement DB_PATH for backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 server/data.json
 data.json
 data/
+data/db.sqlite

--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ Los respaldos se encuentran en la carpeta `data/backups/`. Si eliminas el reposi
 
 Si quieres guardar la base de datos en otra ubicación puedes definir la variable de entorno `DATA_DIR` antes de iniciar el servidor y apuntar a la carpeta deseada.
 
+El backend basado en SQLite (`backend/main.py`) lee la ruta del archivo desde `DB_PATH`. Si no se define, usará `data/db.sqlite`.
+
 Para iniciar el servicio ejecuta:
 
 ```bash

--- a/backend/main.py
+++ b/backend/main.py
@@ -7,7 +7,7 @@ from flask import Flask, request, jsonify, Response
 from flask_cors import CORS
 from flask_socketio import SocketIO
 
-DB_PATH = os.getenv("DATA_PATH", os.path.join("data", "db.sqlite"))
+DB_PATH = os.getenv("DB_PATH", os.path.join("data", "db.sqlite"))
 os.makedirs(os.path.dirname(DB_PATH), exist_ok=True)
 
 app = Flask(__name__)


### PR DESCRIPTION
## Summary
- read SQLite path from `DB_PATH` in `backend/main.py`
- mention `DB_PATH` in the README
- ensure `data/db.sqlite` is ignored

## Testing
- `./format_check.sh`

------
https://chatgpt.com/codex/tasks/task_e_6853f86bb1d8832f962a497b5f27d0db