### PR TITLE
Fix CORS dependency name

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Flask
-flask_cors
+Flask-Cors
 flask_socketio>=5.0.0
 eventlet>=0.33.0
 APScheduler


### PR DESCRIPTION
## Summary
- standardize CORS package naming

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68597a92e8c4832f97499662ca46af37