### PR TITLE
Add creation dropdown to synoptic editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Proyecto Barack
 
-Versión actual: **385**
+Versión actual: **386**
 
 Esta es una pequeña SPA (Single Page Application) escrita en HTML, CSS y JavaScript.
 Incluye un módulo llamado *Sinóptico* para gestionar jerarquías de productos.

--- a/docs/assets/styles.css
+++ b/docs/assets/styles.css
@@ -851,6 +851,9 @@ body, html {
   box-shadow: 0 2px 6px rgba(0,0,0,0.2);
   min-width: 160px;
   z-index: 1100;
+  opacity: 0;
+  transform: translateY(10px);
+  transition: opacity 0.2s, transform 0.2s;
 }
 .dropdown-menu a {
   display: block;
@@ -862,11 +865,27 @@ body, html {
 .dropdown-menu a:hover {
   background: rgba(255,255,255,0.1);
 }
+.dropdown-menu button {
+  display: block;
+  width: 100%;
+  padding: 4px 12px;
+  border: none;
+  background: none;
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+.dropdown-menu button:hover {
+  background: rgba(255,255,255,0.1);
+}
 .dropdown:hover .dropdown-menu {
   display: block;
 }
+.dropdown.open .dropdown-menu,
 .nav-item.dropdown.open .dropdown-menu {
   display: block;
+  opacity: 1;
+  transform: translateY(0);
 }
 .main-nav #toggleDarkMode {
   background: none;
@@ -1439,7 +1458,8 @@ select {
   justify-content: center;
 }
 
-.editor-menu button {
+.editor-menu > button,
+.editor-menu > .dropdown > button {
   padding: 10px 18px;
   background: linear-gradient(135deg, var(--color-accent), var(--color-primary));
   color: var(--color-light);

--- a/docs/js/crearMenu.js
+++ b/docs/js/crearMenu.js
@@ -1,0 +1,19 @@
+export function initCrearMenu() {
+  const menuBtn = document.getElementById('btnMenuCrear');
+  const dropdown = menuBtn?.nextElementSibling;
+  if (!menuBtn || !dropdown) return;
+  menuBtn.addEventListener('click', e => {
+    e.stopPropagation();
+    dropdown.parentElement.classList.toggle('open');
+  });
+  window.addEventListener('click', e => {
+    if (!dropdown.parentElement.contains(e.target)) {
+      dropdown.parentElement.classList.remove('open');
+    }
+  });
+}
+
+if (typeof window !== 'undefined') {
+  window.initCrearMenu = initCrearMenu;
+  document.addEventListener('DOMContentLoaded', initCrearMenu);
+}

--- a/docs/js/version.js
+++ b/docs/js/version.js
@@ -1,4 +1,4 @@
-export const version = '385';
+export const version = '386';
 export function displayVersion() {
   const div = document.createElement('div');
   div.className = 'version-info';

--- a/docs/sinoptico-editor.html
+++ b/docs/sinoptico-editor.html
@@ -10,6 +10,8 @@
     if (localStorage.getItem('darkMode') === 'true') {
       document.documentElement.classList.add('dark');
     }
+    // Ensure edit mode is active before loading modules
+    sessionStorage.setItem('sinopticoEdit', 'true');
   </script>
 </head>
 <body>
@@ -19,7 +21,16 @@
     <h1 class="editor-title">Editor de Sinóptico</h1>
   </header>
   <section class="editor-menu">
-    <a id="linkCrear" href="arbol.html">Crear</a>
+    <div class="dropdown">
+      <button id="btnMenuCrear" type="button">Crear ▼</button>
+      <div class="dropdown-menu crear-menu">
+        <button id="btnNuevoCliente" type="button">Cliente</button>
+        <button id="btnNuevoProducto" type="button">Producto</button>
+        <button id="btnNuevoSub" type="button">Subcomponente</button>
+        <button id="btnNuevoInsumo" type="button">Insumo</button>
+        <a id="linkArbol" href="arbol.html">Árbol de producto</a>
+      </div>
+    </div>
     <a id="linkBaseDatos" href="database.html">Base de Datos</a>
   </section>
   <section id="loading"></section>
@@ -148,6 +159,7 @@
   <script type="module" src="js/ui/animations.js" defer></script>
   <script type="module" src="js/backButton.js" defer></script>
   <script type="module" src="js/imageViewer.js" defer></script>
+  <script type="module" src="js/crearMenu.js" defer></script>
   <script type="module" src="js/app.js" defer></script>
   <script type="module" src="js/pageSettings.js" defer></script>
   <script type="module" src="js/hideLoading.js" defer></script>
@@ -157,8 +169,5 @@
   <script type="module" src="js/newSubDialog.js" defer></script>
   <script type="module" src="js/newInsumoDialog.js" defer></script>
   <script type="module" src="js/version.js" defer></script>
-  <script>
-    sessionStorage.setItem('sinopticoEdit', 'true');
-  </script>
 </body>
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "proyecto-barack",
-  "version": "385",
+  "version": "386",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "proyecto-barack",
-      "version": "385",
+      "version": "386",
       "license": "ISC",
       "devDependencies": {}
     }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "proyecto-barack",
-  "version": "385",
-  "description": "Versión actual: **385**",
+  "version": "386",
+  "description": "Versión actual: **386**",
   "main": "index.js",
   "directories": {
     "lib": "lib"


### PR DESCRIPTION
## Summary
- enable edit mode earlier in *sinoptico-editor.html*
- add creation dropdown with options for Cliente, Producto, Subcomponente, Insumo and Árbol
- style dropdown menus with smooth animations
- ensure menu logic via new `crearMenu.js`
- bump version to 386

## Testing
- `bash format_check.sh`

------
https://chatgpt.com/codex/tasks/task_e_6854989f0d7c832faa624a82f257c12d