### PR TITLE
Add image viewer for products

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Proyecto Barack
 
-Versión actual: **379**
+Versión actual: **380**
 
 Esta es una pequeña SPA (Single Page Application) escrita en HTML, CSS y JavaScript.
 Incluye un módulo llamado *Sinóptico* para gestionar jerarquías de productos.
@@ -141,10 +141,22 @@ Para mas detalles consulta `docs/backend.md`.
 
 Los módulos de exportación comprueban el valor de
 `localStorage.getItem('useMock')`. Si guardas
+
 `localStorage.setItem('useMock', 'true')` en la consola del navegador,
 puedes interceptar las descargas y usar datos locales sin depender del
 servidor. Vuelve al comportamiento normal eliminando esa clave o
 estableciéndola en `'false'`.
+
+### Imágenes del Sinóptico
+
+Las fotografías de productos e insumos se guardan en la carpeta
+`docs/imagenes_sinoptico`. Cada archivo debe llamarse igual que el
+código del elemento pero eliminando cualquier carácter que no sea letra
+o número y en minúsculas. Por ejemplo, si el código es `A-123 45`, el
+archivo correspondiente será `a12345.jpg`.
+
+Coloca aquí las imágenes con la extensión que prefieras (`.jpg`, `.png`,
+etc.) para que puedan visualizarse desde la tabla.
 
 
 ## Desarrollo

