### PR TITLE
Fix nav layout issues and dark mode toggle

### DIFF
--- a/docs/assets/styles.css
+++ b/docs/assets/styles.css
@@ -815,7 +815,7 @@ body, html {
   width: 100%;
   background-color: rgba(13, 27, 61, 0.9);
   display: flex;
-  justify-content: center;
+  justify-content: flex-start;
   gap: 20px;
   padding: 10px;
   box-shadow: 0 2px 4px rgba(0,0,0,0.2);
@@ -867,7 +867,8 @@ body, html {
   color: var(--color-light);
   font-size: 1rem;
   cursor: pointer;
-  margin-left: 10px;
+  margin-left: auto;
+  margin-right: 10px;
 }
 
 .main-nav .logout-link {
@@ -2054,6 +2055,8 @@ tr:not(.pending) td:first-child::before {
   text-decoration: none;
   padding: .75rem 1rem;
   display: block;
+  border-bottom: 3px solid transparent;
+  box-sizing: border-box;
 }
 .nav-item.active a,
 .nav-item a:hover {
@@ -2067,6 +2070,7 @@ tr:not(.pending) td:first-child::before {
 }
 .user-menu {
   position: relative;
+  margin-right: 10px;
 }
 .user-menu .avatar {
   width: 32px; height: 32px; border-radius: 50%; cursor: pointer;

--- a/docs/js/app.js
+++ b/docs/js/app.js
@@ -35,6 +35,7 @@ function setupDarkMode() {
   const apply = state => {
     document.body.classList.toggle('dark', state);
     document.documentElement.classList.toggle('dark', state);
+    btn.textContent = state ? '☀️' : '🌙';
   };
   const stored = localStorage.getItem('darkMode');
   apply(stored === 'true');


### PR DESCRIPTION
## Summary
- keep the navbar from growing on hover
- push the dark mode toggle and user menu to the right
- show correct icon when switching themes

## Testing
- `./format_check.sh`


------
https://chatgpt.com/codex/tasks/task_e_685485045e28832faa54d3070c1e06a0