### PR TITLE
Fix dev banner shown outside settings

### DIFF
--- a/docs/js/pageSettings.js
+++ b/docs/js/pageSettings.js
@@ -29,7 +29,8 @@ export function activateDevMode() {
 }
 
 export function checkDevBanner() {
-  if (localStorage.getItem('devMode') === 'true') {
+  const inSettings = document.body.classList.contains('settings-page');
+  if (inSettings && localStorage.getItem('devMode') === 'true') {
     showDevBanner();
   }
 }


### PR DESCRIPTION
## Summary
- limit dev banner to settings page only

## Testing
- `./format_check.sh`


------
https://chatgpt.com/codex/tasks/task_e_68557e622108832fa1ba5607aba1472c