### PR TITLE
Add two-column wizard with sticky component tree

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Proyecto Barack
 
-Versión actual: **394**
+Versión actual: **395**
 
 Esta es una pequeña SPA (Single Page Application) escrita en HTML, CSS y JavaScript.
 Incluye un módulo llamado *Sinóptico* para gestionar jerarquías de productos.

--- a/docs/asistente.html
+++ b/docs/asistente.html
@@ -20,15 +20,23 @@
   </nav>
   <div id="loading"></div>
   <div id="appMessage" role="alert" aria-live="polite"></div>
-  <div class="wizard">
-    <div class="progress"><div id="progressBar"></div></div>
-    <div class="step-indicator">
-      <span class="step active">1</span>
-      <span class="step">2</span>
-      <span class="step">3</span>
-      <span class="step">4</span>
-    </div>
-    <div id="step1" class="wizard-step active node-form">
+  <div class="wizard-layout">
+    <div class="wizard-left">
+      <nav id="breadcrumb" class="breadcrumb">
+        <a href="#" data-step="1" class="active">Paso 1</a> ›
+        <a href="#" data-step="2">Paso 2</a> ›
+        <a href="#" data-step="3">Paso 3</a> ›
+        <a href="#" data-step="4">Paso 4</a>
+      </nav>
+      <div class="wizard">
+        <div class="progress"><div id="progressBar"></div></div>
+        <div class="step-indicator">
+          <span class="step active">1</span>
+          <span class="step">2</span>
+          <span class="step">3</span>
+          <span class="step">4</span>
+        </div>
+        <div id="step1" class="wizard-step active node-form">
       <h2>Datos Generales</h2>
       <label for="productCliente">Cliente:</label>
       <select id="productCliente"></select>
@@ -64,10 +72,6 @@
         <button id="backTo1" type="button">Atrás</button>
         <button id="gotoStep3" type="button">Siguiente</button>
       </div>
-      <div id="treeContainer" class="tree-preview flow-diagram">
-        <span id="productPreview" class="tree-node product-node"></span>
-        <ul id="subList" class="tree-list"></ul>
-      </div>
     </div>
     <div id="step3" class="wizard-step node-form">
       <h2>Agregar Insumos</h2>
@@ -100,7 +104,6 @@
         <button id="backTo2" type="button">Atrás</button>
         <button id="gotoStep4" type="button">Siguiente</button>
       </div>
-      <div id="treeHolder2"></div>
     </div>
     <div id="step4" class="wizard-step node-form">
       <h2>Vista Previa</h2>
@@ -108,9 +111,16 @@
         <button id="backTo3" type="button">Atrás</button>
         <button id="finishBtn" type="button">Guardar Árbol</button>
       </div>
-      <div id="treeHolder4"></div>
     </div>
-  </div>
+      </div> <!-- wizard -->
+    </div> <!-- wizard-left -->
+    <aside class="wizard-right">
+      <div id="treeContainer" class="tree-preview flow-diagram">
+        <span id="productPreview" class="tree-node product-node"></span>
+        <ul id="subList" class="tree-list"></ul>
+      </div>
+    </aside>
+  </div> <!-- wizard-layout -->
   <script src="lib/dexie.min.js" defer></script>
   <script src="./socket.io/socket.io.js" defer></script>
   <script type="module" src="js/authGuard.js"></script>

--- a/docs/assets/styles.css
+++ b/docs/assets/styles.css
@@ -1454,10 +1454,6 @@ select {
   background-color: var(--color-primary-hover);
 }
 
