### PR TITLE
Add collapsible sidebar for dataset filtering

### DIFF
--- a/docs/assets/styles.css
+++ b/docs/assets/styles.css
@@ -1539,6 +1539,68 @@ select {
   color: var(--color-light);
 }
 
+/* Collapsible sidebar for dataset selection */
+.sidebar-toggle {
+  position: fixed;
+  top: 70px;
+  left: 50px;
+  background: linear-gradient(135deg, var(--color-accent), var(--color-primary));
+  border: none;
+  border-radius: 6px;
+  padding: 6px 10px;
+  color: var(--color-light);
+  cursor: pointer;
+  z-index: 1101;
+}
+
+.dataset-sidebar {
+  position: fixed;
+  top: 0;
+  bottom: 0;
+  left: -220px;
+  width: 200px;
+  padding-top: 100px;
+  background: var(--color-primary);
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  transition: left var(--anim-duration) var(--anim-ease);
+  z-index: 1100;
+}
+
+.dataset-sidebar button {
+  margin: 0 10px;
+  padding: 10px;
+  color: var(--color-light);
+  background: none;
+  border: 1px solid var(--color-light);
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+.dataset-sidebar button:hover {
+  background: rgba(255, 255, 255, 0.1);
+}
+
+.sidebar-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.4);
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity var(--anim-duration) var(--anim-ease);
+  z-index: 1099;
+}
+
+body.sidebar-open .dataset-sidebar {
+  left: 0;
+}
+
+body.sidebar-open .sidebar-overlay {
+  opacity: 1;
+  visibility: visible;
+}
+
 /* Admin menu buttons */
 .admin-menu {
   width: 80%;

--- a/docs/database.html
+++ b/docs/database.html
@@ -15,6 +15,17 @@
 </head>
 <body>
   <nav id="nav-placeholder"></nav>
+  <button id="sidebarToggle" class="sidebar-toggle" type="button">☰</button>
+  <div id="sidebarOverlay" class="sidebar-overlay"></div>
+  <aside id="datasetSidebar" class="dataset-sidebar">
+    <button data-filter="">Todos</button>
+    <button data-filter="Cliente">Clientes</button>
+    <button data-filter="Producto">Productos</button>
+    <button data-filter="Subproducto">Subproductos</button>
+    <button data-filter="ProductoSub">Productos + Subproductos</button>
+    <button data-filter="Insumo">Insumos</button>
+    <button data-filter="Desactivado">Desactivados</button>
+  </aside>
   <button class="back-btn" onclick="goBack()">← Volver</button>
   <header class="editor-header">
     <h1 class="editor-title">Sinóptico de Base de Datos</h1>
@@ -34,15 +45,6 @@
       <input id="globalSearch" type="search" placeholder="Buscar...">
       <span id="searchSpinner" class="spinner"></span>
     </div>
-    <select id="datasetSelect" class="dataset-select">
-      <option value="">Todos</option>
-      <option value="Cliente">Clientes</option>
-      <option value="Producto">Productos</option>
-      <option value="Subproducto">Subproductos</option>
-      <option value="ProductoSub">Productos + Subproductos</option>
-      <option value="Insumo">Insumos</option>
-      <option value="Desactivado">Desactivados</option>
-    </select>
   </section>
   <div id="dbTable" class="tabla-contenedor"></div>
   <div id="tableSkeleton" class="skeleton-table" hidden></div>

--- a/docs/js/interactiveTable.js
+++ b/docs/js/interactiveTable.js
@@ -124,10 +124,30 @@ function applyFilter() {
 
 function setupFilterButtons() {
   const select = document.getElementById('datasetSelect');
-  if (!select) return;
-  select.addEventListener('change', () => {
-    currentFilter = select.value || '';
+  if (select) {
+    select.addEventListener('change', () => {
+      currentFilter = select.value || '';
+      applyFilter();
+    });
+  }
+}
+
+function setupSidebar() {
+  const toggle = document.getElementById('sidebarToggle');
+  const sidebar = document.getElementById('datasetSidebar');
+  const overlay = document.getElementById('sidebarOverlay');
+  if (!sidebar || !toggle) return;
+  const close = () => document.body.classList.remove('sidebar-open');
+  toggle.addEventListener('click', () => {
+    document.body.classList.toggle('sidebar-open');
+  });
+  overlay && overlay.addEventListener('click', close);
+  sidebar.addEventListener('click', ev => {
+    const btn = ev.target.closest('button[data-filter]');
+    if (!btn) return;
+    currentFilter = btn.dataset.filter || '';
     applyFilter();
+    close();
   });
 }
 
@@ -233,6 +253,7 @@ function initTable() {
 export function initInteractiveTable() {
   initTable();
   setupFilterButtons();
+  setupSidebar();
   setupSearch();
   setupActions();
   loadData();


### PR DESCRIPTION
## Summary
- replace dataset `<select>` with a slide‑out sidebar
- style sidebar and toggle button
- update JS to manage sidebar selection

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6856efb0ab08832f84843e71b7ae111b