### PR TITLE
Add docs dependency on backend

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,7 @@ services:
     ports: ["5000:5000"]
   docs:
     image: nginx:alpine
+    depends_on: [backend]
     volumes:
       - ./docs:/usr/share/nginx/html:ro
       - ./nginx.conf:/etc/nginx/conf.d/default.conf:ro


### PR DESCRIPTION
## Summary
- make the docs service wait for backend by adding `depends_on: [backend]`

## Testing
- `bash format_check.sh`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68597a153198832fb307ab6b85652aec