### PR TITLE
Fix export buttons on Sinoptico pages

### DIFF
--- a/docs/js/ui/renderer.js
+++ b/docs/js/ui/renderer.js
@@ -245,10 +245,19 @@ document.addEventListener('DOMContentLoaded', () => {
   });
   document.getElementById('btnRefrescar')?.addEventListener('click', loadData);
 
+  const exportBtn = document.getElementById('exportBtn');
+  const exportMenu = document.querySelector('.export-menu');
+  exportBtn?.addEventListener('click', () => {
+    if (exportMenu) {
+      exportMenu.style.display = exportMenu.style.display === 'block' ? 'none' : 'block';
+    }
+  });
+
   /* ==================================================
      4) Exportar a Excel
   ==================================================*/
   document.getElementById('btnExcel')?.addEventListener('click', () => {
+    if (exportMenu) exportMenu.style.display = 'none';
     if (typeof XLSX==='undefined') return mostrarMensaje('Excel deshabilitado','warning');
     const datos=[...document.querySelectorAll('#sinoptico thead th')].filter(th=>th.style.display!=='none').map(th=>th.textContent);
     const filas=[];
@@ -259,6 +268,26 @@ document.addEventListener('DOMContentLoaded', () => {
     });
     const wb=XLSX.utils.book_new(); const ws=XLSX.utils.aoa_to_sheet([datos,...filas]);
     XLSX.utils.book_append_sheet(wb,ws,'Sinoptico'); XLSX.writeFile(wb,'sinoptico.xlsx');
+  });
+
+  document.getElementById('btnPdf')?.addEventListener('click', async () => {
+    if (exportMenu) exportMenu.style.display = 'none';
+    try {
+      const resp = await fetch('/api/sinoptico/export?format=pdf');
+      if (!resp.ok) throw new Error('fail');
+      const blob = await resp.blob();
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = 'sinoptico.pdf';
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      URL.revokeObjectURL(url);
+      mostrarMensaje('Exportación completa', 'success');
+    } catch {
+      mostrarMensaje('Error al exportar');
+    }
   });
 
   /* ==================================================

--- a/docs/js/views/sinoptico.js
+++ b/docs/js/views/sinoptico.js
@@ -7,10 +7,12 @@ export async function render(container) {
       <button id="sin-edit">Editar</button>
       <a id="linkCrear" href="asistente.html">Crear</a>
       <a id="linkBaseDatos" href="database.html">Base de Datos</a>
-      <button id="sin-export">Exportar...</button>
-      <div class="export-menu">
-        <button data-fmt="excel">Excel</button> |
-        <button data-fmt="pdf">PDF</button>
+      <div class="export-group">
+        <button id="sin-export">⬇ Export</button>
+        <div class="export-menu">
+          <button data-fmt="excel" class="btn-excel">Excel</button>
+          <button data-fmt="pdf" class="btn-pdf">PDF</button>
+        </div>
       </div>
     </div>
     <table id="sinoptico">

--- a/docs/sinoptico.html
+++ b/docs/sinoptico.html
@@ -40,7 +40,13 @@
       <label><input type="checkbox" id="chkMostrarNivel1" checked> Nivel 1</label>
       <label><input type="checkbox" id="chkMostrarNivel2" checked> Nivel 2</label>
       <label><input type="checkbox" id="chkMostrarNivel3" checked> Nivel 3</label>
-      <button id="btnExcel" class="no-guest" aria-label="Exportar a Excel" title="Exportar a Excel">Exportar Excel</button>
+      <div class="export-group">
+        <button id="exportBtn" class="no-guest">⬇ Export</button>
+        <div class="export-menu">
+          <button data-fmt="excel" id="btnExcel" class="btn-excel">Excel</button>
+          <button data-fmt="pdf" id="btnPdf" class="btn-pdf">PDF</button>
+        </div>
+      </div>
     </section>
   </section>
   <section class="tabla-contenedor">


### PR DESCRIPTION
## Summary
- style Sinóptico SPA export menu like other views
- show Excel and PDF options in `sinoptico.html`
- add export button logic to renderer to support PDF download

## Testing
- `./format_check.sh`

------
https://chatgpt.com/codex/tasks/task_e_6855a307ac78832f9615170feb508322