### PR TITLE
Mejoras en menú y tabla de registros

### DIFF
--- a/docs/assets/styles.css
+++ b/docs/assets/styles.css
@@ -939,7 +939,7 @@ body, html {
 
 .back-btn {
   position: fixed;
-  top: 70px;
+  top: 80px;
   left: 10px;
   background: linear-gradient(135deg, var(--color-accent), var(--color-primary));
   border: none;
@@ -961,7 +961,7 @@ body, html {
 }
 
 body.sinoptico-page .back-btn {
-  top: 90px;
+  top: 100px;
 }
 
 header {
@@ -1545,7 +1545,7 @@ select {
 /* Collapsible sidebar for dataset selection */
 .sidebar-toggle {
   position: fixed;
-  top: 70px;
+  top: 80px;
   left: 50px;
   background: linear-gradient(135deg, var(--color-accent), var(--color-primary));
   border: none;
@@ -2458,6 +2458,13 @@ tr:not(.pending) td:first-child::before {
 }
 #dbTable .tabulator-cell {
   padding: 8px;
+  color: var(--color-text);
+}
+#dbTable .tabulator-row:nth-child(even) {
+  background-color: #f7f7f7;
+}
+.dark #dbTable .tabulator-row:nth-child(even) {
+  background-color: #222;
 }
 #dbTable button {
   background-color: var(--color-accent);

--- a/docs/js/interactiveTable.js
+++ b/docs/js/interactiveTable.js
@@ -160,6 +160,9 @@ function setupSidebar() {
     document.body.classList.toggle('sidebar-open');
   });
   overlay && overlay.addEventListener('click', close);
+  document.addEventListener('keydown', ev => {
+    if (ev.key === 'Escape') close();
+  });
   sidebar.addEventListener('click', ev => {
     const btn = ev.target.closest('button[data-filter]');
     if (!btn) return;

--- a/docs/nav.html
+++ b/docs/nav.html
@@ -4,7 +4,7 @@
     <a href="sinoptico.html">Sinóptico</a>
     <div class="dropdown-menu">
       <a href="sinoptico.html">Ver Sinóptico</a>
-      <a href="registros.html" class="no-guest">Registros</a>
+      <a href="registros.html">Registro Sinóptico</a>
     </div>
   </div>
   <div class="nav-item dropdown">


### PR DESCRIPTION
## Summary
- mostrar "Registro Sinóptico" junto con "Ver Sinóptico" en el menú superior
- mejorar contraste de filas en la tabla de registros
- ajustar posición de botones de navegación y sidebar
- permitir cerrar la barra lateral con la tecla Esc

## Testing
- `black --check server.py`

------
https://chatgpt.com/codex/tasks/task_e_68571c6182c4832fa375fd86a32bb014