### PR TITLE
Improve home layout and dark mode

### DIFF
--- a/docs/arbol.html
+++ b/docs/arbol.html
@@ -13,6 +13,7 @@
 </head>
 <body>
   <nav id="nav-placeholder"></nav>
+  <button class="back-btn" onclick="history.back()">← Volver</button>
   <section id="loading"></section>
   <section id="appMessage" role="alert" aria-live="polite"></section>
   <section id="step1" class="node-form">

--- a/docs/assets/styles.css
+++ b/docs/assets/styles.css
@@ -20,8 +20,8 @@
   --page-brightness: 100%;
   --maestro-header-bg: #44546A;
   --maestro-row-alt: #F3F6F9;
-  --hero-start: var(--color-primary);
-  --hero-end: var(--color-accent);
+  --hero-start: #ffffff;
+  --hero-end: #f9f9f9;
 }
 
 .dark {
@@ -150,6 +150,16 @@ h1 {
   box-shadow: 0 1px 4px rgba(0, 0, 0, 0.1);
   font-size: 0.9rem;
   line-height: 1.4;
+}
+
+.card {
+  background: var(--color-light);
+  color: var(--color-text);
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+.dark .card {
+  background: var(--color-surface-dark);
 }
 
 /* ==============================
@@ -801,6 +811,24 @@ body, html {
   margin-left: auto;
 }
 
+.back-btn {
+  position: fixed;
+  top: 70px;
+  left: 10px;
+  background: rgba(255, 255, 255, 0.8);
+  border: none;
+  border-radius: 4px;
+  padding: 4px 8px;
+  font-size: 0.9rem;
+  color: var(--color-text);
+  cursor: pointer;
+  z-index: 1000;
+}
+.dark .back-btn {
+  background: rgba(0, 0, 0, 0.5);
+  color: var(--color-light);
+}
+
 header {
   padding: 0;
   text-align: center;
@@ -829,11 +857,15 @@ body.amfe-page:not(.dark) .logo {
 }
 
 .kpi-card {
-  background: var(--color-primary);
-  color: var(--color-light);
+  background: var(--color-light);
+  color: var(--color-text);
   padding: 1rem;
   border-radius: 8px;
   text-align: center;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+.dark .kpi-card {
+  background: var(--color-surface-dark);
 }
 
 .kpi-icon {
@@ -854,7 +886,7 @@ body.amfe-page:not(.dark) .logo {
 .hero {
   min-height: 85vh;
   background: linear-gradient(135deg, var(--hero-start), var(--hero-end));
-  color: var(--color-light);
+  color: var(--color-text);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -871,7 +903,7 @@ body.amfe-page:not(.dark) .logo {
 
 .hero h1 {
   font-size: clamp(2rem, 6vw, 4rem);
-  color: var(--color-light);
+  color: var(--color-primary);
   margin-bottom: 1rem;
 }
 .intro {
@@ -895,7 +927,7 @@ body.amfe-page:not(.dark) .logo {
   margin-bottom: 1.5rem;
 }
 .tagline-card {
-  background-color: rgba(255, 255, 255, 0.2);
+  background-color: rgba(255, 255, 255, 0.8);
   padding: 1rem 1.5rem;
   border-radius: 8px;
   backdrop-filter: blur(3px);
@@ -966,27 +998,24 @@ body.amfe-page:not(.dark) .logo {
   margin-bottom: 1.5rem;
 }
 
-@media (min-width: 900px) {
+@media (min-width: 600px) {
   .menu-grid {
     grid-template-columns: repeat(4, 1fr);
   }
 }
 
 .menu-item {
-  display: block;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
   text-decoration: none;
   color: var(--color-text);
   border-radius: 8px;
   background: var(--color-light);
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
   transition: transform 0.2s, box-shadow 0.2s;
-}
-
-.menu-item > div {
   padding: 20px;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
   gap: 0.5rem;
 }
 

--- a/docs/database.html
+++ b/docs/database.html
@@ -13,6 +13,7 @@
 </head>
 <body>
   <nav id="nav-placeholder"></nav>
+  <button class="back-btn" onclick="history.back()">← Volver</button>
   <header class="editor-header">
     <h1 class="editor-title">Base de Datos</h1>
   </header>

--- a/docs/history.html
+++ b/docs/history.html
@@ -13,6 +13,7 @@
 </head>
 <body>
   <nav id="nav-placeholder"></nav>
+  <button class="back-btn" onclick="history.back()">← Volver</button>
   <h1>Historial reciente</h1>
   <section class="tabla-contenedor">
     <table id="historyTable">

--- a/docs/js/app.js
+++ b/docs/js/app.js
@@ -1,3 +1,7 @@
+const API_BASE = window.location.hostname.includes('github.io')
+  ? null
+  : 'http://TU_IP:5000';
+
 document.addEventListener('DOMContentLoaded', () => {
   const btn = document.getElementById('toggleDarkMode');
   if (!btn) return;

--- a/docs/js/views/home.js
+++ b/docs/js/views/home.js
@@ -2,30 +2,6 @@
 
 export function render(container) {
   container.innerHTML = `
-    <section class="kpi-panel">
-      <div class="kpi-grid">
-        <div class="kpi-card">
-          <span class="kpi-icon" aria-hidden="true">📈</span>
-          <span class="kpi-number">120</span>
-          <span class="kpi-label">Proyectos</span>
-        </div>
-        <div class="kpi-card">
-          <span class="kpi-icon" aria-hidden="true">👥</span>
-          <span class="kpi-number">50</span>
-          <span class="kpi-label">Clientes</span>
-        </div>
-        <div class="kpi-card">
-          <span class="kpi-icon" aria-hidden="true">⚙️</span>
-          <span class="kpi-number">300</span>
-          <span class="kpi-label">Equipos</span>
-        </div>
-        <div class="kpi-card">
-          <span class="kpi-icon" aria-hidden="true">⭐</span>
-          <span class="kpi-number">95%</span>
-          <span class="kpi-label">Satisfacción</span>
-        </div>
-      </div>
-    </section>
     <section class="hero">
       <div class="hero-content">
         <h1>Ingeniería Barack</h1>
@@ -35,55 +11,42 @@ export function render(container) {
         </div>
       </div>
     </section>
+    <section class="kpi-panel">
+      <div class="kpi-grid" id="kpiGrid"></div>
+    </section>
     <section class="home-menu">
       <div class="menu-grid">
-        <a href="sinoptico-editor.html" class="menu-item no-guest">
-          <div>
-            <span class="menu-icon" aria-hidden="true">📝</span>
-            <span class="menu-text">Editar Sinóptico</span>
-          </div>
+        <a href="sinoptico-editor.html" class="menu-item card no-guest">
+          <span class="menu-icon" aria-hidden="true">📝</span>
+          <span class="menu-text">Editar Sinóptico</span>
         </a>
-        <a href="sinoptico.html" class="menu-item">
-          <div>
-            <span class="menu-icon" aria-hidden="true">📄</span>
-            <span class="menu-text">Ver Sinóptico</span>
-          </div>
+        <a href="sinoptico.html" class="menu-item card">
+          <span class="menu-icon" aria-hidden="true">📄</span>
+          <span class="menu-text">Ver Sinóptico</span>
         </a>
-        <a href="#/amfe" class="menu-item">
-          <div>
-            <span class="menu-icon" aria-hidden="true">🔧</span>
-            <span class="menu-text">AMFE</span>
-          </div>
+        <a href="#/amfe" class="menu-item card">
+          <span class="menu-icon" aria-hidden="true">🔧</span>
+          <span class="menu-text">AMFE</span>
         </a>
-        <a href="maestro.html" class="menu-item">
-          <div>
-            <span class="menu-icon" aria-hidden="true">📋</span>
-            <span class="menu-text">Listado Maestro</span>
-          </div>
+        <a href="maestro.html" class="menu-item card">
+          <span class="menu-icon" aria-hidden="true">📋</span>
+          <span class="menu-text">Listado Maestro</span>
         </a>
-        <a href="maestro_editor.html" class="menu-item no-guest">
-          <div>
-            <span class="menu-icon" aria-hidden="true">✏️</span>
-            <span class="menu-text">Editar Maestro</span>
-          </div>
+        <a href="maestro_editor.html" class="menu-item card no-guest">
+          <span class="menu-icon" aria-hidden="true">✏️</span>
+          <span class="menu-text">Editar Maestro</span>
         </a>
-        <a href="database.html" class="menu-item no-guest">
-          <div>
-            <span class="menu-icon" aria-hidden="true">🗄️</span>
-            <span class="menu-text">Base de Datos</span>
-          </div>
+        <a href="database.html" class="menu-item card no-guest">
+          <span class="menu-icon" aria-hidden="true">🗄️</span>
+          <span class="menu-text">Base de Datos</span>
         </a>
-        <a href="history.html" class="menu-item admin-only">
-          <div>
-            <span class="menu-icon" aria-hidden="true">📜</span>
-            <span class="menu-text">Historial</span>
-          </div>
+        <a href="history.html" class="menu-item card admin-only">
+          <span class="menu-icon" aria-hidden="true">📜</span>
+          <span class="menu-text">Historial</span>
         </a>
-        <a href="#/settings" class="menu-item no-guest">
-          <div>
-            <span class="menu-icon" aria-hidden="true">⚙️</span>
-            <span class="menu-text">Ajustes</span>
-          </div>
+        <a href="#/settings" class="menu-item card no-guest">
+          <span class="menu-icon" aria-hidden="true">⚙️</span>
+          <span class="menu-text">Ajustes</span>
         </a>
       </div>
       <div class="db-actions no-guest">
@@ -112,4 +75,29 @@ export function render(container) {
     alert('Datos importados');
     fileInput.value = '';
   });
+
+  const kpiGrid = container.querySelector('#kpiGrid');
+  if (kpiGrid) loadKpis(kpiGrid);
+}
+
+async function loadKpis(el) {
+  if (!window.API_BASE) return;
+  try {
+    const resp = await fetch(`${window.API_BASE}/api/server-info`);
+    if (!resp.ok) return;
+    const info = await resp.json();
+    const data = [
+      { icon: '📦', label: 'Productos', value: info.data_keys?.length || 0 },
+      { icon: '⏳', label: 'Pendientes', value: info.pending || 0 },
+      { icon: '✅', label: 'Completados', value: info.completed || 0 },
+      { icon: '📝', label: 'Cambios', value: info.history_entries || 0 },
+    ];
+    el.innerHTML = data
+      .map(
+        d => `\n      <div class="kpi-card">\n        <span class="kpi-icon" aria-hidden="true">${d.icon}</span>\n        <span class="kpi-number">${d.value}</span>\n        <span class="kpi-label">${d.label}</span>\n      </div>`
+      )
+      .join('');
+  } catch (err) {
+    console.error('KPI fetch failed', err);
+  }
 }

--- a/docs/maestro.html
+++ b/docs/maestro.html
@@ -13,6 +13,7 @@
 </head>
 <body>
   <nav id="nav-placeholder"></nav>
+  <button class="back-btn" onclick="history.back()">← Volver</button>
   <h1>Listado Maestro</h1>
   <section class="editor-menu">
     <label for="search">Buscar:</label>

--- a/docs/sinoptico-editor.html
+++ b/docs/sinoptico-editor.html
@@ -13,6 +13,7 @@
 </head>
 <body>
   <nav id="nav-placeholder"></nav>
+  <button class="back-btn" onclick="history.back()">← Volver</button>
   <header class="editor-header">
     <h1 class="editor-title">Editor de Sinóptico</h1>
   </header>

--- a/docs/sinoptico.html
+++ b/docs/sinoptico.html
@@ -13,6 +13,7 @@
 </head>
 <body>
   <nav id="nav-placeholder"></nav>
+  <button class="back-btn" onclick="history.back()">← Volver</button>
   <section class="filtro-contenedor">
     <section class="filtros-texto">
       <label for="search">Buscar:</label>


### PR DESCRIPTION
## Summary
- adjust hero layout and set API base URL
- fetch KPIs from backend and display them under the hero
- restyle menu items as white cards and tweak grid responsiveness
- add dark-mode friendly card and back button styles
- place a back button on all secondary pages

## Testing
- `bash format_check.sh`

------
https://chatgpt.com/codex/tasks/task_e_6854244a4a6c832fbcee5a2f53bc1582