### PR TITLE
Improve dev settings toggles

### DIFF
--- a/docs/assets/styles.css
+++ b/docs/assets/styles.css
@@ -168,6 +168,37 @@ h1 {
   line-height: 1.4;
 }
 
+.backup-tools {
+  margin: 20px;
+  padding: 10px;
+  background-color: var(--color-light);
+  border-radius: 6px;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.1);
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  animation: fadeIn 0.3s ease-in-out;
+}
+
+.backup-tools select {
+  padding: 6px;
+  border: 1px solid #bbb;
+  border-radius: 4px;
+}
+
+.backup-tools button {
+  padding: 6px 12px;
+  background-color: var(--color-primary);
+  color: var(--color-light);
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.backup-tools button:hover {
+  background-color: var(--color-primary-hover);
+}
+
 .card {
   background: var(--color-light);
   color: var(--color-text);
@@ -2601,4 +2632,8 @@ tr:not(.pending) td:first-child::before {
 .guest .delete-row,
 .guest .toggle-status {
   display: none !important;
+}
+
+body.settings-page main {
+  animation: fadeIn 0.3s ease-in-out;
 }

--- a/docs/js/pageSettings.js
+++ b/docs/js/pageSettings.js
@@ -29,6 +29,13 @@ export function activateDevMode() {
   showDevBanner();
 }
 
+export function deactivateDevMode() {
+  localStorage.removeItem('devMode');
+  if (typeof window.mostrarMensaje === 'function') {
+    window.mostrarMensaje('Modo Dev desactivado', 'info');
+  }
+}
+
 export function checkDevBanner() {
   const inSettings = document.body.classList.contains('settings-page');
   if (inSettings && localStorage.getItem('devMode') === 'true') {

--- a/docs/js/views/home.js
+++ b/docs/js/views/home.js
@@ -133,7 +133,7 @@ function loadModules(el) {
     {
       main: '#/settings',
       icon: '⚙️',
-      text: 'Ajustes',
+      text: 'Modo Dev',
       actions: [],
       class: 'no-guest',
     },

--- a/docs/js/views/settings.js
+++ b/docs/js/views/settings.js
@@ -1,11 +1,16 @@
 import { getAll, ready } from '../dataService.js';
 import { getUser } from '../session.js';
-import { activateDevMode } from '../pageSettings.js';
+import { activateDevMode, deactivateDevMode } from '../pageSettings.js';
+import { animateInsert } from '../ui/animations.js';
 
 export async function render(container) {
   container.innerHTML = `
-    <h1>Modo Desarrollador</h1>
+    <h1>Modo Dev</h1>
     <section class="dev-options">
+      <label>
+        <input type="checkbox" id="toggleDevMode">
+        Activar Modo Dev
+      </label>
       <label>
         Brillo de la página:
         <input id="brightnessRange" type="range" min="50" max="150" step="10">
@@ -34,7 +39,7 @@ export async function render(container) {
       <button id="restoreBackup" type="button">Restaurar</button>
     </section>`;
 
-  activateDevMode();
+  animateInsert(container);
 
   await ready;
   const data = await getAll('sinoptico');
@@ -44,6 +49,7 @@ export async function render(container) {
 
   const range = container.querySelector('#brightnessRange');
   const valueLabel = container.querySelector('#brightnessValue');
+  const devChk = container.querySelector('#toggleDevMode');
   const versionChk = container.querySelector('#toggleVersionOverlay');
   const gridChk = container.querySelector('#toggleGridOverlay');
   const userSpan = container.querySelector('#devUser');
@@ -57,6 +63,17 @@ export async function render(container) {
   const storedBrightness = localStorage.getItem('pageBrightness') || '100';
   range.value = storedBrightness;
   valueLabel.textContent = storedBrightness + '%';
+
+  const devActive = localStorage.getItem('devMode') === 'true';
+  if (devChk) devChk.checked = devActive;
+
+  devChk?.addEventListener('change', ev => {
+    if (ev.target.checked) {
+      activateDevMode();
+    } else {
+      deactivateDevMode();
+    }
+  });
 
   range.addEventListener('input', ev => {
     const val = ev.target.value;


### PR DESCRIPTION
## Summary
- allow disabling dev mode
- style backup tools section and fade in settings page
- rename "Ajustes" module tile to "Modo Dev"
- add animated entrance to dev page

## Testing
- `bash format_check.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68571cd54c5c832fa2d51887c7f34df8