### PR TITLE
Add new assistant for product tree creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Proyecto Barack
 
-Versión actual: **393**
+Versión actual: **394**
 
 Esta es una pequeña SPA (Single Page Application) escrita en HTML, CSS y JavaScript.
 Incluye un módulo llamado *Sinóptico* para gestionar jerarquías de productos.
@@ -59,7 +59,7 @@ await dataService.importJSON(json); // Restaura la copia
 
 Si ya conoces estas páginas, puedes trabajar solo con `docs/sinoptico-editor.html` y consultar los datos desde `docs/sinoptico.html`. La SPA (`index.html`) queda como opción adicional.
 
-### Crear un nuevo producto con `docs/arbol.html`
+### Crear un nuevo producto con `docs/asistente.html`
 
 - Selecciona el cliente, la descripción y el código del producto.
 - Verás una vista previa del nodo seguido de sus subcomponentes e insumos.

--- a/docs/asistente.html
+++ b/docs/asistente.html
@@ -1,0 +1,125 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Crear árbol de producto</title>
+  <link rel="stylesheet" href="assets/styles.css">
+  <script>
+    if (localStorage.getItem('darkMode') === 'true') {
+      document.documentElement.classList.add('dark-mode');
+    }
+  </script>
+</head>
+<body>
+  <nav class="main-nav">
+    <a href="index.html">Inicio</a>
+    <a href="sinoptico-editor.html" class="no-guest">Editor Sinóptico</a>
+    <button id="toggleDarkMode" type="button">🌙</button>
+    <button type="button" class="logout-link">Salir</button>
+  </nav>
+  <div id="loading"></div>
+  <div id="appMessage" role="alert" aria-live="polite"></div>
+  <div class="wizard">
+    <div class="progress"><div id="progressBar"></div></div>
+    <div class="step-indicator">
+      <span class="step active">1</span>
+      <span class="step">2</span>
+      <span class="step">3</span>
+      <span class="step">4</span>
+    </div>
+    <div id="step1" class="wizard-step active node-form">
+      <h2>Datos Generales</h2>
+      <label for="productCliente">Cliente:</label>
+      <select id="productCliente"></select>
+      <label for="productDesc">Descripción:</label>
+      <input id="productDesc" type="text" required placeholder="Descripción del producto">
+      <label for="productCode">Código:</label>
+      <input id="productCode" type="text" placeholder="Código (opcional)">
+      <label for="productLargo">Largo (mm):</label>
+      <input id="productLargo" type="number" step="any" placeholder="Largo">
+      <label for="productAncho">Ancho (mm):</label>
+      <input id="productAncho" type="number" step="any" placeholder="Ancho">
+      <label for="productAlto">Alto (mm):</label>
+      <input id="productAlto" type="number" step="any" placeholder="Alto">
+      <label for="productPeso">Peso (kg):</label>
+      <input id="productPeso" type="number" step="any" placeholder="Peso">
+      <div class="form-actions">
+        <button id="continueBtn" type="button">Siguiente</button>
+      </div>
+    </div>
+    <div id="step2" class="wizard-step node-form">
+      <h2>Crear Subcomponentes</h2>
+      <fieldset class="sub-section">
+        <legend>Nuevo subcomponente</legend>
+        <label for="subDesc">Descripción:</label>
+        <input id="subDesc" type="text" placeholder="Descripción del subcomponente">
+        <label for="subCode">Código:</label>
+        <input id="subCode" type="text" placeholder="Código (opcional)">
+        <label for="subParent">Depende de:</label>
+        <select id="subParent"></select>
+        <button id="addSubBtn" type="button">Agregar subcomponente</button>
+      </fieldset>
+      <div class="form-actions">
+        <button id="backTo1" type="button">Atrás</button>
+        <button id="gotoStep3" type="button">Siguiente</button>
+      </div>
+      <div id="treeContainer" class="tree-preview flow-diagram">
+        <span id="productPreview" class="tree-node product-node"></span>
+        <ul id="subList" class="tree-list"></ul>
+      </div>
+    </div>
+    <div id="step3" class="wizard-step node-form">
+      <h2>Agregar Insumos</h2>
+      <fieldset class="sub-section">
+        <legend>Nuevo insumo</legend>
+        <label for="insumoDesc">Descripción:</label>
+        <input id="insumoDesc" type="text" placeholder="Descripción del insumo">
+        <label for="insumoCode">Código:</label>
+        <input id="insumoCode" type="text" placeholder="Código (opcional)">
+        <label for="insumoUnidad">Unidad:</label>
+        <input id="insumoUnidad" type="text" placeholder="Unidad">
+        <label for="insumoProveedor">Proveedor:</label>
+        <input id="insumoProveedor" type="text" placeholder="Proveedor">
+        <label for="insumoMaterial">Material:</label>
+        <input id="insumoMaterial" type="text" placeholder="Material">
+        <label for="insumoOrigen">Origen:</label>
+        <select id="insumoOrigen">
+          <option value="Local">Local</option>
+          <option value="Interno">Interno</option>
+          <option value="Importado">Importado</option>
+          <option value="Consignado">Consignado</option>
+        </select>
+        <label for="insumoObs">Observaciones:</label>
+        <input id="insumoObs" type="text" placeholder="Observaciones">
+        <label for="insumoParent">Asociado a:</label>
+        <select id="insumoParent"></select>
+        <button id="addInsumoBtn" type="button">Agregar insumo</button>
+      </fieldset>
+      <div class="form-actions">
+        <button id="backTo2" type="button">Atrás</button>
+        <button id="gotoStep4" type="button">Siguiente</button>
+      </div>
+      <div id="treeHolder2"></div>
+    </div>
+    <div id="step4" class="wizard-step node-form">
+      <h2>Vista Previa</h2>
+      <div class="form-actions">
+        <button id="backTo3" type="button">Atrás</button>
+        <button id="finishBtn" type="button">Guardar Árbol</button>
+      </div>
+      <div id="treeHolder4"></div>
+    </div>
+  </div>
+  <script src="lib/dexie.min.js" defer></script>
+  <script src="./socket.io/socket.io.js" defer></script>
+  <script type="module" src="js/authGuard.js"></script>
+  <script type="module" src="js/dataService.js" defer></script>
+  <script type="module" src="js/asistente.js" defer></script>
+  <script type="module" src="js/ui/animations.js" defer></script>
+  <script type="module" src="js/darkMode.js" defer></script>
+  <script type="module" src="js/pageSettings.js" defer></script>
+  <script type="module" src="js/hideLoading.js" defer></script>
+  <script type="module" src="js/version.js" defer></script>
+</body>
+</html>

