### PR TITLE
Fix hover menu layout shift

### DIFF
--- a/docs/assets/styles.css
+++ b/docs/assets/styles.css
@@ -1048,6 +1048,7 @@ body.amfe-page:not(.dark) .logo {
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
   transition: transform 0.2s, box-shadow 0.2s;
   padding: 20px;
+  padding-bottom: 48px; /* reserve space for hover actions */
   gap: 0.5rem;
   cursor: pointer;
 }
@@ -1062,8 +1063,12 @@ body.amfe-page:not(.dark) .logo {
 }
 .menu-actions {
   display: none;
+  position: absolute;
+  bottom: 10px;
+  left: 0;
+  width: 100%;
   font-size: 0.8rem;
-  margin-top: 8px;
+  margin: 0;
   text-align: center;
 }
 .menu-actions a {


### PR DESCRIPTION
## Summary
- prevent scroll when hovering home menu icons by reserving space
- position menu actions absolutely

## Testing
- `./format_check.sh`

------
https://chatgpt.com/codex/tasks/task_e_685442c05d4c832f9a00db47478902d1