### PR TITLE
Fix blank product tree

### DIFF
--- a/docs/js/productTree.js
+++ b/docs/js/productTree.js
@@ -1,7 +1,9 @@
 import { getAll, replaceAll, ready } from './dataService.js';
 import { isAdmin } from './session.js';
 
-const { Tree, TreeNode } = window['react-organizational-chart'];
+// Library exposes a global named `reactOrganizationalChart`.
+// Using the wrong name prevents the tree from rendering.
+const { Tree, TreeNode } = window.reactOrganizationalChart || {};
 const { useState, useEffect } = React;
 
 async function fetchSinoptico() {


### PR DESCRIPTION
## Summary
- use correct `reactOrganizationalChart` global when rendering the product tree

## Testing
- `./format_check.sh`


------
https://chatgpt.com/codex/tasks/task_e_6854b2b43840832fac69e123694a9b27