--- a/docs/assets/styles.css
+++ b/docs/assets/styles.css
@@ -1380,7 +1380,7 @@ select {
   font-size: 1rem;
   padding: 2px 4px;
 }
-...edit-btn {
+.edit-btn {
   color: var(--color-primary);
 }
 .edit-btn:hover {
@@ -1586,6 +1586,17 @@ select {
   background-color: var(--color-light);
   white-space: nowrap;
 }
+.tree-list li.collapsed > ul {
+  display: none;
+}
+.toggle-btn {
+  cursor: pointer;
+  user-select: none;
+  margin-right: 4px;
+}
+#treeContainer.collapsed > ul {
+  display: none;
+}
 
 .add-child-btn {
   margin-left: 4px;
@@ -1616,6 +1627,19 @@ select {
 
 .remove-btn:hover {
   background-color: var(--color-danger-hover, #c0392b);
+}
+.edit-btn {
+  margin-left: 4px;
+  padding: 0 4px;
+  font-size: 0.8rem;
+  background-color: var(--color-primary);
+  color: var(--color-light);
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+.edit-btn:hover {
+  background-color: var(--color-primary-hover);
 }
 
 .product-node {
@@ -1831,6 +1855,9 @@ select {
 .wizard { max-width: 900px; margin: 20px auto; font-family: var(--font-base, sans-serif); }
 .wizard .progress { height: 8px; background:#e0e0e0; border-radius:4px; overflow:hidden; margin-bottom:20px; }
 .wizard .progress #progressBar { height:100%; width:0; background:linear-gradient(90deg,#4b6cb7,#182848); transition:width 0.3s; }
+.step-indicator { display:flex; justify-content:space-between; margin-bottom:10px; }
+.step-indicator .step { flex:1; text-align:center; color:#777; }
+.step-indicator .step.active { color:var(--color-primary); font-weight:bold; }
 .client-info { text-align:center; margin-bottom:10px; font-weight:bold; }
 .wizard-step { display:none; }
 .wizard-step.active { display:flex; }

--- a/docs/js/asistente.js
+++ b/docs/js/asistente.js
@@ -1,0 +1,442 @@
+import { getAll, addNode, ready } from './dataService.js';
+import { animateInsert, animateRemove } from './ui/animations.js';
+
+function getClienteNombre(clientes, id) {
+  const c = clientes.find(x => String(x.ID) === String(id));
+  return c ? c.Descripción : '';
+}
+
+document.addEventListener('DOMContentLoaded', async () => {
+  const clienteSel = document.getElementById('productCliente');
+  const descInput = document.getElementById('productDesc');
+  const codeInput = document.getElementById('productCode');
+  const continueBtn = document.getElementById('continueBtn');
+  const step1 = document.getElementById('step1');
+  const step2 = document.getElementById('step2');
+  const step3 = document.getElementById('step3');
+  const step4 = document.getElementById('step4');
+  const gotoStep3 = document.getElementById('gotoStep3');
+  const gotoStep4 = document.getElementById('gotoStep4');
+  const backTo1 = document.getElementById('backTo1');
+  const backTo2 = document.getElementById('backTo2');
+  const backTo3 = document.getElementById('backTo3');
+  const progressBar = document.getElementById('progressBar');
+  const steps = document.querySelectorAll('.step-indicator .step');
+
+  const subDesc = document.getElementById('subDesc');
+  const subCode = document.getElementById('subCode');
+  const subParent = document.getElementById('subParent');
+  const addSubBtn = document.getElementById('addSubBtn');
+  const subList = document.getElementById('subList');
+  const finishBtn = document.getElementById('finishBtn');
+  const productPreview = document.getElementById('productPreview');
+  const treeContainer = document.getElementById('treeContainer');
+  const treeHolder2 = document.getElementById('treeHolder2');
+  const treeHolder4 = document.getElementById('treeHolder4');
+  const insumoDesc = document.getElementById('insumoDesc');
+  const insumoCode = document.getElementById('insumoCode');
+  const insumoUnidad = document.getElementById('insumoUnidad');
+  const insumoProveedor = document.getElementById('insumoProveedor');
+  const insumoMaterial = document.getElementById('insumoMaterial');
+  const insumoOrigen = document.getElementById('insumoOrigen');
+  const insumoObs = document.getElementById('insumoObs');
+  const insumoParent = document.getElementById('insumoParent');
+  const addInsumoBtn = document.getElementById('addInsumoBtn');
+  const productLargo = document.getElementById('productLargo');
+  const productAncho = document.getElementById('productAncho');
+  const productAlto = document.getElementById('productAlto');
+  const productPeso = document.getElementById('productPeso');
+
+  await ready;
+  const all = await getAll('sinoptico');
+  const clientes = all.filter(n => n.Tipo === 'Cliente');
+  if (clienteSel) {
+    clienteSel.innerHTML = clientes
+      .map(c => `<option value="${c.ID}">${c.Descripción}</option>`)
+      .join('');
+  }
+
+  let subcomponents = [];
+  let insumos = [];
+  const levelMap = new Map();
+  levelMap.set('root', 0);
+  const domMap = new Map();
+  domMap.set('root', subList);
+  const liMap = new Map();
+  let productData = null;
+
+  function updateParentOptions() {
+    if (!insumoParent) return;
+    insumoParent.innerHTML = '<option value="root">(Producto principal)</option>';
+    for (const sub of subcomponents) {
+      const level = levelMap.get(sub.id) || 1;
+      const opt = document.createElement('option');
+      opt.value = sub.id;
+      opt.textContent = `${'\u2014 '.repeat(level)}${sub.desc}`;
+      insumoParent.appendChild(opt);
+    }
+  }
+
+  function removeSubcomponent(id) {
+    const stack = [id];
+    const subsToRemove = [];
+    while (stack.length) {
+      const cur = stack.pop();
+      subsToRemove.push(cur);
+      subcomponents.forEach(sc => {
+        if (sc.parentId === cur) stack.push(sc.id);
+      });
+    }
+    const insIds = insumos.filter(i => subsToRemove.includes(i.parentId)).map(i => i.id);
+    const allIds = subsToRemove.concat(insIds);
+    subcomponents = subcomponents.filter(sc => !subsToRemove.includes(sc.id));
+    insumos = insumos.filter(i => !insIds.includes(i.id));
+    for (const rid of allIds) {
+      subParent?.querySelector(`option[value='${rid}']`)?.remove();
+      insumoParent?.querySelector(`option[value='${rid}']`)?.remove();
+      levelMap.delete(rid);
+      const li = liMap.get(rid);
+      animateRemove(li, () => {
+        li?.remove();
+        liMap.delete(rid);
+        domMap.delete(rid);
+      });
+    }
+    updateParentOptions();
+  }
+
+  function editSubcomponent(id) {
+    const sc = subcomponents.find(s => s.id === id);
+    if (!sc) return;
+    const desc = prompt('Descripción', sc.desc);
+    if (desc === null) return;
+    const code = prompt('Código', sc.code || '') || '';
+    sc.desc = desc.trim();
+    sc.code = code.trim();
+    const li = liMap.get(id);
+    if (li) {
+      const label = li.querySelector('.node-label');
+      if (label) label.textContent = sc.code ? `${sc.desc} (${sc.code})` : sc.desc;
+    }
+    const opt = subParent?.querySelector(`option[value='${id}']`);
+    if (opt) opt.textContent = `${'\u2014 '.repeat(levelMap.get(id) || 1)}${sc.desc}`;
+    updateParentOptions();
+  }
+
+  function removeInsumo(id) {
+    insumos = insumos.filter(i => i.id !== id);
+    const li = liMap.get(id);
+    animateRemove(li, () => {
+      li?.remove();
+      liMap.delete(id);
+    });
+  }
+
+  function editInsumo(id) {
+    const item = insumos.find(i => i.id === id);
+    if (!item) return;
+    const desc = prompt('Descripción', item.desc);
+    if (desc === null) return;
+    const code = prompt('Código', item.code || '') || '';
+    item.desc = desc.trim();
+    item.code = code.trim();
+    const li = liMap.get(id);
+    if (li) {
+      const label = li.querySelector('.node-label');
+      if (label) label.textContent = item.code ? `${item.desc} (${item.code})` : item.desc;
+    }
+  }
+
+  function buildProduct(desc, code, clienteId, largo, ancho, alto, peso) {
+    return {
+      ID: Date.now().toString(),
+      ParentID: clienteId,
+      Tipo: 'Producto',
+      Descripción: desc,
+      Cliente: getClienteNombre(clientes, clienteId),
+      Vehículo: '',
+      RefInterno: '',
+      versión: '',
+      Imagen: '',
+      Consumo: '',
+      Unidad: '',
+      Sourcing: '',
+      Código: code || '',
+      Largo: largo || '',
+      Ancho: ancho || '',
+      Alto: alto || '',
+      Peso: peso || ''
+    };
+  }
+
+  async function persist(product, subs, ins) {
+    await addNode(product);
+    const idMap = { root: product.ID };
+    for (const sub of subs) {
+      const parentId = idMap[sub.parentId] || product.ID;
+      const node = {
+        ID: Date.now().toString() + Math.random().toString(16).slice(2),
+        ParentID: parentId,
+        Tipo: 'Subproducto',
+        Descripción: sub.desc,
+        Cliente: product.Cliente,
+        Vehículo: '',
+        RefInterno: '',
+        versión: '',
+        Imagen: '',
+        Consumo: '',
+        Unidad: '',
+        Sourcing: '',
+        Código: sub.code || ''
+      };
+      await addNode(node);
+      idMap[sub.id] = node.ID;
+    }
+    for (const insumo of ins) {
+      const parentId = idMap[insumo.parentId] || product.ID;
+      const n = {
+        ID: Date.now().toString() + Math.random().toString(16).slice(2),
+        ParentID: parentId,
+        Tipo: 'Insumo',
+        Descripción: insumo.desc,
+        Cliente: product.Cliente,
+        Vehículo: '',
+        RefInterno: '',
+        versión: '',
+        Imagen: '',
+        Consumo: '',
+        Unidad: insumo.unidad || '',
+        Proveedor: insumo.proveedor || '',
+        Material: insumo.material || '',
+        Observaciones: insumo.observaciones || '',
+        Sourcing: insumo.origen || '',
+        Código: insumo.code || ''
+      };
+      await addNode(n);
+    }
+  }
+
+
+  continueBtn?.addEventListener('click', () => {
+    const cid = clienteSel.value;
+    const desc = descInput.value.trim();
+    if (!cid || !desc) return;
+    const code = codeInput.value.trim();
+    productData = {
+      cid,
+      desc,
+      code,
+      largo: productLargo.value.trim(),
+      ancho: productAncho.value.trim(),
+      alto: productAlto.value.trim(),
+      peso: productPeso.value.trim()
+    };
+    step1.classList.remove('active');
+    step2.classList.add('active');
+    steps.forEach(s => s.classList.remove('active'));
+    steps[1].classList.add('active');
+    if (progressBar) progressBar.style.width = '25%';
+  if (productPreview) {
+      const info = code ? `${desc} (${code})` : desc;
+      productPreview.textContent = `Producto: ${info}`;
+    }
+    productPreview.addEventListener('click', ev => {
+      if (ev.target === productPreview) treeContainer.classList.toggle('collapsed');
+    });
+    if (subParent) {
+      subParent.innerHTML = '<option value="root">(Producto principal)</option>';
+    }
+    if (insumoParent) {
+      insumoParent.innerHTML = '<option value="root">(Producto principal)</option>';
+    }
+    updateParentOptions();
+  });
+
+  addSubBtn?.addEventListener('click', () => {
+    const d = subDesc.value.trim();
+    if (!d) return;
+    const c = subCode.value.trim();
+    const parent = subParent?.value || 'root';
+    const id = Date.now().toString(16) + Math.random().toString(16).slice(2);
+    const level = parent === 'root' ? 1 : (levelMap.get(parent) || 0) + 1;
+    subcomponents.push({ id, parentId: parent, desc: d, code: c });
+    levelMap.set(id, level);
+
+    const parentList = domMap.get(parent) || subList;
+    const parentLi = liMap.get(parent);
+    if (parentLi) {
+      parentLi.classList.add('has-children');
+    } else if (parent === 'root' && productPreview) {
+      productPreview.classList.add('has-children');
+    }
+    const li = document.createElement('li');
+    li.dataset.id = id;
+    const node = document.createElement('span');
+    node.className = 'tree-node';
+    const label = document.createElement('span');
+    label.className = 'node-label';
+    label.textContent = c ? `${d} (${c})` : d;
+    node.appendChild(label);
+    const editBtn = document.createElement('button');
+    editBtn.className = 'edit-btn';
+    editBtn.type = 'button';
+    editBtn.textContent = '✎';
+    editBtn.addEventListener('click', () => editSubcomponent(id));
+    node.appendChild(editBtn);
+    const delBtn = document.createElement('button');
+    delBtn.className = 'remove-btn';
+    delBtn.type = 'button';
+    delBtn.textContent = '🗑';
+    delBtn.addEventListener('click', () => removeSubcomponent(id));
+    node.appendChild(delBtn);
+    node.addEventListener('click', ev => {
+      if (ev.target === node) li.classList.toggle('collapsed');
+    });
+    li.appendChild(node);
+    const childUl = document.createElement('ul');
+    li.appendChild(childUl);
+    parentList.appendChild(li);
+    animateInsert(li);
+    domMap.set(id, childUl);
+    liMap.set(id, li);
+
+    if (subParent) {
+      const opt = document.createElement('option');
+      opt.value = id;
+      opt.textContent = `${'\u2014 '.repeat(level)}${d}`;
+      subParent.appendChild(opt);
+    }
+    updateParentOptions();
+    subDesc.value = '';
+    subCode.value = '';
+  });
+
+  addInsumoBtn?.addEventListener('click', () => {
+    const d = insumoDesc.value.trim();
+    if (!d) return;
+    const c = insumoCode.value.trim();
+    const parent = insumoParent?.value || 'root';
+    const id = Date.now().toString(16) + Math.random().toString(16).slice(2);
+    const level = (levelMap.get(parent) || 0) + 1;
+    insumos.push({
+      id,
+      parentId: parent,
+      desc: d,
+      code: c,
+      unidad: insumoUnidad.value.trim(),
+      proveedor: insumoProveedor.value.trim(),
+      material: insumoMaterial.value.trim(),
+      origen: insumoOrigen.value,
+      observaciones: insumoObs.value.trim()
+    });
+
+    const parentList = domMap.get(parent) || subList;
+    const parentLi = liMap.get(parent);
+    if (parentLi) {
+      parentLi.classList.add('has-children');
+    } else if (parent === 'root' && productPreview) {
+      productPreview.classList.add('has-children');
+    }
+    const li = document.createElement('li');
+    li.dataset.id = id;
+    const node = document.createElement('span');
+    node.className = 'tree-node insumo-node';
+    const label = document.createElement('span');
+    label.className = 'node-label';
+    label.textContent = c ? `${d} (${c})` : d;
+    node.appendChild(label);
+    const editBtn = document.createElement('button');
+    editBtn.className = 'edit-btn';
+    editBtn.type = 'button';
+    editBtn.textContent = '✎';
+    editBtn.addEventListener('click', () => editInsumo(id));
+    node.appendChild(editBtn);
+    const delBtn = document.createElement('button');
+    delBtn.className = 'remove-btn';
+    delBtn.type = 'button';
+    delBtn.textContent = '🗑';
+    delBtn.addEventListener('click', () => removeInsumo(id));
+    node.appendChild(delBtn);
+    node.addEventListener('click', ev => {
+      if (ev.target === node) li.classList.toggle('collapsed');
+    });
+    li.appendChild(node);
+    parentList.appendChild(li);
+    animateInsert(li);
+    liMap.set(id, li);
+
+    insumoDesc.value = '';
+    insumoCode.value = '';
+    insumoUnidad.value = '';
+    insumoProveedor.value = '';
+    insumoMaterial.value = '';
+    insumoObs.value = '';
+  });
+
+  gotoStep3?.addEventListener('click', () => {
+    step2.classList.remove('active');
+    step3.classList.add('active');
+    steps.forEach(s => s.classList.remove('active'));
+    steps[2].classList.add('active');
+    if (progressBar) progressBar.style.width = '50%';
+    if (treeContainer && treeHolder2) treeHolder2.appendChild(treeContainer);
+  });
+
+  gotoStep4?.addEventListener('click', () => {
+    step3.classList.remove('active');
+    step4.classList.add('active');
+    steps.forEach(s => s.classList.remove('active'));
+    steps[3].classList.add('active');
+    if (progressBar) progressBar.style.width = '75%';
+    if (treeContainer && treeHolder4) treeHolder4.appendChild(treeContainer);
+  });
+
+  backTo1?.addEventListener('click', () => {
+    step2.classList.remove('active');
+    step1.classList.add('active');
+    steps.forEach(s => s.classList.remove('active'));
+    steps[0].classList.add('active');
+    if (progressBar) progressBar.style.width = '0%';
+  });
+
+  backTo2?.addEventListener('click', () => {
+    step3.classList.remove('active');
+    step2.classList.add('active');
+    steps.forEach(s => s.classList.remove('active'));
+    steps[1].classList.add('active');
+    if (progressBar) progressBar.style.width = '25%';
+    if (treeContainer && step2.contains(treeContainer) === false) {
+      step2.appendChild(treeContainer);
+    }
+  });
+
+  backTo3?.addEventListener('click', () => {
+    step4.classList.remove('active');
+    step3.classList.add('active');
+    steps.forEach(s => s.classList.remove('active'));
+    steps[2].classList.add('active');
+    if (progressBar) progressBar.style.width = '50%';
+    if (treeContainer && treeHolder2.contains(treeContainer) === false) {
+      treeHolder2.appendChild(treeContainer);
+    }
+  });
+
+  finishBtn?.addEventListener('click', async () => {
+    if (!productData) return;
+    const product = buildProduct(
+      productData.desc,
+      productData.code,
+      productData.cid,
+      productData.largo,
+      productData.ancho,
+      productData.alto,
+      productData.peso
+    );
+    await persist(product, subcomponents, insumos);
+    if (progressBar) progressBar.style.width = '100%';
+    steps.forEach(s => s.classList.remove('active'));
+    steps[3].classList.add('active');
+    if (window.mostrarMensaje) window.mostrarMensaje('Árbol creado con éxito', 'success');
+    window.location.href = 'sinoptico-editor.html';
+  });
+});

--- a/docs/js/authGuard.js
+++ b/docs/js/authGuard.js
@@ -1,7 +1,7 @@
 import { logout, isAdmin, isGuest } from './session.js';
 
 // guests shouldn't access certain pages directly
-const guestOnlyPages = ['sinoptico-editor.html', 'database.html', 'arbol.html', 'history.html'];
+const guestOnlyPages = ['sinoptico-editor.html', 'database.html', 'asistente.html', 'history.html'];
 if (isGuest() && guestOnlyPages.some(p => location.pathname.endsWith(p))) {
   location.href = 'sinoptico.html';
 }

--- a/docs/js/version.js
+++ b/docs/js/version.js
@@ -1,4 +1,4 @@
-export const version = '393';
+export const version = '394';
 export function displayVersion() {
   const div = document.createElement('div');
   div.className = 'version-info';

--- a/docs/js/views/sinoptico.js
+++ b/docs/js/views/sinoptico.js
@@ -5,7 +5,7 @@ export async function render(container) {
   container.innerHTML = `
     <div class="toolbar">
       <button id="sin-edit">Editar</button>
-      <a id="linkCrear" href="arbol.html">Crear</a>
+      <a id="linkCrear" href="asistente.html">Crear</a>
       <a id="linkBaseDatos" href="database.html">Base de Datos</a>
       <button id="sin-export">Exportar...</button>
       <div class="export-menu">

--- a/docs/sinoptico-editor.html
+++ b/docs/sinoptico-editor.html
@@ -28,7 +28,7 @@
         <button id="btnNuevoProducto" type="button">Producto</button>
         <button id="btnNuevoSub" type="button">Subcomponente</button>
         <button id="btnNuevoInsumo" type="button">Insumo</button>
-        <a id="linkArbol" href="arbol.html">Árbol de producto</a>
+        <a id="linkArbol" href="asistente.html">Árbol de producto</a>
       </div>
     </div>
     <a id="linkBaseDatos" href="database.html">Base de Datos</a>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "proyecto-barack",
-  "version": "393",
+  "version": "394",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "proyecto-barack",
-      "version": "393",
+      "version": "394",
       "license": "ISC",
       "dependencies": {
         "jsdom": "^22.1.0"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "proyecto-barack",
-  "version": "393",
-  "description": "Versión actual: **393**",
+  "version": "394",
+  "description": "Versión actual: **394**",
   "main": "index.js",
   "directories": {
     "lib": "lib"
@@ -20,7 +20,7 @@
       "database.html",
       "sinoptico.html",
       "sinoptico-editor.html",
-      "arbol.html",
+      "asistente.html",
       "assets/**/*",
       "images/**/*",
       "js/**/*",


### PR DESCRIPTION
## Summary
- create `asistente.html` and related script to build products via 4‑step wizard
- update links and permissions to use the new assistant page
- add editing, collapsing and step indicator styles
- bump version to 394

## Testing
- `./format_check.sh`

------
https://chatgpt.com/codex/tasks/task_e_68557f869658832fa2840d1a3e13c8f5