### PR TITLE
Add database tables and generic CRUD API

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -55,6 +55,7 @@ def get_db():
 def init_db():
     conn = get_db()
     cur = conn.cursor()
+
     cur.execute(
         """
         CREATE TABLE IF NOT EXISTS products (
@@ -65,6 +66,7 @@ def init_db():
         )
         """
     )
+
     cur.execute(
         """
         CREATE TABLE IF NOT EXISTS history (
@@ -77,6 +79,157 @@ def init_db():
         )
         """
     )
+
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS Cliente (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            codigo TEXT NOT NULL UNIQUE CHECK(codigo != '' AND codigo NOT GLOB '*[^A-Z0-9-]*'),
+            nombre TEXT NOT NULL,
+            imagen_path TEXT,
+            updated_at TEXT NOT NULL,
+            version INTEGER NOT NULL DEFAULT 1
+        )
+        """
+    )
+
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS Proveedor (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            codigo TEXT NOT NULL UNIQUE CHECK(codigo != '' AND codigo NOT GLOB '*[^A-Z0-9-]*'),
+            nombre TEXT NOT NULL,
+            imagen_path TEXT,
+            updated_at TEXT NOT NULL,
+            version INTEGER NOT NULL DEFAULT 1
+        )
+        """
+    )
+
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS UnidadMedida (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            codigo TEXT NOT NULL UNIQUE CHECK(codigo != '' AND codigo NOT GLOB '*[^A-Z0-9-]*'),
+            descripcion TEXT NOT NULL,
+            updated_at TEXT NOT NULL,
+            version INTEGER NOT NULL DEFAULT 1
+        )
+        """
+    )
+
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS Insumo (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            codigo TEXT NOT NULL UNIQUE CHECK(codigo != '' AND codigo NOT GLOB '*[^A-Z0-9-]*'),
+            nombre TEXT NOT NULL,
+            unidad_id INTEGER NOT NULL,
+            peso REAL CHECK(peso > 0),
+            imagen_path TEXT,
+            updated_at TEXT NOT NULL,
+            version INTEGER NOT NULL DEFAULT 1,
+            FOREIGN KEY(unidad_id) REFERENCES UnidadMedida(id) ON DELETE RESTRICT
+        )
+        """
+    )
+
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS Producto (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            codigo TEXT NOT NULL UNIQUE CHECK(codigo != '' AND codigo NOT GLOB '*[^A-Z0-9-]*'),
+            descripcion TEXT NOT NULL,
+            cliente_id INTEGER NOT NULL,
+            peso REAL CHECK(peso > 0),
+            imagen_path TEXT,
+            updated_at TEXT NOT NULL,
+            version INTEGER NOT NULL DEFAULT 1,
+            FOREIGN KEY(cliente_id) REFERENCES Cliente(id) ON DELETE RESTRICT
+        )
+        """
+    )
+
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS Subproducto (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            producto_id INTEGER NOT NULL,
+            codigo TEXT NOT NULL UNIQUE CHECK(codigo != '' AND codigo NOT GLOB '*[^A-Z0-9-]*'),
+            descripcion TEXT,
+            peso REAL CHECK(peso > 0),
+            imagen_path TEXT,
+            updated_at TEXT NOT NULL,
+            version INTEGER NOT NULL DEFAULT 1,
+            FOREIGN KEY(producto_id) REFERENCES Producto(id) ON DELETE RESTRICT
+        )
+        """
+    )
+
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS ProductoInsumo (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            producto_id INTEGER NOT NULL,
+            insumo_id INTEGER NOT NULL,
+            cantidad REAL NOT NULL CHECK(cantidad > 0),
+            updated_at TEXT NOT NULL,
+            version INTEGER NOT NULL DEFAULT 1,
+            FOREIGN KEY(producto_id) REFERENCES Producto(id) ON DELETE RESTRICT,
+            FOREIGN KEY(insumo_id) REFERENCES Insumo(id) ON DELETE RESTRICT,
+            UNIQUE(producto_id, insumo_id)
+        )
+        """
+    )
+
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS AuditLog (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            table_name TEXT NOT NULL,
+            row_id INTEGER NOT NULL,
+            action TEXT NOT NULL,
+            snapshot TEXT NOT NULL,
+            timestamp TEXT NOT NULL
+        )
+        """
+    )
+
+    # create audit triggers
+    tables = [
+        "Cliente",
+        "Proveedor",
+        "UnidadMedida",
+        "Insumo",
+        "Producto",
+        "Subproducto",
+        "ProductoInsumo",
+    ]
+
+    for tbl in tables:
+        cols = [r[1] for r in cur.execute(f"PRAGMA table_info({tbl})").fetchall()]
+        new_cols = ", ".join([f"'{c}', NEW.{c}" for c in cols])
+        old_cols = ", ".join([f"'{c}', OLD.{c}" for c in cols])
+        cur.executescript(
+            f"""
+            CREATE TRIGGER IF NOT EXISTS {tbl}_ai AFTER INSERT ON {tbl}
+            BEGIN
+                INSERT INTO AuditLog(table_name,row_id,action,snapshot,timestamp)
+                VALUES ('{tbl}', NEW.id, 'insert', json_object({new_cols}), CURRENT_TIMESTAMP);
+            END;
+            CREATE TRIGGER IF NOT EXISTS {tbl}_au AFTER UPDATE ON {tbl}
+            BEGIN
+                INSERT INTO AuditLog(table_name,row_id,action,snapshot,timestamp)
+                VALUES ('{tbl}', NEW.id, 'update', json_object({new_cols}), CURRENT_TIMESTAMP);
+            END;
+            CREATE TRIGGER IF NOT EXISTS {tbl}_ad AFTER DELETE ON {tbl}
+            BEGIN
+                INSERT INTO AuditLog(table_name,row_id,action,snapshot,timestamp)
+                VALUES ('{tbl}', OLD.id, 'delete', json_object({old_cols}), CURRENT_TIMESTAMP);
+            END;
+            """
+        )
+
     conn.commit()
     conn.close()
 
