### PR TITLE
Fix dropdown menu closing

### DIFF
--- a/docs/assets/styles.css
+++ b/docs/assets/styles.css
@@ -883,9 +883,6 @@ body, html {
 .dropdown-menu button:hover {
   background: rgba(255,255,255,0.1);
 }
-.dropdown:hover .dropdown-menu {
-  display: block;
-}
 .dropdown.open .dropdown-menu,
 .nav-item.dropdown.open .dropdown-menu {
   display: block;


### PR DESCRIPTION
## Summary
- remove hover rule from dropdowns so the click-based menu stays open

## Testing
- `bash format_check.sh`

------
https://chatgpt.com/codex/tasks/task_e_6854a5ec3bb0832fb4e32ae855069079