### PR TITLE
Fix navbar dropdown on homepage

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -13,25 +13,7 @@
   </script>
 </head>
 <body>
-  <nav class="navbar">
-    <ul class="nav-list">
-      <li class="nav-item active"><a href="index.html">Inicio</a></li>
-      <li class="nav-item"><a href="sinoptico.html">Sinóptico</a></li>
-      <li class="nav-item"><a href="amfe.html">AMFE</a></li>
-      <li class="nav-item"><a href="maestro.html">Listado Maestro</a></li>
-      <li class="nav-item no-guest"><a href="database.html">Base de Datos</a></li>
-      <li class="nav-item no-guest"><a href="index.html#/settings">Modo Dev</a></li>
-      <li class="nav-item admin-only"><a href="history.html">Historial</a></li>
-    </ul>
-    <div class="spacer"></div>
-    <button class="theme-toggle" aria-label="Toggle theme">🌙</button>
-    <div class="user-menu">
-      <img src="assets/icons/avatar.svg" class="avatar" alt="Usuario"/>
-      <ul class="dropdown">
-        <li><button type="button" class="logout-link">Cerrar sesión</button></li>
-      </ul>
-    </div>
-  </nav>
+  <nav id="nav-placeholder"></nav>
   <section id="loading"></section>
   <section id="appMessage" role="alert" aria-live="polite"></section>
   <main id="app">Cargando…</main>

--- a/docs/nav.html
+++ b/docs/nav.html
@@ -21,9 +21,14 @@
       <a href="maestro.html#export">Exportar maestro</a>
     </div>
   </div>
-  <div class="nav-item no-guest"><a href="database.html">Base de Datos</a></div>
-  <div class="nav-item no-guest"><a href="index.html#/settings">Modo Dev</a></div>
-  <div class="nav-item admin-only"><a href="history.html">Historial</a></div>
+  <div class="nav-item dropdown">
+    <a href="#">Ver más</a>
+    <div class="dropdown-menu">
+      <a href="database.html" class="no-guest">Base de Datos</a>
+      <a href="index.html#/settings" class="no-guest">Modo Dev</a>
+      <a href="history.html" class="admin-only">Historial</a>
+    </div>
+  </div>
   <button id="toggleDarkMode" type="button" aria-label="Alternar modo oscuro" title="Alternar modo oscuro">🌙</button>
   <div class="user-menu">
     <img src="assets/icons/avatar.svg" class="avatar" alt="Usuario" />


### PR DESCRIPTION
## Summary
- switch home page to use shared navigation template
- add "Ver más" dropdown to group minor links

## Testing
- `./format_check.sh`

------
https://chatgpt.com/codex/tasks/task_e_685481fa03e4832f8994b4cd7dc61791