### PR TITLE
Improve product tree clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Proyecto Barack
 
-Versión actual: **392**
+Versión actual: **393**
 
 Esta es una pequeña SPA (Single Page Application) escrita en HTML, CSS y JavaScript.
 Incluye un módulo llamado *Sinóptico* para gestionar jerarquías de productos.

--- a/docs/assets/styles.css
+++ b/docs/assets/styles.css
@@ -1621,7 +1621,7 @@ select {
 .product-node {
   font-weight: bold;
   background-color: var(--color-accent);
-  color: var(--color-light);
+  color: var(--color-text);
 }
 
 .insumo-node {

--- a/docs/js/arbol.js
+++ b/docs/js/arbol.js
@@ -212,7 +212,8 @@ document.addEventListener('DOMContentLoaded', async () => {
     step2.classList.add('active');
     if (progressBar) progressBar.style.width = '50%';
     if (productPreview) {
-      productPreview.textContent = code ? `${desc} (${code})` : desc;
+      const info = code ? `${desc} (${code})` : desc;
+      productPreview.textContent = `Producto: ${info}`;
     }
     if (subParent) {
       subParent.innerHTML = '<option value="root">(Producto principal)</option>';

--- a/docs/js/version.js
+++ b/docs/js/version.js
@@ -1,4 +1,4 @@
-export const version = '392';
+export const version = '393';
 export function displayVersion() {
   const div = document.createElement('div');
   div.className = 'version-info';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "proyecto-barack",
-  "version": "392",
+  "version": "393",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "proyecto-barack",
-      "version": "392",
+      "version": "393",
       "license": "ISC",
       "dependencies": {
         "jsdom": "^22.1.0"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "proyecto-barack",
-  "version": "392",
-  "description": "Versión actual: **392**",
+  "version": "393",
+  "description": "Versión actual: **393**",
   "main": "index.js",
   "directories": {
     "lib": "lib"


### PR DESCRIPTION
## Summary
- increment version to 393
- adjust product node colors for better contrast
- label the product preview to avoid confusion

## Testing
- `bash format_check.sh`
- `python -m py_compile server.py`
- `python -m py_compile backend/main.py`


------
https://chatgpt.com/codex/tasks/task_e_68557d380e78832f91c018dbb01b1a84