### PR TITLE
Frontend fixes for Maestro listing

### DIFF
--- a/docs/assets/styles.css
+++ b/docs/assets/styles.css
@@ -1851,3 +1851,15 @@ tr:not(.pending) td:first-child::before {
   text-decoration: underline;
 }
 
+/* export buttons */
+.btn-excel,
+.btn-pdf {
+  padding: 10px 18px;
+  color: #fff;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+}
+.btn-excel { background: #1b6e1b; }
+.btn-pdf { background: #c0392b; }
+

--- a/docs/maestro.html
+++ b/docs/maestro.html
@@ -19,13 +19,15 @@
   <section class="editor-menu">
     <label for="search">Buscar:</label>
     <input id="search" type="text">
-    <button id="exportExcel" aria-label="Exportar a Excel" title="Exportar a Excel">Exportar Excel</button>
+    <button id="exportExcelSrv" class="btn-excel" aria-label="Exportar a Excel" title="Exportar a Excel">📊 Exportar Excel</button>
+    <button id="exportPdfSrv" class="btn-pdf" aria-label="Exportar a PDF" title="Exportar a PDF">📄 Exportar PDF</button>
   </section>
+  <section id="loading"></section>
+  <section id="appMessage" role="alert" aria-live="polite"></section>
   <section class="tabla-contenedor">
     <table id="maestroTable" class="db-table">
       <thead>
         <tr>
-          <th>ID</th>
           <th>Flujograma</th>
           <th>AMFE</th>
           <th>Hoja Op</th>


### PR DESCRIPTION
## Summary
- tweak Listado Maestro UI
- hide internal ID column
- add Exportar Excel/PDF buttons
- add styling for export buttons
- update static maestro script

## Testing
- `./format_check.sh`


------
https://chatgpt.com/codex/tasks/task_e_685442d6249c832fb8b348b82ef88433