### PR TITLE
Add icons and responsive menu cards

### DIFF
--- a/docs/assets/styles.css
+++ b/docs/assets/styles.css
@@ -961,26 +961,42 @@ body.amfe-page:not(.dark) .logo {
 
 .menu-grid {
   display: grid;
-  /* Ensure items wrap nicely on small screens */
-  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
   gap: 15px;
+  grid-template-columns: repeat(2, 1fr);
   margin-bottom: 1.5rem;
 }
 
+@media (min-width: 900px) {
+  .menu-grid {
+    grid-template-columns: repeat(4, 1fr);
+  }
+}
+
 .menu-item {
-  padding: 16px;
-  background: var(--color-primary);
-  color: var(--color-light);
+  display: block;
   text-decoration: none;
+  color: var(--color-text);
   border-radius: 8px;
-  font-weight: bold;
-  box-shadow: 0 2px 4px rgba(0,0,0,0.2);
-  transition: transform 0.2s, background-color 0.2s;
+  background: var(--color-light);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  transition: transform 0.2s, box-shadow 0.2s;
+}
+
+.menu-item > div {
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.menu-icon {
+  font-size: 2rem;
 }
 
 .menu-item:hover {
-  background: var(--color-primary-hover);
   transform: translateY(-2px);
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
 }
 
 /* Animaciones */

--- a/docs/js/views/home.js
+++ b/docs/js/views/home.js
@@ -37,14 +37,54 @@ export function render(container) {
     </section>
     <section class="home-menu">
       <div class="menu-grid">
-        <a href="sinoptico-editor.html" class="menu-item no-guest">Editar Sinóptico</a>
-        <a href="sinoptico.html" class="menu-item">Ver Sinóptico</a>
-        <a href="#/amfe" class="menu-item">AMFE</a>
-        <a href="maestro.html" class="menu-item">Listado Maestro</a>
-        <a href="maestro_editor.html" class="menu-item no-guest">Editar Maestro</a>
-        <a href="database.html" class="menu-item no-guest">Base de Datos</a>
-        <a href="history.html" class="menu-item admin-only">Historial</a>
-        <a href="#/settings" class="menu-item no-guest">Ajustes</a>
+        <a href="sinoptico-editor.html" class="menu-item no-guest">
+          <div>
+            <span class="menu-icon" aria-hidden="true">📝</span>
+            <span class="menu-text">Editar Sinóptico</span>
+          </div>
+        </a>
+        <a href="sinoptico.html" class="menu-item">
+          <div>
+            <span class="menu-icon" aria-hidden="true">📄</span>
+            <span class="menu-text">Ver Sinóptico</span>
+          </div>
+        </a>
+        <a href="#/amfe" class="menu-item">
+          <div>
+            <span class="menu-icon" aria-hidden="true">🔧</span>
+            <span class="menu-text">AMFE</span>
+          </div>
+        </a>
+        <a href="maestro.html" class="menu-item">
+          <div>
+            <span class="menu-icon" aria-hidden="true">📋</span>
+            <span class="menu-text">Listado Maestro</span>
+          </div>
+        </a>
+        <a href="maestro_editor.html" class="menu-item no-guest">
+          <div>
+            <span class="menu-icon" aria-hidden="true">✏️</span>
+            <span class="menu-text">Editar Maestro</span>
+          </div>
+        </a>
+        <a href="database.html" class="menu-item no-guest">
+          <div>
+            <span class="menu-icon" aria-hidden="true">🗄️</span>
+            <span class="menu-text">Base de Datos</span>
+          </div>
+        </a>
+        <a href="history.html" class="menu-item admin-only">
+          <div>
+            <span class="menu-icon" aria-hidden="true">📜</span>
+            <span class="menu-text">Historial</span>
+          </div>
+        </a>
+        <a href="#/settings" class="menu-item no-guest">
+          <div>
+            <span class="menu-icon" aria-hidden="true">⚙️</span>
+            <span class="menu-text">Ajustes</span>
+          </div>
+        </a>
       </div>
       <div class="db-actions no-guest">
         <button id="importBtn">Importar datos</button>


### PR DESCRIPTION
## Summary
- style home menu items as cards with icons
- update grid for 4/2-column responsive layout

## Testing
- `./format_check.sh`


------
https://chatgpt.com/codex/tasks/task_e_685420c459d4832f8d11c85179694d26