### PR TITLE
Update guest restrictions in frontend

### DIFF
--- a/docs/assets/styles.css
+++ b/docs/assets/styles.css
@@ -2586,3 +2586,15 @@ tr:not(.pending) td:first-child::before {
 .fade-img.loaded {
   opacity: 1;
 }
+
+/* Hide editing controls for guest users */
+.guest #sin-edit,
+.guest #btnMenuCrear,
+.guest #btnNuevoCliente,
+.guest #btnNuevoProducto,
+.guest #btnNuevoSub,
+.guest #btnNuevoInsumo,
+.guest .delete-row,
+.guest .toggle-status {
+  display: none !important;
+}

--- a/docs/js/authGuard.js
+++ b/docs/js/authGuard.js
@@ -1,7 +1,7 @@
 import { logout, isAdmin, isGuest } from './session.js';
 
 // guests shouldn't access certain pages directly
-const guestOnlyPages = ['registros.html', 'asistente.html', 'history.html'];
+const guestOnlyPages = ['registros.html', 'records.html', 'asistente.html', 'history.html'];
 if (isGuest() && guestOnlyPages.some(p => location.pathname.endsWith(p))) {
   location.href = 'sinoptico.html';
 }
@@ -9,7 +9,13 @@ if (isGuest() && guestOnlyPages.some(p => location.pathname.endsWith(p))) {
 function applyRoleRules() {
   if (isGuest()) {
     sessionStorage.setItem('sinopticoEdit', 'false');
+    document.body.classList.add('guest');
     document.querySelectorAll('.no-guest').forEach(el => el.style.display = 'none');
+    document.querySelector('#sin-edit')?.classList.add('hidden');
+    document.getElementById('btnMenuCrear')?.classList.add('hidden');
+    document.querySelectorAll('.delete-row, .toggle-status').forEach(el => el.classList.add('hidden'));
+  } else {
+    document.body.classList.remove('guest');
   }
   if (!isAdmin()) {
     document.querySelectorAll('.admin-only').forEach(el => el.style.display = 'none');

--- a/docs/js/pageSettings.js
+++ b/docs/js/pageSettings.js
@@ -1,3 +1,4 @@
+import { isGuest } from './session.js';
 // Apply saved UI preferences like brightness and version overlay
 export function applyUserSettings() {
   const brightness = localStorage.getItem('pageBrightness') || '100';
@@ -11,7 +12,7 @@ export function applyUserSettings() {
   document.body.classList.toggle('grid-overlay', grid);
 
   const edit = localStorage.getItem('defaultEditMode') === 'true';
-  if (edit) {
+  if (edit && !isGuest()) {
     sessionStorage.setItem('sinopticoEdit', 'true');
     document.dispatchEvent(new Event('sinoptico-mode'));
   }

--- a/docs/js/views/sinoptico.js
+++ b/docs/js/views/sinoptico.js
@@ -1,6 +1,6 @@
 import { getAll } from '../dataService.js';
 import { createSinopticoEditor } from '../editors/sinopticoEditor.js';
-import { isAdmin } from '../session.js';
+import { isAdmin, isGuest } from '../session.js';
 
 export async function render(container) {
   const editBtnHtml = isAdmin() ? '<button id="sin-edit">Editar</button>' : '';
@@ -108,8 +108,10 @@ export async function render(container) {
 
 
   container.querySelector('#sin-edit')?.addEventListener('click', () => {
-    sessionStorage.setItem('sinopticoEdit', 'true');
-    document.dispatchEvent(new Event('sinoptico-mode'));
+    if (!isGuest()) {
+      sessionStorage.setItem('sinopticoEdit', 'true');
+      document.dispatchEvent(new Event('sinoptico-mode'));
+    }
   });
 
 

--- a/docs/sinoptico.html
+++ b/docs/sinoptico.html
@@ -80,8 +80,11 @@
   <script type="module" src="js/hideLoading.js" defer></script>
   <script type="module" src="js/newClientDialog.js" defer></script>
   <script type="module" src="js/version.js" defer></script>
-  <script>
-    sessionStorage.setItem('sinopticoEdit', 'false');
+  <script type="module">
+    import { isGuest } from './js/session.js';
+    if (isGuest()) {
+      sessionStorage.setItem('sinopticoEdit', 'false');
+    }
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- extend guest guard to block the new records page
- hide editing controls when a guest is logged in
- respect guest/admin checks when toggling edit mode

## Testing
- `./format_check.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68570fb9a5b4832fbfcc1e762a7e2991