### PR TITLE
Improve accessibility labels and dark mode contrast

### DIFF
--- a/docs/assets/styles.css
+++ b/docs/assets/styles.css
@@ -25,10 +25,10 @@
 .dark-mode {
   --color-bg: #000;
   --color-text: #e0e0e0;
-  --color-primary: #1e88e5;
+  --color-primary: #1a73e8;
   --color-primary-hover: #1565c0;
-  --color-accent: #42a5f5;
-  --color-accent-hover: #2196f3;
+  --color-accent: #1565c0;
+  --color-accent-hover: #0d47a1;
   --color-danger: #e74c3c;
   --color-danger-hover: #c0392b;
   --color-surface-dark: #000;
@@ -38,8 +38,8 @@
 
 /* ajustar colores en modo oscuro para mejor contraste en la página de inicio */
 .home.dark-mode {
-  --color-primary: #1e88e5;
-  --color-accent: #42a5f5;
+  --color-primary: #1a73e8;
+  --color-accent: #1565c0;
 }
 
 /* barra de navegación en modo oscuro */
@@ -1524,9 +1524,9 @@ select {
 .builder-card { background:linear-gradient(135deg,#ffffff,#f0f4ff); padding:12px; border-radius:8px; box-shadow:0 2px 4px rgba(0,0,0,0.1); margin:10px 0; position:relative; overflow-x:auto; }
 .dark-mode .builder-card { background:linear-gradient(135deg,#000,#111); }
 .builder-card .add-btn { position:absolute; top:8px; right:8px; width:24px; height:24px; border:none; border-radius:50%; background:#0066cc; color:#fff; cursor:pointer; }
-.dark-mode .builder-card .add-btn { background:#42a5f5; }
+.dark-mode .builder-card .add-btn { background:var(--color-accent); }
 .builder-card .add-btn:hover { background:#004c99; }
-.dark-mode .builder-card .add-btn:hover { background:#2196f3; }
+.dark-mode .builder-card .add-btn:hover { background:var(--color-accent-hover); }
 .builder-card .children { margin-left:30px; }
 
 .inline-form { display:flex; gap:6px; margin-top:8px; }

--- a/docs/js/ui/renderer.js
+++ b/docs/js/ui/renderer.js
@@ -223,8 +223,17 @@ document.addEventListener('DOMContentLoaded', () => {
   }
   function toggleNodo(btn, parentId) {
     const exp = btn.getAttribute('data-expanded') === 'true';
-    if (exp) { btn.textContent='+'; btn.setAttribute('data-expanded','false'); hideSubtree(parentId); }
-    else { btn.textContent='–'; btn.setAttribute('data-expanded','true'); showChildren(parentId); }
+    if (exp) {
+      btn.textContent = '+';
+      btn.setAttribute('data-expanded', 'false');
+      btn.setAttribute('aria-label', 'Expandir');
+      hideSubtree(parentId);
+    } else {
+      btn.textContent = '–';
+      btn.setAttribute('data-expanded', 'true');
+      btn.setAttribute('aria-label', 'Colapsar');
+      showChildren(parentId);
+    }
   }
   document.getElementById('expandirTodo')?.addEventListener('click', () => {
     document.querySelectorAll('#sinoptico tbody tr').forEach(tr => tr.style.display = '');
@@ -318,6 +327,8 @@ document.addEventListener('DOMContentLoaded', () => {
       const btn=document.createElement('button');
       btn.classList.add('toggle-btn');
       btn.textContent='+';
+      btn.setAttribute('aria-label', 'Expandir');
+      btn.setAttribute('title', 'Expandir');
       btn.onclick=()=>toggleNodo(btn,fila.ID);
       td0.appendChild(btn);
       tr.appendChild(td0);

--- a/docs/js/views/amfe.js
+++ b/docs/js/views/amfe.js
@@ -3,10 +3,10 @@ import { getAll, ready } from '../dataService.js';
 export async function render(container) {
   container.innerHTML = `
     <h1>AMFE</h1>
-    <button id="amfe-export">Exportar...</button>
+    <button id="amfe-export" aria-label="Opciones de exportación" title="Opciones de exportación">Exportar...</button>
     <div class="export-menu">
-      <button data-fmt="excel">Excel</button> |
-      <button data-fmt="pdf">PDF</button>
+      <button data-fmt="excel" aria-label="Exportar a Excel" title="Exportar a Excel">Excel</button> |
+      <button data-fmt="pdf" aria-label="Exportar a PDF" title="Exportar a PDF">PDF</button>
     </div>
     <div id="amfe"></div>
   `;

--- a/docs/js/views/maestro.js
+++ b/docs/js/views/maestro.js
@@ -6,11 +6,11 @@ export async function render(container) {
     <div class="editor-menu">
       <label for="search">Buscar:</label>
       <input id="search" type="text">
-      <button id="exportExcel">Exportar Excel</button>
-      <button id="exportSrv">Exportar...</button>
+      <button id="exportExcel" aria-label="Exportar a Excel" title="Exportar a Excel">Exportar Excel</button>
+      <button id="exportSrv" aria-label="Opciones de exportación" title="Opciones de exportación">Exportar...</button>
       <div class="export-menu">
-        <button data-fmt="excel">Excel</button> |
-        <button data-fmt="pdf">PDF</button>
+        <button data-fmt="excel" aria-label="Exportar a Excel" title="Exportar a Excel">Excel</button> |
+        <button data-fmt="pdf" aria-label="Exportar a PDF" title="Exportar a PDF">PDF</button>
       </div>
     </div>
     <div class="tabla-contenedor">

--- a/docs/maestro.html
+++ b/docs/maestro.html
@@ -17,7 +17,7 @@
   <div class="editor-menu">
     <label for="search">Buscar:</label>
     <input id="search" type="text">
-    <button id="exportExcel">Exportar Excel</button>
+    <button id="exportExcel" aria-label="Exportar a Excel" title="Exportar a Excel">Exportar Excel</button>
   </div>
   <div class="tabla-contenedor">
     <table id="maestroTable" class="db-table">

--- a/docs/nav.html
+++ b/docs/nav.html
@@ -7,6 +7,6 @@
   <a href="maestro.html">Listado Maestro</a>
   <a href="index.html#/settings" class="no-guest">Modo Dev</a>
   <a href="history.html" class="admin-only">Historial</a>
-  <button id="toggleDarkMode" type="button">🌙</button>
-  <button type="button" class="logout-link">Salir</button>
+  <button id="toggleDarkMode" type="button" aria-label="Alternar modo oscuro" title="Alternar modo oscuro">🌙</button>
+  <button type="button" class="logout-link" aria-label="Cerrar sesión" title="Cerrar sesión">Salir</button>
 </nav>

--- a/docs/sinoptico.html
+++ b/docs/sinoptico.html
@@ -30,15 +30,15 @@
         <option value="Insumo">Insumo</option>
       </select>
       <div id="selectedItems" class="chips"></div>
-      <button id="expandirTodo">Expandir todo</button>
-      <button id="colapsarTodo">Colapsar todo</button>
+      <button id="expandirTodo" aria-label="Expandir todo" title="Expandir todo">Expandir todo</button>
+      <button id="colapsarTodo" aria-label="Colapsar todo" title="Colapsar todo">Colapsar todo</button>
     </div>
     <div class="filtro-opciones">
       <label><input type="checkbox" id="chkMostrarNivel0" checked> Nivel 0</label>
       <label><input type="checkbox" id="chkMostrarNivel1" checked> Nivel 1</label>
       <label><input type="checkbox" id="chkMostrarNivel2" checked> Nivel 2</label>
       <label><input type="checkbox" id="chkMostrarNivel3" checked> Nivel 3</label>
-      <button id="btnExcel" class="no-guest">Exportar Excel</button>
+      <button id="btnExcel" class="no-guest" aria-label="Exportar a Excel" title="Exportar a Excel">Exportar Excel</button>
     </div>
   </div>
   <div class="tabla-contenedor">


### PR DESCRIPTION
## Summary
- add ARIA labels and tooltips for nav, export and toggle buttons
- adjust dark-mode color variables for better contrast
- update renderer toggle behavior with accessible labels

## Testing
- `bash format_check.sh`

------
https://chatgpt.com/codex/tasks/task_e_68540a4124a0832fb8701ae71a39ee3c