### PR TITLE
Improve hero layout responsiveness

### DIFF
--- a/docs/assets/styles.css
+++ b/docs/assets/styles.css
@@ -812,17 +812,23 @@ body.amfe-page:not(.dark-mode) .logo {
   background: linear-gradient(135deg, var(--color-primary), var(--color-accent));
   color: var(--color-light);
   display: flex;
-  flex-direction: column;
-  justify-content: center;
   align-items: center;
+  justify-content: center;
   text-align: center;
   padding: 60px 20px 40px;
   font-family: var(--font-base, sans-serif);
 }
+
+.hero-content {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
 .hero h1 {
-  font-size: 3rem;
+  font-size: clamp(2rem, 6vw, 4rem);
   color: var(--color-light);
-  margin-bottom: 1.5rem;
+  margin-bottom: 1rem;
 }
 .intro {
   background-color: var(--color-light);
@@ -841,8 +847,17 @@ body.amfe-page:not(.dark-mode) .logo {
   color: var(--color-primary);
 }
 .tagline {
-  font-size: 1.2rem;
+  font-size: clamp(1rem, 3vw, 1.5rem);
   margin-bottom: 1.5rem;
+}
+
+@media (min-width: 900px) {
+  .hero h1 {
+    font-size: 4rem;
+  }
+  .tagline {
+    font-size: 1.75rem;
+  }
 }
 .features {
   list-style: none;

--- a/docs/js/views/home.js
+++ b/docs/js/views/home.js
@@ -3,8 +3,10 @@
 export function render(container) {
   container.innerHTML = `
     <section class="hero">
-      <h1>Ingeniería Barack</h1>
-      <p class="tagline">Soluciones modernas para tu negocio</p>
+      <div class="hero-content">
+        <h1>Ingeniería Barack</h1>
+        <p class="tagline">Soluciones modernas para tu negocio</p>
+      </div>
     </section>
     <section class="home-menu">
       <div class="menu-grid">


### PR DESCRIPTION
## Summary
- wrap home page hero text in a new `.hero-content` container
- scale hero heading and tagline with `clamp()` and add desktop media query

## Testing
- `bash format_check.sh`

------
https://chatgpt.com/codex/tasks/task_e_685408bb97dc832fa41a96ec04ddc8ca