### PR TITLE
Improve DB page layout

### DIFF
--- a/docs/assets/styles.css
+++ b/docs/assets/styles.css
@@ -594,18 +594,30 @@ tr[data-level] td:first-child {
   background-color: var(--maestro-row-alt);
 }
 
+
 .category-section {
   margin-bottom: 20px;
+  border-radius: 8px;
+  overflow: hidden;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
 }
 
 .category-section summary {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
   font-weight: bold;
   background: linear-gradient(90deg, var(--color-primary), var(--color-accent));
   color: #fff;
-  padding: 8px;
-  border-radius: 4px;
+  padding: 8px 12px;
   cursor: pointer;
-  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+}
+.category-section summary::after {
+  content: '▼';
+  transition: transform 0.3s ease;
+}
+.category-section[open] summary::after {
+  transform: rotate(-180deg);
 }
 .dark .category-section summary {
   background: linear-gradient(90deg, var(--color-primary-hover), var(--color-accent-hover));
@@ -619,6 +631,7 @@ tr[data-level] td:first-child {
   border-radius: 6px;
   overflow: hidden;
   box-shadow: 0 1px 4px rgba(0,0,0,0.1);
+  animation: fadeIn 0.3s ease-in-out;
 }
 .category-section th,
 .category-section td {
@@ -2144,6 +2157,27 @@ tr:not(.pending) td:first-child::before {
 }
 
 .maestro-tabs button.active {
+  background: var(--color-accent);
+  color: #fff;
+}
+
+/* ===== Base de Datos tabs ===== */
+.db-tabs {
+  display: flex;
+  gap: 10px;
+  margin-bottom: 10px;
+  flex-wrap: wrap;
+}
+
+.db-tabs button {
+  padding: 6px 12px;
+  border: none;
+  background: var(--color-light);
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.db-tabs button.active {
   background: var(--color-accent);
   color: #fff;
 }

--- a/docs/database.html
+++ b/docs/database.html
@@ -19,16 +19,13 @@
     <h1 class="editor-title">Base de Datos</h1>
   </header>
   <section class="editor-menu">
-    <section id="dbFilters">
-      <label for="dbTipoFilter">Mostrar:</label>
-      <select id="dbTipoFilter">
-        <option value="">Todos</option>
-        <option value="Cliente">Clientes</option>
-        <option value="Producto">Productos</option>
-        <option value="Subproducto">Subproductos</option>
-        <option value="Insumo">Insumos</option>
-        <option value="Desactivado">Desactivados</option>
-      </select>
+    <section class="db-tabs">
+      <button data-type="" class="active">Todos</button>
+      <button data-type="Cliente">Clientes</button>
+      <button data-type="Producto">Productos</button>
+      <button data-type="Subproducto">Subproductos</button>
+      <button data-type="Insumo">Insumos</button>
+      <button data-type="Desactivado">Desactivados</button>
     </section>
   </section>
   <section id="dbTables" class="tabla-contenedor">

--- a/docs/js/dbPage.js
+++ b/docs/js/dbPage.js
@@ -1,8 +1,10 @@
 'use strict';
 import { getAll, updateNode, deleteNode, ready } from './dataService.js';
+import { animateInsert } from './ui/animations.js';
 
 document.addEventListener('DOMContentLoaded', () => {
-  const tipoFilter = document.getElementById('dbTipoFilter');
+  const tabButtons = document.querySelectorAll('.db-tabs button');
+  let activeType = '';
   const clientesBody = document.querySelector('#clientesSection tbody');
   const productosBody = document.querySelector('#productosSection tbody');
   const subproductosBody = document.querySelector('#subproductosSection tbody');
@@ -15,11 +17,18 @@ document.addEventListener('DOMContentLoaded', () => {
   const desactivadosSection = document.getElementById('desactivadosSection');
   const tableContainer = document.getElementById('dbTables');
 
+  tabButtons.forEach(btn => {
+    btn.addEventListener('click', () => {
+      tabButtons.forEach(b => b.classList.remove('active'));
+      btn.classList.add('active');
+      activeType = btn.dataset.type || '';
+      load();
+    });
+  });
+
   async function load() {
     await ready;
     const data = await getAll('sinoptico');
-    const clientes = data.filter(d => d.Tipo === 'Cliente');
-
     clientesBody.innerHTML = '';
     productosBody.innerHTML = '';
     subproductosBody.innerHTML = '';
@@ -35,12 +44,12 @@ document.addEventListener('DOMContentLoaded', () => {
     };
     Object.values(sections).forEach(s => (s.style.display = ''));
     let items = data.slice();
-    if (tipoFilter.value && tipoFilter.value !== 'Desactivado') {
-      items = items.filter(i => i.Tipo === tipoFilter.value && !i.Desactivado);
+    if (activeType && activeType !== 'Desactivado') {
+      items = items.filter(i => i.Tipo === activeType && !i.Desactivado);
       Object.keys(sections).forEach(k => {
-        sections[k].style.display = k === tipoFilter.value ? '' : 'none';
+        sections[k].style.display = k === activeType ? '' : 'none';
       });
-    } else if (tipoFilter.value === 'Desactivado') {
+    } else if (activeType === 'Desactivado') {
       items = items.filter(i => i.Desactivado);
       Object.keys(sections).forEach(k => {
         sections[k].style.display = k === 'Desactivado' ? '' : 'none';
@@ -96,10 +105,10 @@ document.addEventListener('DOMContentLoaded', () => {
         else target = subproductosBody;
       }
       target.appendChild(tr);
+      animateInsert(tr);
     });
   }
 
-  tipoFilter.addEventListener('change', load);
 
   tableContainer.addEventListener('click', async ev => {
     const btn = ev.target.closest('button');


### PR DESCRIPTION
## Summary
- style details section with arrow and fade animation
- add tab controls for filtering DB categories
- animate table row insertion

## Testing
- `./format_check.sh`


------
https://chatgpt.com/codex/tasks/task_e_6855a3493238832fbaf471ed409d79b7