### PR TITLE
Add simple DB viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ Puedes generar copias manualmente con `POST /api/backups` o desde la página **M
 Por defecto se programa una copia diaria en `data/backups/AAAA-MM-DD.json`. Si prefieres desactivar esta tarea define `DISABLE_AUTOBACKUP=1` antes de iniciar el servidor.
 Los respaldos se encuentran en la carpeta `data/backups/`. Si eliminas el repositorio también se borrará esta carpeta a menos que la conserves aparte.
 
+Para revisar visualmente el contenido actual de la base de datos se incluye la página `docs/dbviewer.html`. Ábrela con el servidor en marcha para ver los datos en formato JSON.
+
 El servidor también expone `GET /api/sinoptico/export` para descargar la tabla
 de Sinóptico en Excel o PDF. Usa el parámetro `format=excel` o `format=pdf`
 según prefieras.

--- a/docs/dbviewer.html
+++ b/docs/dbviewer.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <title>Base de datos</title>
+  <link rel="stylesheet" href="assets/styles.css">
+</head>
+<body>
+  <nav id="nav-placeholder"></nav>
+  <main class="container">
+    <h1>Base de datos</h1>
+    <p>Vista de la base de datos actual en formato JSON.</p>
+    <pre id="dbDump">Cargando...</pre>
+    <p>Para conocer el esquema completo puedes consultar <a href="er.svg" target="_blank">er.svg</a>.</p>
+  </main>
+  <script src="js/nav.js"></script>
+  <script>
+    fetch('/api/data').then(r => r.json()).then(data => {
+      const pre = document.getElementById('dbDump');
+      pre.textContent = JSON.stringify(data, null, 2);
+    }).catch(() => {
+      document.getElementById('dbDump').textContent = 'No se pudo cargar la base de datos';
+    });
+  </script>
+</body>
+</html>

--- a/docs/nav.html
+++ b/docs/nav.html
@@ -26,6 +26,7 @@
     <div class="dropdown-menu">
       <a href="index.html#/settings" class="no-guest">Modo Dev</a>
       <a href="history.html" class="admin-only">Historial</a>
+      <a href="dbviewer.html" class="no-guest">Ver base de datos</a>
     </div>
   </div>
   <button id="toggleDarkMode" type="button" aria-label="Alternar modo oscuro" title="Alternar modo oscuro">🌙</button>


### PR DESCRIPTION
## Summary
- add `docs/dbviewer.html` page showing JSON data and ER diagram link
- link new page in navigation menu
- mention dbviewer in README for easier inspection

## Testing
- `pytest -q`
- `./format_check.sh`

------
https://chatgpt.com/codex/tasks/task_e_68572176aeb0832f8273be98f93d1840