### PR TITLE
Fix dropdown toggle logic

### DIFF
--- a/docs/assets/styles.css
+++ b/docs/assets/styles.css
@@ -899,6 +899,9 @@ body, html {
 .dropdown-menu button:hover {
   background: rgba(255,255,255,0.1);
 }
+.dropdown.open {
+  z-index: 1200;
+}
 .dropdown.open .dropdown-menu,
 .nav-item.dropdown.open .dropdown-menu {
   display: block;

--- a/docs/js/crearMenu.js
+++ b/docs/js/crearMenu.js
@@ -1,14 +1,14 @@
 export function initCrearMenu() {
   const menuBtn = document.getElementById('btnMenuCrear');
-  const dropdown = menuBtn?.nextElementSibling;
+  const dropdown = menuBtn?.closest('.dropdown');
   if (!menuBtn || !dropdown) return;
   menuBtn.addEventListener('click', e => {
     e.stopPropagation();
-    dropdown.parentElement.classList.toggle('open');
+    dropdown.classList.toggle('open');
   });
   window.addEventListener('click', e => {
-    if (!dropdown.parentElement.contains(e.target)) {
-      dropdown.parentElement.classList.remove('open');
+    if (!dropdown.contains(e.target)) {
+      dropdown.classList.remove('open');
     }
   });
 }

--- a/tools/test_dropdown.js
+++ b/tools/test_dropdown.js
@@ -1,0 +1,25 @@
+import { JSDOM } from 'jsdom';
+import { readFileSync } from 'fs';
+
+async function test(htmlPath) {
+  const dom = await JSDOM.fromFile(htmlPath, { runScripts: "outside-only" });
+  const { window } = dom;
+  const scriptSrc = readFileSync('docs/js/crearMenu.js', 'utf8');
+  const script = scriptSrc.replace('export function', 'function');
+  window.eval(script);
+  window.initCrearMenu();
+  const btn = window.document.getElementById('btnMenuCrear');
+  if (!btn) {
+    console.log(`button not found in ${htmlPath}`);
+    return;
+  }
+  const dropdown = btn.closest('.dropdown');
+  btn.dispatchEvent(new window.Event('click', { bubbles: true }));
+  const opened = dropdown.classList.contains('open');
+  window.document.body.dispatchEvent(new window.Event('click', { bubbles: true }));
+  const closed = !dropdown.classList.contains('open');
+  console.log(`${htmlPath}: opened=${opened} closed=${closed}`);
+}
+
+await test('docs/registros.html');
+await test('docs/sinoptico.html');


### PR DESCRIPTION
## Summary
- ensure menu toggle attaches to the `.dropdown` container
- raise dropdown `z-index` when open so it overlays other content
- add small test script to verify opening/closing behaviour

## Testing
- `./format_check.sh`
- `pytest -q`
- `node tools/test_dropdown.js`


------
https://chatgpt.com/codex/tasks/task_e_68570e67c08c832f9a1500b692e8b708