### PR TITLE
Update hero layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Proyecto Barack
 
-Versión actual: **375**
+Versión actual: **376**
 
 Esta es una pequeña SPA (Single Page Application) escrita en HTML, CSS y JavaScript.
 Incluye un módulo llamado *Sinóptico* para gestionar jerarquías de productos.

--- a/docs/assets/styles.css
+++ b/docs/assets/styles.css
@@ -20,6 +20,8 @@
   --page-brightness: 100%;
   --maestro-header-bg: #44546A;
   --maestro-row-alt: #F3F6F9;
+  --hero-start: var(--color-primary);
+  --hero-end: var(--color-accent);
 }
 
 .dark-mode {
@@ -34,6 +36,8 @@
   --color-surface-dark: #000;
   --maestro-header-bg: #000;
   --maestro-row-alt: #111;
+  --hero-start: #0a1a33;
+  --hero-end: #1a73e8;
 }
 
 /* ajustar colores en modo oscuro para mejor contraste en la página de inicio */
@@ -849,7 +853,7 @@ body.amfe-page:not(.dark-mode) .logo {
 
 .hero {
   min-height: 85vh;
-  background: linear-gradient(135deg, var(--color-primary), var(--color-accent));
+  background: linear-gradient(135deg, var(--hero-start), var(--hero-end));
   color: var(--color-light);
   display: flex;
   align-items: center;
@@ -889,6 +893,20 @@ body.amfe-page:not(.dark-mode) .logo {
 .tagline {
   font-size: clamp(1rem, 3vw, 1.5rem);
   margin-bottom: 1.5rem;
+}
+.tagline-card {
+  background-color: rgba(255, 255, 255, 0.2);
+  padding: 1rem 1.5rem;
+  border-radius: 8px;
+  backdrop-filter: blur(3px);
+}
+.tagline-card p {
+  margin: 0;
+}
+.review-count {
+  font-size: 0.9rem;
+  margin-top: 0.5rem;
+  opacity: 0.9;
 }
 
 @media (min-width: 900px) {

--- a/docs/js/version.js
+++ b/docs/js/version.js
@@ -1,4 +1,4 @@
-export const version = '375';
+export const version = '376';
 export function displayVersion() {
   const div = document.createElement('div');
   div.className = 'version-info';

--- a/docs/js/views/home.js
+++ b/docs/js/views/home.js
@@ -29,7 +29,10 @@ export function render(container) {
     <section class="hero">
       <div class="hero-content">
         <h1>Ingeniería Barack</h1>
-        <p class="tagline">Soluciones modernas para tu negocio</p>
+        <div class="tagline-card">
+          <p class="tagline">Soluciones modernas para tu negocio</p>
+          <p id="reviewCount" class="review-count"></p>
+        </div>
       </div>
     </section>
     <section class="home-menu">
@@ -52,6 +55,13 @@ export function render(container) {
 
   const importBtn = container.querySelector('#importBtn');
   const fileInput = container.querySelector('#importFile');
+  const reviewCountEl = container.querySelector('#reviewCount');
+  const count = parseInt(localStorage.getItem('reviewCount') || '0', 10);
+  if (count > 0) {
+    reviewCountEl.textContent = `Hoy ${count} archivos por revisar`;
+  } else {
+    reviewCountEl.remove();
+  }
 
   importBtn.addEventListener('click', () => fileInput.click());
   fileInput.addEventListener('change', async ev => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "proyecto-barack",
-  "version": "375",
+  "version": "376",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "proyecto-barack",
-      "version": "375",
+      "version": "376",
       "license": "ISC",
       "devDependencies": {}
     }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "proyecto-barack",
-  "version": "375",
-  "description": "Versión actual: **375**",
+  "version": "376",
+  "description": "Versión actual: **376**",
   "main": "index.js",
   "directories": {
     "lib": "lib"


### PR DESCRIPTION
## Summary
- tweak landing hero gradient with `--hero-start` and `--hero-end`
- place tagline inside a translucent card with optional review count
- bump version to 376

## Testing
- `sh format_check.sh`

------
https://chatgpt.com/codex/tasks/task_e_68541f1257b8832fa17c2da20560ea9d