### PR TITLE
Fix back navigation and style actions column

### DIFF
--- a/docs/arbol.html
+++ b/docs/arbol.html
@@ -14,7 +14,7 @@
 </head>
 <body>
   <nav id="nav-placeholder"></nav>
-  <button class="back-btn" onclick="history.back()">← Volver</button>
+  <button class="back-btn" onclick="goBack()">← Volver</button>
   <section id="loading"></section>
   <section id="appMessage" role="alert" aria-live="polite"></section>
   <section id="step1" class="node-form">
@@ -90,6 +90,7 @@
   <script type="module" src="js/dataService.js" defer></script>
   <script type="module" src="js/arbol.js" defer></script>
   <script type="module" src="js/ui/animations.js" defer></script>
+  <script type="module" src="js/backButton.js" defer></script>
   <script type="module" src="js/app.js" defer></script>
   <script type="module" src="js/pageSettings.js" defer></script>
   <script type="module" src="js/hideLoading.js" defer></script>

--- a/docs/assets/styles.css
+++ b/docs/assets/styles.css
@@ -320,6 +320,10 @@ table#sinoptico thead th {
   text-align: left;
   z-index: 2;
 }
+#thActions {
+  background-color: var(--color-danger);
+  color: var(--color-light);
+}
 table#sinoptico tbody tr {
   transition: background-color 0.2s;
 }
