### PR TITLE
Centralize navigation markup

### DIFF
--- a/docs/arbol.html
+++ b/docs/arbol.html
@@ -12,12 +12,7 @@
   </script>
 </head>
 <body>
-  <nav class="main-nav">
-    <a href="index.html">Inicio</a>
-    <a href="sinoptico-editor.html" class="no-guest">Editor Sinóptico</a>
-    <button id="toggleDarkMode" type="button">🌙</button>
-    <button type="button" class="logout-link">Salir</button>
-  </nav>
+  <div id="nav-placeholder"></div>
   <div id="loading"></div>
   <div id="appMessage" role="alert" aria-live="polite"></div>
   <div id="step1" class="node-form">
@@ -89,6 +84,7 @@
   <script src="lib/dexie.min.js" defer></script>
   <script src="./socket.io/socket.io.js" defer></script>
   <script type="module" src="js/authGuard.js"></script>
+  <script type="module" src="js/nav.js" defer></script>
   <script type="module" src="js/dataService.js" defer></script>
   <script type="module" src="js/arbol.js" defer></script>
   <script type="module" src="js/ui/animations.js" defer></script>

--- a/docs/database.html
+++ b/docs/database.html
@@ -12,13 +12,7 @@
   </script>
 </head>
 <body>
-  <nav class="main-nav">
-    <a href="index.html">Inicio</a>
-    <a href="sinoptico.html">Sinóptico</a>
-    <a href="sinoptico-editor.html" class="no-guest">Editor</a>
-    <button id="toggleDarkMode" type="button">🌙</button>
-    <button type="button" class="logout-link">Salir</button>
-  </nav>
+  <div id="nav-placeholder"></div>
   <header class="editor-header">
     <h1 class="editor-title">Base de Datos</h1>
   </header>
@@ -115,6 +109,7 @@
   <script src="lib/dexie.min.js" defer></script>
   <script src="./socket.io/socket.io.js" defer></script>
   <script type="module" src="js/authGuard.js"></script>
+  <script type="module" src="js/nav.js" defer></script>
   <script type="module" src="js/dataService.js" defer></script>
   <script type="module" src="js/dbPage.js" defer></script>
   <script type="module" src="js/ui/animations.js" defer></script>

--- a/docs/history.html
+++ b/docs/history.html
@@ -12,12 +12,7 @@
   </script>
 </head>
 <body>
-  <nav class="main-nav">
-    <a href="index.html">Inicio</a>
-    <a href="history.html" class="admin-only">Historial</a>
-    <button id="toggleDarkMode" type="button">🌙</button>
-    <button type="button" class="logout-link">Salir</button>
-  </nav>
+  <div id="nav-placeholder"></div>
   <h1>Historial reciente</h1>
   <div class="tabla-contenedor">
     <table id="historyTable">
@@ -32,6 +27,7 @@
     </table>
   </div>
   <script type="module" src="js/authGuard.js"></script>
+  <script type="module" src="js/nav.js" defer></script>
   <script type="module" src="js/history.js"></script>
   <script type="module" src="js/ui/animations.js" defer></script>
   <script type="module" src="js/darkMode.js" defer></script>

--- a/docs/index.html
+++ b/docs/index.html
@@ -12,17 +12,7 @@
   </script>
 </head>
 <body>
-  <nav class="main-nav">
-    <a href="#/home">Inicio</a>
-    <a href="sinoptico-editor.html" class="no-guest">Editar Sinóptico</a>
-    <a href="database.html" class="no-guest">Base de Datos</a>
-    <a href="#/amfe">AMFE</a>
-    <a href="maestro.html">Listado Maestro</a>
-    <a href="#/settings" class="no-guest">Modo Dev</a>
-    <a href="history.html" class="admin-only">Historial</a>
-    <button id="toggleDarkMode" type="button">🌙</button>
-    <button type="button" class="logout-link">Salir</button>
-  </nav>
+  <div id="nav-placeholder"></div>
   <div id="loading"></div>
   <div id="appMessage" role="alert" aria-live="polite"></div>
   <div id="app">Cargando…</div>
@@ -40,6 +30,7 @@
   <script src="lib/fuse.min.js" defer></script>
   <script src="./socket.io/socket.io.js" defer></script>
   <script type="module" src="js/authGuard.js"></script>
+  <script type="module" src="js/nav.js" defer></script>
   <script type="module" src="js/router.js" defer></script>
   <script type="module" src="js/dataService.js" defer></script>
   <script src="https://cdn.jsdelivr.net/npm/xlsx/dist/xlsx.full.min.js" defer></script>

