### PR TITLE
Update navbar links and hover style

### DIFF
--- a/docs/assets/styles.css
+++ b/docs/assets/styles.css
@@ -782,6 +782,9 @@ body, html {
   text-decoration: none;
   font-weight: bold;
 }
+.main-nav a:hover {
+  color: var(--color-accent);
+}
 .main-nav a[aria-current="page"] {
   text-decoration: underline;
 }
@@ -791,6 +794,7 @@ body, html {
   color: var(--color-light);
   font-size: 1rem;
   cursor: pointer;
+  margin-left: auto;
 }
 
 header {

--- a/docs/nav.html
+++ b/docs/nav.html
@@ -1,12 +1,8 @@
 <nav class="main-nav">
   <a href="index.html#/home">Inicio</a>
   <a href="sinoptico.html">Sinóptico</a>
-  <a href="sinoptico-editor.html" class="no-guest">Editar Sinóptico</a>
-  <a href="database.html" class="no-guest">Base de Datos</a>
   <a href="index.html#/amfe">AMFE</a>
   <a href="maestro.html">Listado Maestro</a>
-  <a href="index.html#/settings" class="no-guest">Modo Dev</a>
-  <a href="history.html" class="admin-only">Historial</a>
-  <button id="toggleDarkMode" type="button" aria-label="Alternar modo oscuro" title="Alternar modo oscuro">🌙</button>
   <button type="button" class="logout-link" aria-label="Cerrar sesión" title="Cerrar sesión">Salir</button>
+  <button id="toggleDarkMode" type="button" aria-label="Alternar modo oscuro" title="Alternar modo oscuro">🌙</button>
 </nav>


### PR DESCRIPTION
## Summary
- shorten the navigation menu to key pages only
- highlight nav links on hover
- move dark mode toggle to the far right

## Testing
- `./format_check.sh`


------
https://chatgpt.com/codex/tasks/task_e_68541e621624832fbdf65422f4958220