@@ -163,6 +316,162 @@ def get_history():
     rows = conn.execute(query, params).fetchall()
     conn.close()
     return jsonify([dict(r) for r in rows])
+
+
+TABLE_MAP = {
+    "clientes": "Cliente",
+    "proveedores": "Proveedor",
+    "unidades": "UnidadMedida",
+    "insumos": "Insumo",
+    "productos_db": "Producto",
+    "subproductos": "Subproducto",
+    "producto_insumos": "ProductoInsumo",
+    "auditlog": "AuditLog",
+}
+
+
+def select_all(table):
+    conn = get_db()
+    rows = conn.execute(f"SELECT * FROM {table}").fetchall()
+    conn.close()
+    return [dict(r) for r in rows]
+
+
+def select_one(table, item_id):
+    conn = get_db()
+    cur = conn.cursor()
+    cur.execute(f"SELECT * FROM {table} WHERE id = ?", (item_id,))
+    row = cur.fetchone()
+    conn.close()
+    return dict(row) if row else None
+
+
+def insert_row(table, data):
+    now = datetime.utcnow().isoformat() + "Z"
+    data.setdefault("updated_at", now)
+    data.setdefault("version", 1)
+    keys = ", ".join(data.keys())
+    placeholders = ", ".join(["?" for _ in data])
+    values = list(data.values())
+    conn = get_db()
+    cur = conn.cursor()
+    try:
+        cur.execute(
+            f"INSERT INTO {table} ({keys}) VALUES ({placeholders})",
+            values,
+        )
+        item_id = cur.lastrowid
+        conn.commit()
+        cur.execute(f"SELECT * FROM {table} WHERE id = ?", (item_id,))
+        row = cur.fetchone()
+        result = dict(row)
+    except sqlite3.IntegrityError as e:
+        conn.rollback()
+        conn.close()
+        return None, str(e)
+    conn.close()
+    return result, None
+
+
+def update_row(table, item_id, data):
+    conn = get_db()
+    cur = conn.cursor()
+    cur.execute(f"SELECT * FROM {table} WHERE id = ?", (item_id,))
+    row = cur.fetchone()
+    if not row:
+        conn.close()
+        return None, "not found", 404
+    if row["updated_at"] != data.get("updated_at") or row["version"] != data.get(
+        "version"
+    ):
+        conn.close()
+        return None, "conflict", 409
+    new_version = row["version"] + 1
+    new_updated = datetime.utcnow().isoformat() + "Z"
+    fields = []
+    values = []
+    for k, v in data.items():
+        if k in ("id", "updated_at", "version"):
+            continue
+        fields.append(f"{k} = ?")
+        values.append(v)
+    fields.append("updated_at = ?")
+    values.append(new_updated)
+    fields.append("version = ?")
+    values.append(new_version)
+    values.append(item_id)
+    try:
+        cur.execute(f"UPDATE {table} SET {', '.join(fields)} WHERE id = ?", values)
+        conn.commit()
+        cur.execute(f"SELECT * FROM {table} WHERE id = ?", (item_id,))
+        updated = cur.fetchone()
+        result = dict(updated)
+    except sqlite3.IntegrityError as e:
+        conn.rollback()
+        conn.close()
+        return None, str(e), 400
+    conn.close()
+    return result, None, 200
+
+
+def delete_row(table, item_id):
+    conn = get_db()
+    cur = conn.cursor()
+    cur.execute(f"SELECT * FROM {table} WHERE id = ?", (item_id,))
+    row = cur.fetchone()
+    if not row:
+        conn.close()
+        return None, "not found", 404
+    try:
+        cur.execute(f"DELETE FROM {table} WHERE id = ?", (item_id,))
+        conn.commit()
+    except sqlite3.IntegrityError as e:
+        conn.rollback()
+        conn.close()
+        return None, str(e), 400
+    conn.close()
+    return dict(row), None, 200
+
+
+@app.route("/api/<table>", methods=["GET", "POST"])
+@app.route("/api/<table>/<int:item_id>", methods=["GET", "PATCH", "DELETE"])
+def generic_crud(table, item_id=None):
+    if table not in TABLE_MAP:
+        return jsonify({"success": False, "errors": "not found"}), 404
+
+    db_table = TABLE_MAP[table]
+
+    if request.method == "GET" and item_id is None:
+        data = select_all(db_table)
+        return jsonify({"success": True, "data": data})
+
+    if request.method == "GET" and item_id is not None:
+        row = select_one(db_table, item_id)
+        if row is None:
+            return jsonify({"success": False, "errors": "not found"}), 404
+        return jsonify({"success": True, "data": row})
+
+    if request.method == "POST":
+        payload = request.get_json(force=True, silent=True) or {}
+        row, err = insert_row(db_table, payload)
+        if err:
+            return jsonify({"success": False, "errors": err}), 400
+        return jsonify({"success": True, "data": row})
+
+    if request.method == "PATCH":
+        payload = request.get_json(force=True, silent=True) or {}
+        res, err, code = update_row(db_table, item_id, payload)
+        if err:
+            return jsonify({"success": False, "errors": err}), code
+        return jsonify({"success": True, "data": res})
+
+    if request.method == "DELETE":
+        res, err, code = delete_row(db_table, item_id)
+        if err:
+            return jsonify({"success": False, "errors": err}), code
+        return jsonify({"success": True, "data": res})
+
+    return jsonify({"success": False, "errors": "method not allowed"}), 405
 
 
 @app.get("/api/<module>/export")


### PR DESCRIPTION
## Summary
- create new SQLite tables with constraints and triggers
- add audit triggers logging row snapshots
- expose generic CRUD endpoints for new tables

## Testing
- `./format_check.sh`
- `python -m py_compile backend/main.py`

------
https://chatgpt.com/codex/tasks/task_e_6856c07e2dbc832f95b31e2101f281c6