### PR TITLE
Fix blank product tree page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Proyecto Barack
 
-Versión actual: **387**
+Versión actual: **388**
 
 Esta es una pequeña SPA (Single Page Application) escrita en HTML, CSS y JavaScript.
 Incluye un módulo llamado *Sinóptico* para gestionar jerarquías de productos.

--- a/docs/assets/styles.css
+++ b/docs/assets/styles.css
@@ -1522,6 +1522,32 @@ select {
   transform: scale(1.05);
 }
 
+/* ========= Product Tree App ========= */
+.tree-app {
+  display: flex;
+  gap: 20px;
+  padding: 20px;
+  align-items: flex-start;
+}
+
+.tree-container {
+  flex: 1;
+  overflow: auto;
+}
+
+.side-panel {
+  width: 260px;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  padding: 10px;
+  background: var(--color-light, #fff);
+}
+.dark .side-panel {
+  background: #333;
+  color: var(--color-light, #eee);
+}
+
+
 /* ========= Tree preview ========= */
 .tree-preview {
   margin: 20px auto;

--- a/docs/js/productTree.js
+++ b/docs/js/productTree.js
@@ -98,6 +98,24 @@ function App() {
     fetchSinoptico().then(data => setTree(buildTree(data)));
   }, []);
 
+  const addRoot = () => {
+    const id = Date.now().toString();
+    const root = {
+      ID: id,
+      ParentID: '',
+      Tipo: 'Producto',
+      Descripción: 'Nuevo producto',
+      Código: '',
+      Largo: '',
+      Ancho: '',
+      Alto: '',
+      Peso: '',
+      children: []
+    };
+    setTree([root]);
+    setSelected(root);
+  };
+
   const addChild = (parent) => {
     const id = Date.now().toString();
     const child = { ID: id, ParentID: parent.ID, Tipo: 'Subcomponente', Descripción: 'Nuevo', Código: '', Largo: '', Ancho: '', Alto: '', Peso: '', children: [] };
@@ -122,12 +140,15 @@ function App() {
   };
 
   return React.createElement('div', { className: 'tree-app' },
-    React.createElement('div', { className: 'tree-container' },
-      React.createElement(Tree, { lineWidth: '2px', lineColor: '#888', lineBorderRadius: '10px' },
-        tree.map(n => React.createElement(RenderNode, { key: n.ID, node: n, admin, onSelect: setSelected, onAdd: addChild }))
-      )
-    ),
-    admin && React.createElement('button', { id: 'saveTree', onClick: handleSave }, 'Guardar árbol'),
+    tree.length === 0 && admin &&
+      React.createElement('button', { id: 'createRoot', onClick: addRoot }, 'Crear producto'),
+    tree.length > 0 &&
+      React.createElement('div', { className: 'tree-container' },
+        React.createElement(Tree, { lineWidth: '2px', lineColor: '#888', lineBorderRadius: '10px' },
+          tree.map(n => React.createElement(RenderNode, { key: n.ID, node: n, admin, onSelect: setSelected, onAdd: addChild }))
+        )
+      ),
+    admin && tree.length > 0 && React.createElement('button', { id: 'saveTree', onClick: handleSave }, 'Guardar árbol'),
     React.createElement(SidePanel, { node: selected, onChange: updateNode, onClose: closePanel })
   );
 }

--- a/docs/js/version.js
+++ b/docs/js/version.js
@@ -1,4 +1,4 @@
-export const version = '387';
+export const version = '388';
 export function displayVersion() {
   const div = document.createElement('div');
   div.className = 'version-info';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "proyecto-barack",
-  "version": "387",
+  "version": "388",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "proyecto-barack",
-      "version": "387",
+      "version": "388",
       "license": "ISC",
       "devDependencies": {}
     }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "proyecto-barack",
-  "version": "387",
-  "description": "Versión actual: **387**",
+  "version": "388",
+  "description": "Versión actual: **388**",
   "main": "index.js",
   "directories": {
     "lib": "lib"


### PR DESCRIPTION
## Summary
- add a "Crear producto" button to initialize an empty tree
- style the new tree page UI elements
- bump version to 388

## Testing
- `./format_check.sh`
- `npm test` *(fails: Missing script)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6854b0631aa4832facd980177772ef68