### PR TITLE
Simplify product tree page

### DIFF
--- a/docs/arbol.html
+++ b/docs/arbol.html
@@ -18,9 +18,6 @@
   <section id="loading"></section>
   <section id="appMessage" role="alert" aria-live="polite"></section>
   <div id="root"></div>
-  <script src="lib/react.production.min.js"></script>
-  <script src="lib/react-dom.production.min.js"></script>
-  <script src="lib/react-organizational-chart.js"></script>
   <script type="module" src="js/authGuard.js"></script>
   <script type="module" src="js/nav.js" defer></script>
   <script type="module" src="js/dataService.js" defer></script>


### PR DESCRIPTION
## Summary
- simplify _Árbol de producto_ page and remove React dependencies
- reimplement `productTree.js` without external libraries

## Testing
- `bash format_check.sh`

------
https://chatgpt.com/codex/tasks/task_e_6854b470dd6c832fae5e58c573690700