### PR TITLE
Add sinoptico export endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,10 @@ El servidor debe ejecutarse en un único equipo o servidor accesible por la red 
 El archivo activo se guarda en `data/latest.json` y cada día se crea una copia automática en `data/backups/AAAA-MM-DD.json`. Los respaldos con más de seis meses se eliminan al iniciar el servidor.
 Los respaldos se encuentran en la carpeta `data/backups/`. Si eliminas el repositorio también se borrará esta carpeta a menos que la conserves aparte.
 
+El servidor también expone `GET /api/sinoptico/export` para descargar la tabla
+de Sinóptico en Excel o PDF. Usa el parámetro `format=excel` o `format=pdf`
+según prefieras.
+
 Si quieres guardar la base de datos en otra ubicación puedes definir la variable de entorno `DATA_DIR` antes de iniciar el servidor y apuntar a la carpeta deseada.
 
 El backend basado en SQLite (`backend/main.py`) lee la ruta del archivo desde `DB_PATH`. Si no se define, usará `data/db.sqlite`.

--- a/server.py
+++ b/server.py
@@ -126,6 +126,8 @@ def export_module(module):
         rows = [memory]
     elif module == "history":
         rows = history
+    elif module == "sinoptico":
+        rows = memory.get("sinoptico", [])
     else:
         return jsonify({"error": "not found"}), 404
 


### PR DESCRIPTION
## Summary
- add `sinoptico` handling in `server.py` export endpoint
- document `/api/sinoptico/export` in the README

## Testing
- `./format_check.sh`


------
https://chatgpt.com/codex/tasks/task_e_6855a19c7398832fb4bf5002d817a9fd