--- a/docs/js/nav.js
+++ b/docs/js/nav.js
@@ -1,0 +1,19 @@
+export async function loadNav() {
+  const placeholder = document.getElementById('nav-placeholder');
+  if (!placeholder) return;
+  try {
+    const html = await fetch('nav.html').then(r => r.text());
+    placeholder.outerHTML = html;
+    if (window.applyRoleRules) {
+      window.applyRoleRules();
+    }
+  } catch (err) {
+    console.error('Failed to load navigation', err);
+  }
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', loadNav);
+} else {
+  loadNav();
+}

--- a/docs/maestro.html
+++ b/docs/maestro.html
@@ -12,11 +12,7 @@
   </script>
 </head>
 <body>
-  <nav class="main-nav">
-    <a href="index.html">Inicio</a>
-    <button id="toggleDarkMode" type="button">🌙</button>
-    <button type="button" class="logout-link">Salir</button>
-  </nav>
+  <div id="nav-placeholder"></div>
   <h1>Listado Maestro</h1>
   <div class="editor-menu">
     <label for="search">Buscar:</label>
@@ -59,6 +55,7 @@
   <script src="lib/dexie.min.js" defer></script>
   <script src="./socket.io/socket.io.js" defer></script>
   <script type="module" src="js/authGuard.js"></script>
+  <script type="module" src="js/nav.js" defer></script>
   <script type="module" src="js/dataService.js" defer></script>
   <script src="lib/xlsx.full.noeval.js" defer></script>
   <script type="module" src="js/maestro.js" defer></script>

--- a/docs/nav.html
+++ b/docs/nav.html
@@ -1,0 +1,12 @@
+<nav class="main-nav">
+  <a href="index.html#/home">Inicio</a>
+  <a href="sinoptico.html">Sinóptico</a>
+  <a href="sinoptico-editor.html" class="no-guest">Editar Sinóptico</a>
+  <a href="database.html" class="no-guest">Base de Datos</a>
+  <a href="index.html#/amfe">AMFE</a>
+  <a href="maestro.html">Listado Maestro</a>
+  <a href="index.html#/settings" class="no-guest">Modo Dev</a>
+  <a href="history.html" class="admin-only">Historial</a>
+  <button id="toggleDarkMode" type="button">🌙</button>
+  <button type="button" class="logout-link">Salir</button>
+</nav>

--- a/docs/sinoptico-editor.html
+++ b/docs/sinoptico-editor.html
@@ -12,13 +12,7 @@
   </script>
 </head>
 <body>
-  <nav class="main-nav">
-    <a href="index.html">Inicio</a>
-    <a href="sinoptico.html">Ver Sinóptico</a>
-    <a href="database.html" class="no-guest">Base de Datos</a>
-    <button id="toggleDarkMode" type="button">🌙</button>
-    <button type="button" class="logout-link">Salir</button>
-  </nav>
+  <div id="nav-placeholder"></div>
   <header class="editor-header">
     <h1 class="editor-title">Editor de Sinóptico</h1>
   </header>
@@ -148,6 +142,7 @@
   <script src="lib/fuse.min.js" defer></script>
   <script src="./socket.io/socket.io.js" defer></script>
   <script type="module" src="js/authGuard.js"></script>
+  <script type="module" src="js/nav.js" defer></script>
   <script src="https://cdn.jsdelivr.net/npm/xlsx/dist/xlsx.full.min.js" defer></script>
   <script type="module" src="js/dataService.js" defer></script>
   <script type="module" src="js/views/sinoptico.js" defer></script>

--- a/docs/sinoptico.html
+++ b/docs/sinoptico.html
@@ -12,13 +12,7 @@
   </script>
 </head>
 <body>
-  <nav class="main-nav">
-    <a href="index.html">Inicio</a>
-    <a href="database.html" class="no-guest">Base de Datos</a>
-    <!-- <a href="#/sinoptico">Sinóptico SPA</a> -->
-    <button id="toggleDarkMode" type="button">🌙</button>
-    <button type="button" class="logout-link">Salir</button>
-  </nav>
+  <div id="nav-placeholder"></div>
   <div class="filtro-contenedor">
     <div class="filtros-texto">
       <label for="search">Buscar:</label>
@@ -66,6 +60,7 @@
   <script src="lib/fuse.min.js" defer></script>
   <script src="./socket.io/socket.io.js" defer></script>
   <script type="module" src="js/authGuard.js"></script>
+  <script type="module" src="js/nav.js" defer></script>
   <script src="https://cdn.jsdelivr.net/npm/xlsx/dist/xlsx.full.min.js" defer></script>
   <script type="module" src="js/dataService.js" defer></script>
   <script type="module" src="js/views/sinoptico.js" defer></script>


### PR DESCRIPTION
## Summary
- consolidate navbar into `nav.html`
- load navigation via new `nav.js`
- inject navbar placeholder on each page

## Testing
- `./format_check.sh`

------
https://chatgpt.com/codex/tasks/task_e_685404ec44b4832fb69f998fcfa7a95c