### PR TITLE
Add JSON export/import options

### DIFF
--- a/docs/assets/styles.css
+++ b/docs/assets/styles.css
@@ -2240,6 +2240,7 @@ tr:not(.pending) td:first-child::before {
 }
 .btn-excel { background: #1b6e1b; }
 .btn-pdf { background: #c0392b; }
+.btn-json { background: #34495e; color: #fff; }
 
 /* export button group */
 .export-group {

--- a/docs/js/views/home.js
+++ b/docs/js/views/home.js
@@ -107,16 +107,6 @@ function loadModules(el) {
       ],
     },
     {
-      main: 'maestro_editor.html',
-      icon: '✏️',
-      text: 'Editar Maestro',
-      actions: [
-        { label: 'Editar maestro', href: 'maestro_editor.html' },
-        { label: 'Ver maestro', href: 'maestro.html' },
-      ],
-      class: 'no-guest',
-    },
-    {
       main: 'database.html',
       icon: '🗄️',
       text: 'Sinóptico de Base de Datos',


### PR DESCRIPTION
## Summary
- add export and import JSON buttons to sinoptico toolbar
- hide import button for non-admin users
- remove obsolete editor reference from home menu

## Testing
- `npm test` *(fails: Missing script)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*


------
https://chatgpt.com/codex/tasks/task_e_68570931b18c832f886fa9f3e6381200