### PR TITLE
Add export endpoints for Excel/PDF

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ flask_cors
 flask_socketio>=5.0.0
 eventlet>=0.33.0
 APScheduler
+xlsxwriter
+reportlab


### PR DESCRIPTION
## Summary
- add export routes to `server.py` and `backend/main.py`
- generate Excel or PDF from current data using xlsxwriter and reportlab
- include new dependencies

## Testing
- `sh format_check.sh`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_6854011b0500832f9c4382819f961d70