### PR TITLE
Fix PDF export and improve buttons

### DIFF
--- a/docs/assets/styles.css
+++ b/docs/assets/styles.css
@@ -2134,6 +2134,12 @@ tr:not(.pending) td:first-child::before {
 .btn-excel { background: #1b6e1b; }
 .btn-pdf { background: #c0392b; }
 
+/* export button group */
+.export-group {
+  display: inline-flex;
+  gap: 6px;
+}
+
 /* ===== Maestro professional listing ===== */
 .maestro-page {
   background: var(--color-light);

--- a/docs/index.html
+++ b/docs/index.html
@@ -35,6 +35,8 @@
   <script type="module" src="js/router.js" defer></script>
   <script type="module" src="js/dataService.js" defer></script>
   <script src="lib/xlsx.full.noeval.js" defer></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js" defer></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf-autotable/3.5.28/jspdf.plugin.autotable.min.js" defer></script>
   <script src="lib/chart.min.js" defer></script>
   <script type="module" src="js/views/sinoptico.js" defer></script>
   <script type="module" src="js/ui/renderer.js" defer></script>

--- a/docs/js/ui/renderer.js
+++ b/docs/js/ui/renderer.js
@@ -245,19 +245,13 @@ document.addEventListener('DOMContentLoaded', () => {
   });
   document.getElementById('btnRefrescar')?.addEventListener('click', loadData);
 
-  const exportBtn = document.getElementById('exportBtn');
-  const exportMenu = document.querySelector('.export-menu');
-  exportBtn?.addEventListener('click', () => {
-    if (exportMenu) {
-      exportMenu.style.display = exportMenu.style.display === 'block' ? 'none' : 'block';
-    }
-  });
+  const excelBtn = document.getElementById('btnExcel');
+  const pdfBtn = document.getElementById('btnPdf');
 
   /* ==================================================
      4) Exportar a Excel
   ==================================================*/
-  document.getElementById('btnExcel')?.addEventListener('click', () => {
-    if (exportMenu) exportMenu.style.display = 'none';
+  excelBtn?.addEventListener('click', () => {
     if (typeof XLSX==='undefined') return mostrarMensaje('Excel deshabilitado','warning');
     const datos=[...document.querySelectorAll('#sinoptico thead th')].filter(th=>th.style.display!=='none').map(th=>th.textContent);
     const filas=[];
@@ -270,8 +264,7 @@ document.addEventListener('DOMContentLoaded', () => {
     XLSX.utils.book_append_sheet(wb,ws,'Sinoptico'); XLSX.writeFile(wb,'sinoptico.xlsx');
   });
 
-  document.getElementById('btnPdf')?.addEventListener('click', async () => {
-    if (exportMenu) exportMenu.style.display = 'none';
+  pdfBtn?.addEventListener('click', async () => {
     try {
       const resp = await fetch('/api/sinoptico/export?format=pdf');
       if (!resp.ok) throw new Error('fail');
@@ -286,7 +279,16 @@ document.addEventListener('DOMContentLoaded', () => {
       URL.revokeObjectURL(url);
       mostrarMensaje('Exportación completa', 'success');
     } catch {
-      mostrarMensaje('Error al exportar');
+      try {
+        const { jsPDF } = window.jspdf || {};
+        if (!jsPDF || !jsPDF.API.autoTable) throw new Error('fallback');
+        const doc = new jsPDF();
+        doc.autoTable({ html: '#sinoptico' });
+        doc.save('sinoptico.pdf');
+        mostrarMensaje('Exportación completa', 'success');
+      } catch {
+        mostrarMensaje('Error al exportar');
+      }
     }
   });
 

--- a/docs/maestro.html
+++ b/docs/maestro.html
@@ -20,11 +20,8 @@
     <div class="top-actions">
       <button id="printBtn">🖨 Print</button>
       <div class="export-group">
-        <button id="exportBtn">⬇ Export</button>
-        <div class="export-menu">
-          <button data-fmt="excel" class="btn-excel">Excel</button>
-          <button data-fmt="pdf" class="btn-pdf">PDF</button>
-        </div>
+        <button data-fmt="excel" id="btnExcel" class="btn-excel">Excel</button>
+        <button data-fmt="pdf" id="btnPdf" class="btn-pdf">PDF</button>
       </div>
       <button id="newClientBtn">+ Crear Cliente</button>
     </div>
@@ -101,6 +98,8 @@
   <script type="module" src="js/nav.js" defer></script>
   <script type="module" src="js/dataService.js" defer></script>
   <script src="lib/xlsx.full.noeval.js" defer></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js" defer></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf-autotable/3.5.28/jspdf.plugin.autotable.min.js" defer></script>
   <script type="module" src="js/maestro.js" defer></script>
   <script type="module" src="js/ui/animations.js" defer></script>
   <script type="module" src="js/backButton.js" defer></script>

--- a/docs/sinoptico.html
+++ b/docs/sinoptico.html
@@ -41,11 +41,8 @@
       <label><input type="checkbox" id="chkMostrarNivel2" checked> Nivel 2</label>
       <label><input type="checkbox" id="chkMostrarNivel3" checked> Nivel 3</label>
       <div class="export-group">
-        <button id="exportBtn" class="no-guest">⬇ Export</button>
-        <div class="export-menu">
-          <button data-fmt="excel" id="btnExcel" class="btn-excel">Excel</button>
-          <button data-fmt="pdf" id="btnPdf" class="btn-pdf">PDF</button>
-        </div>
+        <button data-fmt="excel" id="btnExcel" class="btn-excel">Excel</button>
+        <button data-fmt="pdf" id="btnPdf" class="btn-pdf">PDF</button>
       </div>
     </section>
   </section>
@@ -70,6 +67,8 @@
   <script type="module" src="js/authGuard.js"></script>
   <script type="module" src="js/nav.js" defer></script>
   <script src="lib/xlsx.full.noeval.js" defer></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js" defer></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf-autotable/3.5.28/jspdf.plugin.autotable.min.js" defer></script>
   <script type="module" src="js/dataService.js" defer></script>
   <script type="module" src="js/views/sinoptico.js" defer></script>
   <script type="module" src="js/ui/renderer.js" defer></script>


### PR DESCRIPTION
## Summary
- tweak export dropdown to simple button group
- add jsPDF libraries for PDF fallback
- implement local PDF export when server download fails

## Testing
- `./format_check.sh`

------
https://chatgpt.com/codex/tasks/task_e_6855d1552ac8832f9a8500a4995b3eb6