### PR TITLE
Renombrar vista de base de datos

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Proyecto Barack
 
-Versión actual: **400**
+Versión actual: **401**
 
 Esta es una pequeña SPA (Single Page Application) escrita en HTML, CSS y JavaScript.
 Incluye un módulo llamado *Sinóptico* para gestionar jerarquías de productos.
@@ -28,7 +28,7 @@ El script actualiza `package.json`, `package-lock.json`, `README.md` y
    Sinóptico.
 3. Tras iniciar sesión se carga `index.html`, desde donde puedes navegar por las
    distintas páginas.
-   Los administradores tienen acceso completo a "Base de Datos" y "Editar
+   Los administradores tienen acceso completo a "Registros" y "Editar
    Sinóptico".
    También encontrarás el enlace "Listado Maestro" que abre `maestro.html`.
 4. Los datos pueden guardarse localmente en el navegador o en el servidor.
@@ -195,7 +195,7 @@ El esquema relacional completo puede consultarse en `docs/er.svg`.
 
 ## Solución de problemas
 
-Si los cambios realizados desde la vista **Base de Datos** no se guardan,
+Si los cambios realizados desde la vista **Registros** no se guardan,
 verifica lo siguiente:
 
 1. Asegúrate de usar un navegador moderno que permita cargar módulos y acceder

--- a/docs/js/authGuard.js
+++ b/docs/js/authGuard.js
@@ -1,7 +1,7 @@
 import { logout, isAdmin, isGuest } from './session.js';
 
 // guests shouldn't access certain pages directly
-const guestOnlyPages = ['database.html', 'asistente.html', 'history.html'];
+const guestOnlyPages = ['registros.html', 'asistente.html', 'history.html'];
 if (isGuest() && guestOnlyPages.some(p => location.pathname.endsWith(p))) {
   location.href = 'sinoptico.html';
 }

--- a/docs/js/version.js
+++ b/docs/js/version.js
@@ -1,4 +1,4 @@
-export const version = '400';
+export const version = '401';
 export function displayVersion() {
   const div = document.createElement('div');
   div.className = 'version-info';

--- a/docs/js/views/home.js
+++ b/docs/js/views/home.js
@@ -117,9 +117,9 @@ function loadModules(el) {
       class: 'no-guest',
     },
     {
-      main: 'database.html',
+      main: 'registros.html',
       icon: '🗄️',
-      text: 'Sinóptico de Base de Datos',
+      text: 'Sinóptico de Registros',
       actions: [],
       class: 'no-guest',
     },

--- a/docs/js/views/sinoptico.js
+++ b/docs/js/views/sinoptico.js
@@ -8,7 +8,7 @@ export async function render(container) {
     <div class="toolbar">
       ${editBtnHtml}
       <a id="linkCrear" href="asistente.html">Crear</a>
-      <a id="linkBaseDatos" href="database.html">Base de Datos</a>
+      <a id="linkRegistros" href="registros.html">Registros</a>
       <div class="export-group">
         <button data-fmt="excel" id="btnExcel" class="btn-excel">Excel</button>
         <button data-fmt="pdf" id="btnPdf" class="btn-pdf">PDF</button>

--- a/docs/nav.html
+++ b/docs/nav.html
@@ -23,7 +23,7 @@
   <div class="nav-item dropdown">
     <a href="#">Ver más</a>
     <div class="dropdown-menu">
-      <a href="database.html" class="no-guest">Sinóptico de Base de Datos</a>
+      <a href="registros.html" class="no-guest">Sinóptico de Registros</a>
       <a href="index.html#/settings" class="no-guest">Modo Dev</a>
       <a href="history.html" class="admin-only">Historial</a>
     </div>

--- a/docs/registros.html
+++ b/docs/registros.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="Content-Security-Policy" content="default-src * 'unsafe-inline' 'unsafe-eval' data: blob:; connect-src *; img-src * data:; style-src * 'unsafe-inline';">
-  <title>Sinóptico de Base de Datos</title>
+  <title>Sinóptico de Registros</title>
   <link rel="stylesheet" href="assets/styles.css">
   <link rel="stylesheet" href="lib/tabulator/tabulator.min.css">
   <script>
@@ -28,7 +28,7 @@
   </aside>
   <button class="back-btn" onclick="goBack()">← Volver</button>
   <header class="editor-header">
-    <h1 class="editor-title">Sinóptico de Base de Datos</h1>
+    <h1 class="editor-title">Sinóptico de Registros</h1>
   </header>
   <section class="editor-menu">
     <div class="dropdown">

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "proyecto-barack",
-  "version": "400",
+  "version": "401",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "proyecto-barack",
-      "version": "400",
+      "version": "401",
       "license": "ISC",
       "dependencies": {
         "jsdom": "^22.1.0"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "proyecto-barack",
-  "version": "400",
-  "description": "Versión actual: **400**",
+  "version": "401",
+  "description": "Versión actual: **401**",
   "main": "index.js",
   "directories": {
     "lib": "lib"
@@ -17,7 +17,7 @@
     "assets": [
       "index.html",
       "login.html",
-      "database.html",
+      "registros.html",
       "sinoptico.html",
       "asistente.html",
       "assets/**/*",


### PR DESCRIPTION
## Summary
- rename `docs/database.html` to `docs/registros.html`
- update navigation links and auth guard to use `registros.html`
- adjust texts that referenced **Base de Datos**
- bump version to 401

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68570c27f3f4832fad67858c1e2dac83