### PR TITLE
Improve guest access and logout UX

### DIFF
--- a/docs/js/authGuard.js
+++ b/docs/js/authGuard.js
@@ -1,7 +1,7 @@
 import { logout, isAdmin, isGuest } from './session.js';
 
 // guests shouldn't access certain pages directly
-const guestOnlyPages = ['registros.html', 'records.html', 'asistente.html', 'history.html'];
+const guestOnlyPages = ['records.html', 'asistente.html', 'history.html'];
 if (isGuest() && guestOnlyPages.some(p => location.pathname.endsWith(p))) {
   location.href = 'sinoptico.html';
 }
@@ -22,8 +22,11 @@ function applyRoleRules() {
   }
   document.querySelectorAll('.logout-link').forEach(btn => {
     btn.addEventListener('click', () => {
-      logout();
-      location.href = 'login.html';
+      document.body.classList.add('fade-out');
+      setTimeout(() => {
+        logout();
+        location.href = 'login.html';
+      }, 100);
     });
   });
 }


### PR DESCRIPTION
## Summary
- allow guests to open `registros.html` in read-only mode
- add fade-out transition when logging out

## Testing
- `./format_check.sh`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68573b266634832fa4ab0bd6fdd6385d