-.form-actions {
-  display: flex;
-  gap: 8px;
-}
 
 .editor-menu {
   width: 95%;
@@ -1859,7 +1855,7 @@ select {
 .step-indicator .step { flex:1; text-align:center; color:#777; }
 .step-indicator .step.active { color:var(--color-primary); font-weight:bold; }
 .client-info { text-align:center; margin-bottom:10px; font-weight:bold; }
-.wizard-step { display:none; }
+.wizard-step { display:none; flex-direction: column; }
 .wizard-step.active { display:flex; }
 .wizard-step > button {
   padding: 6px 12px;
@@ -1872,6 +1868,43 @@ select {
 }
 .wizard-step > button:hover {
   background-color: var(--color-primary-hover);
+}
+
+.wizard-layout {
+  display: flex;
+  gap: 20px;
+  align-items: flex-start;
+}
+
+.wizard-left {
+  flex-basis: 60%;
+}
+
+.wizard-right {
+  flex-basis: 40%;
+  position: sticky;
+  top: 20px;
+}
+
+.breadcrumb {
+  margin-bottom: 10px;
+}
+
+.breadcrumb a {
+  text-decoration: none;
+  margin-right: 4px;
+  color: var(--color-text);
+}
+
+.breadcrumb a.active {
+  font-weight: bold;
+  text-decoration: underline;
+}
+
+.form-actions {
+  display: flex;
+  gap: 8px;
+  justify-content: flex-end;
 }
 
 .builder-card { background:linear-gradient(135deg,#ffffff,#f0f4ff); padding:12px; border-radius:8px; box-shadow:0 2px 4px rgba(0,0,0,0.1); margin:10px 0; position:relative; overflow-x:auto; }

--- a/docs/js/asistente.js
+++ b/docs/js/asistente.js
@@ -31,8 +31,6 @@ document.addEventListener('DOMContentLoaded', async () => {
   const finishBtn = document.getElementById('finishBtn');
   const productPreview = document.getElementById('productPreview');
   const treeContainer = document.getElementById('treeContainer');
-  const treeHolder2 = document.getElementById('treeHolder2');
-  const treeHolder4 = document.getElementById('treeHolder4');
   const insumoDesc = document.getElementById('insumoDesc');
   const insumoCode = document.getElementById('insumoCode');
   const insumoUnidad = document.getElementById('insumoUnidad');
@@ -64,6 +62,29 @@ document.addEventListener('DOMContentLoaded', async () => {
   domMap.set('root', subList);
   const liMap = new Map();
   let productData = null;
+  const breadcrumbLinks = document.querySelectorAll('#breadcrumb a');
+
+  function activateStep(n) {
+    const stepsArr = [step1, step2, step3, step4];
+    stepsArr.forEach((st, idx) => {
+      if (st) st.classList.toggle('active', idx === n - 1);
+    });
+    steps.forEach((s, idx) => {
+      s.classList.toggle('active', idx === n - 1);
+    });
+    breadcrumbLinks.forEach((b, idx) => {
+      b.classList.toggle('active', idx === n - 1);
+    });
+    if (progressBar) progressBar.style.width = `${(n - 1) * 25}%`;
+  }
+
+  breadcrumbLinks.forEach(link => {
+    link.addEventListener('click', evt => {
+      evt.preventDefault();
+      const stepNum = parseInt(link.dataset.step, 10);
+      if (!isNaN(stepNum)) activateStep(stepNum);
+    });
+  });
 
   function updateParentOptions() {
     if (!insumoParent) return;
@@ -231,11 +252,7 @@ document.addEventListener('DOMContentLoaded', async () => {
       alto: productAlto.value.trim(),
       peso: productPeso.value.trim()
     };
-    step1.classList.remove('active');
-    step2.classList.add('active');
-    steps.forEach(s => s.classList.remove('active'));
-    steps[1].classList.add('active');
-    if (progressBar) progressBar.style.width = '25%';
+    activateStep(2);
   if (productPreview) {
       const info = code ? `${desc} (${code})` : desc;
       productPreview.textContent = `Producto: ${info}`;
@@ -374,51 +391,23 @@ document.addEventListener('DOMContentLoaded', async () => {
   });
 
   gotoStep3?.addEventListener('click', () => {
-    step2.classList.remove('active');
-    step3.classList.add('active');
-    steps.forEach(s => s.classList.remove('active'));
-    steps[2].classList.add('active');
-    if (progressBar) progressBar.style.width = '50%';
-    if (treeContainer && treeHolder2) treeHolder2.appendChild(treeContainer);
+    activateStep(3);
   });
 
   gotoStep4?.addEventListener('click', () => {
-    step3.classList.remove('active');
-    step4.classList.add('active');
-    steps.forEach(s => s.classList.remove('active'));
-    steps[3].classList.add('active');
-    if (progressBar) progressBar.style.width = '75%';
-    if (treeContainer && treeHolder4) treeHolder4.appendChild(treeContainer);
+    activateStep(4);
   });
 
   backTo1?.addEventListener('click', () => {
-    step2.classList.remove('active');
-    step1.classList.add('active');
-    steps.forEach(s => s.classList.remove('active'));
-    steps[0].classList.add('active');
-    if (progressBar) progressBar.style.width = '0%';
+    activateStep(1);
   });
 
   backTo2?.addEventListener('click', () => {
-    step3.classList.remove('active');
-    step2.classList.add('active');
-    steps.forEach(s => s.classList.remove('active'));
-    steps[1].classList.add('active');
-    if (progressBar) progressBar.style.width = '25%';
-    if (treeContainer && step2.contains(treeContainer) === false) {
-      step2.appendChild(treeContainer);
-    }
+    activateStep(2);
   });
 
   backTo3?.addEventListener('click', () => {
-    step4.classList.remove('active');
-    step3.classList.add('active');
-    steps.forEach(s => s.classList.remove('active'));
-    steps[2].classList.add('active');
-    if (progressBar) progressBar.style.width = '50%';
-    if (treeContainer && treeHolder2.contains(treeContainer) === false) {
-      treeHolder2.appendChild(treeContainer);
-    }
+    activateStep(3);
   });
 
   finishBtn?.addEventListener('click', async () => {
@@ -433,9 +422,7 @@ document.addEventListener('DOMContentLoaded', async () => {
       productData.peso
     );
     await persist(product, subcomponents, insumos);
-    if (progressBar) progressBar.style.width = '100%';
-    steps.forEach(s => s.classList.remove('active'));
-    steps[3].classList.add('active');
+    activateStep(4);
     if (window.mostrarMensaje) window.mostrarMensaje('Árbol creado con éxito', 'success');
     window.location.href = 'sinoptico-editor.html';
   });

--- a/docs/js/version.js
+++ b/docs/js/version.js
@@ -1,4 +1,4 @@
-export const version = '394';
+export const version = '395';
 export function displayVersion() {
   const div = document.createElement('div');
   div.className = 'version-info';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "proyecto-barack",
-  "version": "394",
+  "version": "395",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "proyecto-barack",
-      "version": "394",
+      "version": "395",
       "license": "ISC",
       "dependencies": {
         "jsdom": "^22.1.0"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "proyecto-barack",
-  "version": "394",
-  "description": "Versión actual: **394**",
+  "version": "395",
+  "description": "Versión actual: **395**",
   "main": "index.js",
   "directories": {
     "lib": "lib"


### PR DESCRIPTION
## Summary
- redesign `asistente.html` to show form and tree side by side
- keep tree visible in a sticky right panel
- add breadcrumb navigation and CSS for the new layout
- refactor wizard JS to use new `activateStep` helper
- bump version to 395

## Testing
- `bash format_check.sh`


------
https://chatgpt.com/codex/tasks/task_e_685585ff4cc4832f9999765ce2a8d7c8