### PR TITLE
Add KPI panel and responsive styles

### DIFF
--- a/docs/assets/styles.css
+++ b/docs/assets/styles.css
@@ -807,6 +807,42 @@ body.amfe-page:not(.dark-mode) .logo {
   border-radius: 4px;
 }
 
+.kpi-panel {
+  background-color: var(--color-light);
+  padding: 20px;
+}
+
+.kpi-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 15px;
+  max-width: 900px;
+  margin: 0 auto 40px;
+}
+
+.kpi-card {
+  background: var(--color-primary);
+  color: var(--color-light);
+  padding: 1rem;
+  border-radius: 8px;
+  text-align: center;
+}
+
+.kpi-icon {
+  font-size: 1.75rem;
+  margin-bottom: 0.25rem;
+}
+
+.kpi-number {
+  font-size: 1.5rem;
+  font-weight: bold;
+}
+
+.kpi-label {
+  font-size: 0.9rem;
+  opacity: 0.85;
+}
+
 .hero {
   min-height: 85vh;
   background: linear-gradient(135deg, var(--color-primary), var(--color-accent));

--- a/docs/js/views/home.js
+++ b/docs/js/views/home.js
@@ -2,6 +2,30 @@
 
 export function render(container) {
   container.innerHTML = `
+    <section class="kpi-panel">
+      <div class="kpi-grid">
+        <div class="kpi-card">
+          <span class="kpi-icon" aria-hidden="true">📈</span>
+          <span class="kpi-number">120</span>
+          <span class="kpi-label">Proyectos</span>
+        </div>
+        <div class="kpi-card">
+          <span class="kpi-icon" aria-hidden="true">👥</span>
+          <span class="kpi-number">50</span>
+          <span class="kpi-label">Clientes</span>
+        </div>
+        <div class="kpi-card">
+          <span class="kpi-icon" aria-hidden="true">⚙️</span>
+          <span class="kpi-number">300</span>
+          <span class="kpi-label">Equipos</span>
+        </div>
+        <div class="kpi-card">
+          <span class="kpi-icon" aria-hidden="true">⭐</span>
+          <span class="kpi-number">95%</span>
+          <span class="kpi-label">Satisfacción</span>
+        </div>
+      </div>
+    </section>
     <section class="hero">
       <div class="hero-content">
         <h1>Ingeniería Barack</h1>


### PR DESCRIPTION
## Summary
- add KPI panel markup before hero on home page
- style KPI grid with responsive columns

## Testing
- `./format_check.sh`


------
https://chatgpt.com/codex/tasks/task_e_68541d8b23b8832f8165ad3268725ac8