### PR TITLE
Fix dropdown in sinoptico editor

### DIFF
--- a/docs/assets/styles.css
+++ b/docs/assets/styles.css
@@ -839,6 +839,11 @@ body, html {
 .nav-item {
   position: relative;
 }
+
+/* ensure standalone dropdowns position child menu correctly */
+.dropdown {
+  position: relative;
+}
 .dropdown-menu {
   display: none;
   position: absolute;


### PR DESCRIPTION
## Summary
- fix the dropdown in the sinoptico editor so menus position correctly

## Testing
- `bash format_check.sh`

------
https://chatgpt.com/codex/tasks/task_e_68549af3e848832fbde12d2ec4d8f50e