--- a/docs/assets/styles.css
+++ b/docs/assets/styles.css
@@ -1768,6 +1768,13 @@ dialog.modal{border:none;border-radius:8px;padding:20px;box-shadow:0 2px 8px rgb
 .db-table tbody tr:nth-child(even){background-color:#f7f7f7;}
 .db-table button{background-color:var(--color-accent);color:var(--color-light);border:none;border-radius:4px;cursor:pointer;padding:2px 6px;}
 .db-table button:hover{background-color:var(--color-accent-hover);}
+.view-img-btn{background:#fff;border:1px solid #ccc;border-radius:4px;padding:2px 6px;cursor:pointer;color:var(--color-text);} 
+.view-img-btn:hover{background:#f0f0f0;} 
+.dark .view-img-btn{background:#333;border-color:#555;color:#fff;} 
+.dark .view-img-btn:hover{background:#444;} 
+.image-modal::backdrop{background:rgba(0,0,0,0.5);} 
+.image-modal .img-wrapper{max-width:90vw;max-height:90vh;} 
+.image-modal img{display:block;max-width:100%;max-height:100%;}
 .dark .db-table tbody tr:nth-child(even){background-color:var(--maestro-row-alt);}
 .dark .db-table th,.dark .db-table td{border-color:#444;}
 

--- a/docs/database.html
+++ b/docs/database.html
@@ -56,6 +56,7 @@
             <th>Ancho</th>
             <th>Alto</th>
             <th>Peso</th>
+            <th>Imagen</th>
             <th>Acciones</th>
           </tr>
         </thead>
@@ -87,6 +88,7 @@
             <th>Material</th>
             <th>Observaciones</th>
             <th>Origen</th>
+            <th>Imagen</th>
             <th>Acciones</th>
           </tr>
         </thead>
@@ -115,6 +117,7 @@
   <script type="module" src="js/dataService.js" defer></script>
   <script type="module" src="js/dbPage.js" defer></script>
   <script type="module" src="js/ui/animations.js" defer></script>
+  <script type="module" src="js/imageViewer.js" defer></script>
   <script type="module" src="js/app.js" defer></script>
   <script type="module" src="js/pageSettings.js" defer></script>
   <script type="module" src="js/version.js" defer></script>

--- a/docs/imagenes_sinoptico/README.md
+++ b/docs/imagenes_sinoptico/README.md
@@ -1,0 +1,1 @@
+Directorio para imagenes asociadas al Sinoptico.

--- a/docs/js/dbPage.js
+++ b/docs/js/dbPage.js
@@ -67,6 +67,7 @@ document.addEventListener('DOMContentLoaded', () => {
           `<td data-edit="Ancho" data-id="${item.ID}">${item.Ancho || ''}</td>` +
           `<td data-edit="Alto" data-id="${item.ID}">${item.Alto || ''}</td>` +
           `<td data-edit="Peso" data-id="${item.ID}">${item.Peso || ''}</td>` +
+          `<td><button class="view-img-btn" data-cod="${item.Código}">Ver</button></td>` +
           `<td>${actBtn}<button class="db-del" data-id="${item.ID}">🗑️</button></td>`;
       } else if (item.Tipo === 'Insumo') {
         tr.innerHTML =
@@ -77,6 +78,7 @@ document.addEventListener('DOMContentLoaded', () => {
           `<td data-edit="Material" data-id="${item.ID}">${item.Material || ''}</td>` +
           `<td data-edit="Observaciones" data-id="${item.ID}">${item.Observaciones || ''}</td>` +
           `<td data-edit="Sourcing" data-id="${item.ID}">${item.Sourcing || ''}</td>` +
+          `<td><button class="view-img-btn" data-cod="${item.Código}">Ver</button></td>` +
           `<td>${actBtn}<button class="db-del" data-id="${item.ID}">🗑️</button></td>`;
       } else {
         // Subproducto o cualquier otro
@@ -118,6 +120,11 @@ document.addEventListener('DOMContentLoaded', () => {
           await updateNode(id, { Desactivado: false });
           await load();
         }
+      } else if (btn.classList.contains('view-img-btn')) {
+        const code = btn.dataset.cod || '';
+        const sanitized = code.replace(/[^a-z0-9]/gi, '').toLowerCase();
+        const src = sanitized ? `imagenes_sinoptico/${sanitized}.jpg` : '';
+        if (window.showImageModal) window.showImageModal(src);
       }
       return;
     }

--- a/docs/js/imageViewer.js
+++ b/docs/js/imageViewer.js
@@ -1,0 +1,30 @@
+'use strict';
+
+export function showImageModal(src) {
+  let dialog = document.getElementById('imgModal');
+  if (!dialog) {
+    dialog = document.createElement('dialog');
+    dialog.id = 'imgModal';
+    dialog.className = 'modal image-modal';
+    dialog.innerHTML = '<button class="close-dialog">✖</button><div class="img-wrapper"></div>';
+    dialog.querySelector('.close-dialog').addEventListener('click', () => dialog.close());
+    dialog.addEventListener('click', ev => { if (ev.target === dialog) dialog.close(); });
+    document.body.appendChild(dialog);
+  }
+  const wrapper = dialog.querySelector('.img-wrapper');
+  if (src) {
+    wrapper.innerHTML = `<img src="${src}" alt="imagen">`;
+    const img = wrapper.querySelector('img');
+    img.addEventListener('error', () => {
+      wrapper.innerHTML = '<p>Sin imagen</p>';
+    }, { once: true });
+  } else {
+    wrapper.innerHTML = '<p>Sin imagen</p>';
+  }
+  dialog.showModal();
+}
+
+if (typeof window !== 'undefined') {
+  window.showImageModal = showImageModal;
+  document.addEventListener('DOMContentLoaded', () => {});
+}

--- a/docs/js/ui/renderer.js
+++ b/docs/js/ui/renderer.js
@@ -333,7 +333,17 @@ document.addEventListener('DOMContentLoaded', () => {
       td0.appendChild(btn);
       tr.appendChild(td0);
       ['Vehículo','Código','Consumo','Unidad'].forEach(f=>{ const td=document.createElement('td'); td.textContent=fila[f]||''; tr.appendChild(td); });
-      const tdImg=document.createElement('td'); if(fila.Imagen){ const img=document.createElement('img'); img.src=`images/${fila.Imagen}`;tdImg.appendChild(img);} tr.appendChild(tdImg);
+      const tdImg=document.createElement('td');
+      const vBtn=document.createElement('button');
+      vBtn.className='view-img-btn';
+      vBtn.textContent='Ver';
+      vBtn.addEventListener('click',()=>{
+        const code=(fila['Código']||'').replace(/[^a-z0-9]/gi,'').toLowerCase();
+        const src=code?`imagenes_sinoptico/${code}.jpg`:'';
+        if(window.showImageModal) window.showImageModal(src);
+     });
+      tdImg.appendChild(vBtn);
+      tr.appendChild(tdImg);
       const editing=sessionStorage.getItem('sinopticoEdit')==='true';
       if(editing){
         const tdA=document.createElement('td');

--- a/docs/js/version.js
+++ b/docs/js/version.js
@@ -1,4 +1,4 @@
-export const version = '379';
+export const version = '380';
 export function displayVersion() {
   const div = document.createElement('div');
   div.className = 'version-info';

--- a/docs/sinoptico-editor.html
+++ b/docs/sinoptico-editor.html
@@ -150,6 +150,7 @@
   <script type="module" src="js/views/sinoptico.js" defer></script>
   <script type="module" src="js/ui/renderer.js" defer></script>
   <script type="module" src="js/ui/animations.js" defer></script>
+  <script type="module" src="js/imageViewer.js" defer></script>
   <script type="module" src="js/app.js" defer></script>
   <script type="module" src="js/pageSettings.js" defer></script>
   <script type="module" src="js/hideLoading.js" defer></script>

--- a/docs/sinoptico.html
+++ b/docs/sinoptico.html
@@ -68,6 +68,7 @@
   <script type="module" src="js/views/sinoptico.js" defer></script>
   <script type="module" src="js/ui/renderer.js" defer></script>
   <script type="module" src="js/ui/animations.js" defer></script>
+  <script type="module" src="js/imageViewer.js" defer></script>
   <script type="module" src="js/app.js" defer></script>
   <script type="module" src="js/pageSettings.js" defer></script>
   <script type="module" src="js/hideLoading.js" defer></script>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "proyecto-barack",
-  "version": "379",
+  "version": "380",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "proyecto-barack",
-      "version": "379",
+      "version": "380",
       "license": "ISC",
       "devDependencies": {}
     }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "proyecto-barack",
-  "version": "379",
-  "description": "Versión actual: **379**",
+  "version": "380",
+  "description": "Versión actual: **380**",
   "main": "index.js",
   "directories": {
     "lib": "lib"


### PR DESCRIPTION
## Summary
- add reusable image viewer modal
- render button for each item in Sinóptico and Base de Datos
- update styling for view button and modal
- mention image folder and naming convention
- bump version to 380

## Testing
- `bash format_check.sh`


------
https://chatgpt.com/codex/tasks/task_e_6854656d03bc832fa74d9a959a346b73