### PR TITLE
Switch database tabs to selector

### DIFF
--- a/docs/assets/styles.css
+++ b/docs/assets/styles.css
@@ -1517,6 +1517,17 @@ select {
   margin-left: -24px;
 }
 
+/* Dataset selector on database page */
+.dataset-select {
+  margin-left: auto;
+  padding: 6px 8px;
+  border: 1px solid #bbb;
+  border-radius: 4px;
+  background: var(--color-light);
+  color: var(--color-text);
+  min-width: 180px;
+}
+
 /* Admin menu buttons */
 .admin-menu {
   width: 80%;
@@ -2178,26 +2189,6 @@ tr:not(.pending) td:first-child::before {
   color: #fff;
 }
 
-/* ===== Base de Datos tabs ===== */
-.db-tabs {
-  display: flex;
-  gap: 10px;
-  margin-bottom: 10px;
-  flex-wrap: wrap;
-}
-
-.db-tabs button {
-  padding: 6px 12px;
-  border: none;
-  background: var(--color-light);
-  border-radius: 4px;
-  cursor: pointer;
-}
-
-.db-tabs button.active {
-  background: var(--color-accent);
-  color: #fff;
-}
 
 .advanced-filters {
   display: flex;

--- a/docs/database.html
+++ b/docs/database.html
@@ -30,18 +30,19 @@
         <a id="linkArbol" href="asistente.html">Árbol de producto</a>
       </div>
     </div>
-    <section class="db-tabs">
-      <button data-type="" class="active">Todos</button>
-      <button data-type="Cliente">Clientes</button>
-      <button data-type="Producto">Productos</button>
-      <button data-type="Subproducto">Subproductos</button>
-      <button data-type="Insumo">Insumos</button>
-      <button data-type="Desactivado">Desactivados</button>
-    </section>
     <div class="search-wrapper">
       <input id="globalSearch" type="search" placeholder="Buscar...">
       <span id="searchSpinner" class="spinner"></span>
     </div>
+    <select id="datasetSelect" class="dataset-select">
+      <option value="">Todos</option>
+      <option value="Cliente">Clientes</option>
+      <option value="Producto">Productos</option>
+      <option value="Subproducto">Subproductos</option>
+      <option value="ProductoSub">Productos + Subproductos</option>
+      <option value="Insumo">Insumos</option>
+      <option value="Desactivado">Desactivados</option>
+    </select>
   </section>
   <div id="dbTable" class="tabla-contenedor"></div>
   <div id="tableSkeleton" class="skeleton-table" hidden></div>

--- a/docs/js/interactiveTable.js
+++ b/docs/js/interactiveTable.js
@@ -44,6 +44,12 @@ const columnSets = {
     { title: 'Imagen', field: 'imagen_path', formatter: cell => getImageHTML(cell.getValue()), hozAlign: 'center', headerSort: false },
     { title: 'Acciones', formatter: actionsFormatter, hozAlign: 'center', headerSort: false },
   ],
+  ProductoSub: [
+    { title: 'Descripción', field: 'Descripción', headerSort: true },
+    { title: 'Código', field: 'Código', headerSort: true },
+    { title: 'Imagen', field: 'imagen_path', formatter: cell => getImageHTML(cell.getValue()), hozAlign: 'center', headerSort: false },
+    { title: 'Acciones', formatter: actionsFormatter, hozAlign: 'center', headerSort: false },
+  ],
   Subproducto: [
     { title: 'Descripción', field: 'Descripción', headerSort: true },
     { title: 'Código', field: 'Código', headerSort: true },
@@ -102,6 +108,8 @@ function applyFilter() {
   let rows = allData.slice();
   if (currentFilter === 'Desactivado') {
     rows = rows.filter(r => r.Desactivado);
+  } else if (currentFilter === 'ProductoSub') {
+    rows = rows.filter(r => (r.Tipo === 'Producto' || r.Tipo === 'Subproducto') && !r.Desactivado);
   } else if (currentFilter) {
     rows = rows.filter(r => r.Tipo === currentFilter && !r.Desactivado);
   }
@@ -115,14 +123,11 @@ function applyFilter() {
 }
 
 function setupFilterButtons() {
-  const btns = document.querySelectorAll('.db-tabs button');
-  btns.forEach(btn => {
-    btn.addEventListener('click', () => {
-      btns.forEach(b => b.classList.remove('active'));
-      btn.classList.add('active');
-      currentFilter = btn.dataset.type || '';
-      applyFilter();
-    });
+  const select = document.getElementById('datasetSelect');
+  if (!select) return;
+  select.addEventListener('change', () => {
+    currentFilter = select.value || '';
+    applyFilter();
   });
 }
 


### PR DESCRIPTION
## Summary
- replace button tabs with dataset selector in Database page
- handle new selector in interactiveTable.js and support combined Producto/Subproducto
- cleanup obsolete `.db-tabs` CSS and style the selector

## Testing
- `./format_check.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856ce065820832fb522e7bc1183366f