### PR TITLE
Adjust sinoptico page layout

### DIFF
--- a/docs/assets/styles.css
+++ b/docs/assets/styles.css
@@ -86,7 +86,7 @@ body.home {
 }
 
 body.sinoptico-page {
-  padding-top: 80px;
+  padding-top: 100px;
 }
 h1 {
   text-align: center;
@@ -214,6 +214,9 @@ h1 {
   justify-content: space-between;
   align-items: center;
   gap: 12px;
+}
+body.sinoptico-page .filtro-contenedor {
+  margin-top: 20px;
 }
 .filtros-texto {
   display: flex;
@@ -886,7 +889,7 @@ body, html {
 }
 
 body.sinoptico-page .back-btn {
-  top: 80px;
+  top: 90px;
   padding: 6px 12px;
   border-radius: 6px;
 }


### PR DESCRIPTION
## Summary
- widen the padding above sinoptico page content
- shift the back button down
- ensure filters are pushed below the button

## Testing
- `bash format_check.sh`

------
https://chatgpt.com/codex/tasks/task_e_68546852cecc832f933d2920d2673ce2