### PR TITLE
Add wizard progress bar for product builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Proyecto Barack
 
-Versión actual: **391**
+Versión actual: **392**
 
 Esta es una pequeña SPA (Single Page Application) escrita en HTML, CSS y JavaScript.
 Incluye un módulo llamado *Sinóptico* para gestionar jerarquías de productos.

--- a/docs/arbol.html
+++ b/docs/arbol.html
@@ -20,7 +20,9 @@
   </nav>
   <div id="loading"></div>
   <div id="appMessage" role="alert" aria-live="polite"></div>
-  <div id="step1" class="node-form">
+  <div class="wizard">
+    <div class="progress"><div id="progressBar"></div></div>
+    <div id="step1" class="wizard-step active node-form">
     <h2>Nuevo Producto</h2>
     <label for="productCliente">Cliente:</label>
     <select id="productCliente"></select>
@@ -40,8 +42,8 @@
       <button id="confirmBtn" type="button">Crear sin subcomponentes</button>
       <button id="continueBtn" type="button">Continuar</button>
     </div>
-  </div>
-  <div id="step2" class="node-form" style="display:none">
+    </div>
+    <div id="step2" class="wizard-step node-form">
     <h2>Subcomponentes e Insumos</h2>
     <div class="tree-preview flow-diagram">
       <span id="productPreview" class="tree-node product-node"></span>
@@ -84,6 +86,7 @@
     </fieldset>
     <div class="form-actions">
       <button id="finishBtn" type="button">Finalizar</button>
+    </div>
     </div>
   </div>
   <script src="lib/dexie.min.js" defer></script>

--- a/docs/assets/styles.css
+++ b/docs/assets/styles.css
@@ -1797,7 +1797,7 @@ select {
 .wizard .progress #progressBar { height:100%; width:0; background:linear-gradient(90deg,#4b6cb7,#182848); transition:width 0.3s; }
 .client-info { text-align:center; margin-bottom:10px; font-weight:bold; }
 .wizard-step { display:none; }
-.wizard-step.active { display:block; }
+.wizard-step.active { display:flex; }
 .wizard-step > button {
   padding: 6px 12px;
   background-color: var(--color-primary);

--- a/docs/js/arbol.js
+++ b/docs/js/arbol.js
@@ -14,6 +14,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   const confirmBtn = document.getElementById('confirmBtn');
   const step1 = document.getElementById('step1');
   const step2 = document.getElementById('step2');
+  const progressBar = document.getElementById('progressBar');
 
   const subDesc = document.getElementById('subDesc');
   const subCode = document.getElementById('subCode');
@@ -188,6 +189,7 @@ document.addEventListener('DOMContentLoaded', async () => {
       productPeso.value.trim()
     );
     await persist(product, [], []);
+    if (progressBar) progressBar.style.width = '100%';
     if (window.mostrarMensaje) window.mostrarMensaje('Producto creado con éxito', 'success');
     window.location.href = 'sinoptico-editor.html';
   });
@@ -206,8 +208,9 @@ document.addEventListener('DOMContentLoaded', async () => {
       alto: productAlto.value.trim(),
       peso: productPeso.value.trim()
     };
-    step1.style.display = 'none';
-    step2.style.display = 'flex';
+    step1.classList.remove('active');
+    step2.classList.add('active');
+    if (progressBar) progressBar.style.width = '50%';
     if (productPreview) {
       productPreview.textContent = code ? `${desc} (${code})` : desc;
     }
@@ -317,6 +320,7 @@ document.addEventListener('DOMContentLoaded', async () => {
       productData.peso
     );
     await persist(product, subcomponents, insumos);
+    if (progressBar) progressBar.style.width = '100%';
     if (window.mostrarMensaje) window.mostrarMensaje('Árbol creado con éxito', 'success');
     window.location.href = 'sinoptico-editor.html';
   });

--- a/docs/js/version.js
+++ b/docs/js/version.js
@@ -1,4 +1,4 @@
-export const version = '391';
+export const version = '392';
 export function displayVersion() {
   const div = document.createElement('div');
   div.className = 'version-info';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "proyecto-barack",
-  "version": "391",
+  "version": "392",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "proyecto-barack",
-      "version": "391",
+      "version": "392",
       "license": "ISC",
       "dependencies": {
         "jsdom": "^22.1.0"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "proyecto-barack",
-  "version": "391",
-  "description": "Versión actual: **391**",
+  "version": "392",
+  "description": "Versión actual: **392**",
   "main": "index.js",
   "directories": {
     "lib": "lib"


### PR DESCRIPTION
## Summary
- integrate `wizard` progress bar into `arbol.html`
- update `arbol.js` to use progress bar for steps
- keep layout with `wizard-step` styles
- bump version to 392

## Testing
- `black --check server.py`

------
https://chatgpt.com/codex/tasks/task_e_6854da4bbc30832f942ad9615fa0d0ac