### PR TITLE
Simplify toolbar on sinoptico editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Proyecto Barack
 
-Versión actual: **384**
+Versión actual: **385**
 
 Esta es una pequeña SPA (Single Page Application) escrita en HTML, CSS y JavaScript.
 Incluye un módulo llamado *Sinóptico* para gestionar jerarquías de productos.

--- a/docs/js/editorUI.js
+++ b/docs/js/editorUI.js
@@ -96,11 +96,7 @@ async function handleArbol() {
 }
 
 function init() {
-  document.getElementById('btnEliminar')?.addEventListener('click', async () => {
-    const id = prompt('ID a eliminar');
-    if (id) await deleteSubtree(id);
-  });
-  // replaced by newProductDialog.js for a friendlier workflow
+  // expose deleteSubtree for inline actions
   window.SinopticoEditor = { deleteSubtree };
 }
 

--- a/docs/js/version.js
+++ b/docs/js/version.js
@@ -1,4 +1,4 @@
-export const version = '384';
+export const version = '385';
 export function displayVersion() {
   const div = document.createElement('div');
   div.className = 'version-info';

--- a/docs/js/views/sinoptico.js
+++ b/docs/js/views/sinoptico.js
@@ -1,12 +1,12 @@
-import { getAll, remove } from '../dataService.js';
+import { getAll } from '../dataService.js';
 import { createSinopticoEditor } from '../editors/sinopticoEditor.js';
 
 export async function render(container) {
   container.innerHTML = `
     <div class="toolbar">
       <button id="sin-edit">Editar</button>
-      <button id="btnNuevoCliente">Nuevo cliente</button>
-      <button id="sin-delete">Borrar</button>
+      <a id="linkCrear" href="arbol.html">Crear</a>
+      <a id="linkBaseDatos" href="database.html">Base de Datos</a>
       <button id="sin-export">Exportar...</button>
       <div class="export-menu">
         <button data-fmt="excel">Excel</button> |
@@ -91,10 +91,6 @@ export async function render(container) {
 
   checkHealth();
 
-  container.querySelector('#btnNuevoCliente').addEventListener('click', () => {
-    const dlg = document.getElementById('dlgNuevoCliente');
-    if (dlg && dlg.showModal) dlg.showModal();
-  });
 
   container.querySelector('#sin-edit').addEventListener('click', () => {
     const curr = sessionStorage.getItem('sinopticoEdit') === 'true';
@@ -102,11 +98,7 @@ export async function render(container) {
     document.dispatchEvent(new Event('sinoptico-mode'));
   });
 
-  container.querySelector('#sin-delete').addEventListener('click', async () => {
-    if (!confirm('¿Eliminar todos los elementos?')) return;
-    const items = await getAll('sinoptico');
-    for (const item of items) await remove('sinoptico', item.id);
-  });
+
 
 }
 

--- a/docs/sinoptico-editor.html
+++ b/docs/sinoptico-editor.html
@@ -19,12 +19,8 @@
     <h1 class="editor-title">Editor de Sinóptico</h1>
   </header>
   <section class="editor-menu">
-    <button id="btnNuevoCliente">Nuevo cliente</button>
-    <button id="btnNuevoProducto">Nuevo producto</button>
-    <button id="btnNuevoSub">Nuevo subproducto</button>
-    <button id="btnNuevoInsumo">Nuevo insumo</button>
-    <button id="btnEliminar">Eliminar</button>
-    <a id="linkArbol" href="arbol.html">Crear árbol</a>
+    <a id="linkCrear" href="arbol.html">Crear</a>
+    <a id="linkBaseDatos" href="database.html">Base de Datos</a>
   </section>
   <section id="loading"></section>
   <section id="appMessage" role="alert" aria-live="polite"></section>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "proyecto-barack",
-  "version": "384",
+  "version": "385",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "proyecto-barack",
-      "version": "384",
+      "version": "385",
       "license": "ISC",
       "devDependencies": {}
     }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "proyecto-barack",
-  "version": "384",
-  "description": "Versión actual: **384**",
+  "version": "385",
+  "description": "Versión actual: **385**",
   "main": "index.js",
   "directories": {
     "lib": "lib"


### PR DESCRIPTION
## Summary
- remove unused delete controls in sinoptico editor
- provide quick links to create items and open database
- hide redundant listeners
- bump version to 385

## Testing
- `bash format_check.sh`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685493e843f0832fb79ba60936114b7b