@@ -891,24 +895,27 @@ body, html {
   position: fixed;
   top: 70px;
   left: 10px;
-  background: rgba(255, 255, 255, 0.8);
+  background: linear-gradient(135deg, var(--color-accent), var(--color-primary));
   border: none;
-  border-radius: 4px;
-  padding: 4px 8px;
-  font-size: 0.9rem;
-  color: var(--color-text);
+  border-radius: 6px;
+  padding: 6px 14px;
+  font-size: 1rem;
+  color: var(--color-light);
   cursor: pointer;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
   z-index: 1000;
+  transition: filter 0.2s;
+}
+.back-btn:hover {
+  filter: brightness(1.1);
 }
 .dark .back-btn {
-  background: rgba(0, 0, 0, 0.5);
+  background: linear-gradient(135deg, var(--color-primary), var(--color-accent));
   color: var(--color-light);
 }
 
 body.sinoptico-page .back-btn {
   top: 90px;
-  padding: 6px 12px;
-  border-radius: 6px;
 }
 
 header {
@@ -1330,6 +1337,10 @@ select {
   background-color: var(--color-primary-hover);
 }
 
+.actions-col {
+  background-color: rgba(231, 76, 60, 0.1);
+  text-align: center;
+}
 .actions-col button {
   padding: 2px 6px;
 }
@@ -1341,7 +1352,7 @@ select {
   font-size: 1rem;
   padding: 2px 4px;
 }
-.edit-btn {
+...edit-btn {
   color: var(--color-primary);
 }
 .edit-btn:hover {

--- a/docs/database.html
+++ b/docs/database.html
@@ -14,7 +14,7 @@
 </head>
 <body>
   <nav id="nav-placeholder"></nav>
-  <button class="back-btn" onclick="history.back()">← Volver</button>
+  <button class="back-btn" onclick="goBack()">← Volver</button>
   <header class="editor-header">
     <h1 class="editor-title">Base de Datos</h1>
   </header>
@@ -117,6 +117,7 @@
   <script type="module" src="js/dataService.js" defer></script>
   <script type="module" src="js/dbPage.js" defer></script>
   <script type="module" src="js/ui/animations.js" defer></script>
+  <script type="module" src="js/backButton.js" defer></script>
   <script type="module" src="js/imageViewer.js" defer></script>
   <script type="module" src="js/app.js" defer></script>
   <script type="module" src="js/pageSettings.js" defer></script>

--- a/docs/history.html
+++ b/docs/history.html
@@ -14,7 +14,7 @@
 </head>
 <body>
   <nav id="nav-placeholder"></nav>
-  <button class="back-btn" onclick="history.back()">← Volver</button>
+  <button class="back-btn" onclick="goBack()">← Volver</button>
   <h1>Historial reciente</h1>
   <section class="tabla-contenedor">
     <table id="historyTable">
@@ -32,6 +32,7 @@
   <script type="module" src="js/nav.js" defer></script>
   <script type="module" src="js/history.js"></script>
   <script type="module" src="js/ui/animations.js" defer></script>
+  <script type="module" src="js/backButton.js" defer></script>
   <script type="module" src="js/app.js" defer></script>
   <script type="module" src="js/pageSettings.js" defer></script>
   <script type="module" src="js/version.js" defer></script>

--- a/docs/js/backButton.js
+++ b/docs/js/backButton.js
@@ -1,0 +1,12 @@
+export function goBack() {
+  const ref = document.referrer;
+  if (ref) {
+    window.location.href = ref;
+  } else {
+    window.history.back();
+  }
+}
+
+if (typeof window !== 'undefined') {
+  window.goBack = goBack;
+}

--- a/docs/js/ui/renderer.js
+++ b/docs/js/ui/renderer.js
@@ -347,6 +347,7 @@ document.addEventListener('DOMContentLoaded', () => {
       const editing=sessionStorage.getItem('sinopticoEdit')==='true';
       if(editing){
         const tdA=document.createElement('td');
+        tdA.className='actions-col';
         const tipo=(fila.Tipo||'').toLowerCase();
         const allowEdit=!['cliente','producto','pieza final'].includes(tipo);
         if(allowEdit){

--- a/docs/login.html
+++ b/docs/login.html
@@ -13,7 +13,7 @@
   </script>
 </head>
 <body>
-  <button class="back-btn" onclick="history.back()">← Volver</button>
+  <button class="back-btn" onclick="goBack()">← Volver</button>
   <main class="login-container">
     <h1 class="login-title">Acceso</h1>
     <section class="login-form">
@@ -36,6 +36,7 @@
     </p>
   </noscript>
   <script type="module" src="js/ui/animations.js" defer></script>
+  <script type="module" src="js/backButton.js" defer></script>
   <script type="module" src="js/login.js"></script>
 </body>
 </html>

--- a/docs/maestro.html
+++ b/docs/maestro.html
@@ -15,7 +15,7 @@
 <body>
   <nav id="nav-placeholder"></nav>
   <main class="maestro-page">
-    <button class="back-btn" onclick="history.back()">← Volver</button>
+    <button class="back-btn" onclick="goBack()">← Volver</button>
     <h1>Listado Maestro</h1>
     <div class="top-actions">
       <button id="printBtn">🖨 Print</button>
@@ -103,6 +103,7 @@
   <script src="lib/xlsx.full.noeval.js" defer></script>
   <script type="module" src="js/maestro.js" defer></script>
   <script type="module" src="js/ui/animations.js" defer></script>
+  <script type="module" src="js/backButton.js" defer></script>
   <script type="module" src="js/app.js" defer></script>
   <script type="module" src="js/hideLoading.js" defer></script>
   <script type="module" src="js/pageSettings.js" defer></script>

--- a/docs/sinoptico-editor.html
+++ b/docs/sinoptico-editor.html
@@ -14,7 +14,7 @@
 </head>
 <body>
   <nav id="nav-placeholder"></nav>
-  <button class="back-btn" onclick="history.back()">← Volver</button>
+  <button class="back-btn" onclick="goBack()">← Volver</button>
   <header class="editor-header">
     <h1 class="editor-title">Editor de Sinóptico</h1>
   </header>
@@ -146,6 +146,7 @@
   <script type="module" src="js/views/sinoptico.js" defer></script>
   <script type="module" src="js/ui/renderer.js" defer></script>
   <script type="module" src="js/ui/animations.js" defer></script>
+  <script type="module" src="js/backButton.js" defer></script>
   <script type="module" src="js/imageViewer.js" defer></script>
   <script type="module" src="js/app.js" defer></script>
   <script type="module" src="js/pageSettings.js" defer></script>

--- a/docs/sinoptico.html
+++ b/docs/sinoptico.html
@@ -14,7 +14,7 @@
 </head>
 <body class="sinoptico-page">
   <nav id="nav-placeholder"></nav>
-  <button class="back-btn" onclick="history.back()">← Volver</button>
+  <button class="back-btn" onclick="goBack()">← Volver</button>
   <section class="filtro-contenedor">
     <section class="filtros-texto">
       <label for="search">Buscar:</label>
@@ -68,6 +68,7 @@
   <script type="module" src="js/views/sinoptico.js" defer></script>
   <script type="module" src="js/ui/renderer.js" defer></script>
   <script type="module" src="js/ui/animations.js" defer></script>
+  <script type="module" src="js/backButton.js" defer></script>
   <script type="module" src="js/imageViewer.js" defer></script>
   <script type="module" src="js/app.js" defer></script>
   <script type="module" src="js/pageSettings.js" defer></script>


### PR DESCRIPTION
## Summary
- add dedicated back navigation script and include it in HTML pages
- restyle back button
- highlight actions column header
- style delete actions column cells
- mark action cells when generating table

## Testing
- `./format_check.sh`

------
https://chatgpt.com/codex/tasks/task_e_685495fa2fdc832f9f919eaed238f4b8