### PR TITLE
Integrate backups and history

### DIFF
--- a/docs/history.html
+++ b/docs/history.html
@@ -15,7 +15,22 @@
 <body>
   <nav id="nav-placeholder"></nav>
   <button class="back-btn" onclick="goBack()">← Volver</button>
-  <h1>Historial reciente</h1>
+  <h1>Historial y Backups</h1>
+
+  <section class="backup-tools">
+    <button id="createBackup" type="button">Crear backup</button>
+    <select id="backupList"></select>
+    <button id="restoreBackup" type="button">Restaurar</button>
+  </section>
+
+  <div class="advanced-filters">
+    <input type="text" id="pageFilter" placeholder="Página">
+    <input type="text" id="userFilter" placeholder="Usuario">
+    <input type="date" id="startDate">
+    <input type="date" id="endDate">
+    <button id="applyFilters" type="button">Filtrar</button>
+  </div>
+
   <section class="tabla-contenedor">
     <table id="historyTable">
       <thead>

--- a/docs/js/history.js
+++ b/docs/js/history.js
@@ -1,31 +1,80 @@
 'use strict';
 
-document.addEventListener('DOMContentLoaded', async () => {
+document.addEventListener('DOMContentLoaded', () => {
   const tbody = document.querySelector('#historyTable tbody');
-  try {
-    const resp = await fetch('/api/history');
-    if (!resp.ok) throw new Error('Request failed');
-    const data = await resp.json();
-    tbody.innerHTML = '';
-    data.slice().reverse().forEach(entry => {
-      const tr = document.createElement('tr');
-      let summary = entry.summary;
-      if (!summary && entry.changes) {
-        try {
-          summary = entry.changes.summary || JSON.stringify(entry.changes).slice(0, 60);
-        } catch {
-          summary = '';
-        }
-      }
-      tr.innerHTML =
-        `<td>${entry.timestamp || ''}</td>` +
-        `<td>${entry.ip || ''}</td>` +
-        `<td>${summary || ''}</td>`;
-      tbody.appendChild(tr);
-    });
-  } catch (e) {
-    console.error(e);
-    tbody.innerHTML = '<tr><td colspan="3">Error al cargar historial</td></tr>';
-  }
-});
+  const pageInput = document.getElementById('pageFilter');
+  const userInput = document.getElementById('userFilter');
+  const startInput = document.getElementById('startDate');
+  const endInput = document.getElementById('endDate');
+  const applyBtn = document.getElementById('applyFilters');
+  const backupSel = document.getElementById('backupList');
+  const createBtn = document.getElementById('createBackup');
+  const restoreBtn = document.getElementById('restoreBackup');
 
+  async function loadHistory() {
+    const params = new URLSearchParams();
+    if (pageInput.value) params.append('page', pageInput.value);
+    if (userInput.value) params.append('user', userInput.value);
+    if (startInput.value) params.append('from', startInput.value);
+    if (endInput.value) params.append('to', endInput.value);
+    try {
+      const resp = await fetch('/api/history?' + params.toString());
+      if (!resp.ok) throw new Error('Request failed');
+      const data = await resp.json();
+      tbody.innerHTML = '';
+      data.slice().reverse().forEach(entry => {
+        const tr = document.createElement('tr');
+        let summary = entry.summary;
+        if (!summary && entry.changes) {
+          try {
+            summary = entry.changes.summary || JSON.stringify(entry.changes).slice(0, 60);
+          } catch {
+            summary = '';
+          }
+        }
+        tr.innerHTML =
+          `<td>${entry.timestamp || ''}</td>` +
+          `<td>${entry.ip || ''}</td>` +
+          `<td>${summary || ''}</td>`;
+        tbody.appendChild(tr);
+      });
+    } catch (e) {
+      console.error(e);
+      tbody.innerHTML = '<tr><td colspan="3">Error al cargar historial</td></tr>';
+    }
+  }
+
+  async function loadBackups() {
+    try {
+      const resp = await fetch('/api/backups');
+      if (!resp.ok) return;
+      const list = await resp.json();
+      backupSel.innerHTML = list
+        .map(name => `<option value="${name}">${name}</option>`) 
+        .join('');
+    } catch (e) {
+      console.error(e);
+    }
+  }
+
+  createBtn?.addEventListener('click', async () => {
+    await fetch('/api/backups', { method: 'POST' });
+    loadBackups();
+  });
+
+  restoreBtn?.addEventListener('click', async () => {
+    const name = backupSel.value;
+    if (!name) return;
+    await fetch('/api/restore', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name })
+    });
+    window.location.reload();
+  });
+
+  applyBtn?.addEventListener('click', loadHistory);
+
+  loadBackups();
+  loadHistory();
+});

--- a/server.py
+++ b/server.py
@@ -114,7 +114,22 @@ def data():
 
 @app.route("/api/history", methods=["GET"])
 def get_history():
-    return jsonify(history)
+    page = request.args.get("page")
+    user = request.args.get("user")
+    from_ts = request.args.get("from")
+    to_ts = request.args.get("to")
+
+    result = history
+    if page:
+        result = [h for h in result if page in str(h.get("host", ""))]
+    if user:
+        result = [h for h in result if user in str(h.get("user", ""))]
+    if from_ts:
+        result = [h for h in result if h.get("timestamp", "") >= from_ts]
+    if to_ts:
+        result = [h for h in result if h.get("timestamp", "") <= to_ts]
+
+    return jsonify(result)
 
 
 @app.route("/api/server-info", methods=["GET"])


### PR DESCRIPTION
## Summary
- combine backup tools and history view
- add filtering capabilities in history page
- support history filtering on the server

## Testing
- `./format_check.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857410b6bf8832f86f2f5d6316362d9