### PR TITLE
Enable data refresh via subscribeToChanges

### DIFF
--- a/docs/js/dbPage.js
+++ b/docs/js/dbPage.js
@@ -1,5 +1,11 @@
 'use strict';
-import { getAll, updateNode, deleteNode, ready } from './dataService.js';
+import {
+  getAll,
+  updateNode,
+  deleteNode,
+  ready,
+  subscribeToChanges,
+} from './dataService.js';
 import { animateInsert } from './ui/animations.js';
 
 document.addEventListener('DOMContentLoaded', () => {
@@ -163,4 +169,5 @@ document.addEventListener('DOMContentLoaded', () => {
   });
 
   load();
+  subscribeToChanges(load);
 });

--- a/docs/js/history.js
+++ b/docs/js/history.js
@@ -70,7 +70,6 @@ document.addEventListener('DOMContentLoaded', () => {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ name })
     });
-    window.location.reload();
   });
 
   applyBtn?.addEventListener('click', loadHistory);

--- a/docs/js/interactiveTable.js
+++ b/docs/js/interactiveTable.js
@@ -1,5 +1,11 @@
 'use strict';
-import { getAll, updateNode, deleteNode, ready } from './dataService.js';
+import {
+  getAll,
+  updateNode,
+  deleteNode,
+  ready,
+  subscribeToChanges,
+} from './dataService.js';
 
 function showToast(msg) {
   const div = document.createElement('div');
@@ -349,6 +355,7 @@ export function initInteractiveTable() {
   setupActions();
   setupExport();
   loadData();
+  subscribeToChanges(loadData);
 }
 
 document.addEventListener('DOMContentLoaded', initInteractiveTable);

--- a/docs/js/views/amfe.js
+++ b/docs/js/views/amfe.js
@@ -1,4 +1,4 @@
-import { getAll, ready } from '../dataService.js';
+import { getAll, ready, subscribeToChanges } from '../dataService.js';
 
 export async function render(container) {
   container.innerHTML = `
@@ -11,11 +11,16 @@ export async function render(container) {
     <div id="amfe"></div>
   `;
 
-  await ready;
-  const data = await getAll('amfe');
-  if (typeof window.renderAMFE === 'function') {
-    window.renderAMFE(data);
+  async function load() {
+    await ready;
+    const data = await getAll('amfe');
+    if (typeof window.renderAMFE === 'function') {
+      window.renderAMFE(data);
+    }
   }
+
+  await load();
+  subscribeToChanges(load);
 
   const exportBtn = container.querySelector('#amfe-export');
   const menu = container.querySelector('.export-menu');

--- a/docs/js/views/maestro.js
+++ b/docs/js/views/maestro.js
@@ -1,4 +1,4 @@
-import { getAll, ready } from '../dataService.js';
+import { getAll, ready, subscribeToChanges } from '../dataService.js';
 
 export async function render(container) {
   container.innerHTML = `
@@ -74,6 +74,7 @@ export async function render(container) {
 
   let currentPage = 1;
   let pageSize = parseInt(pageSizeSelect.value, 10);
+  let rows = [];
 
   function showSpinner() {
     const el = container.querySelector('#loading');
@@ -85,11 +86,17 @@ export async function render(container) {
     if (el) el.style.display = 'none';
   }
 
-  showSpinner();
-  await ready;
-  let rows = await getAll('maestro');
-  if (!Array.isArray(rows)) rows = [];
-  hideSpinner();
+  async function load() {
+    showSpinner();
+    await ready;
+    rows = await getAll('maestro');
+    if (!Array.isArray(rows)) rows = [];
+    hideSpinner();
+    renderRows();
+  }
+
+  await load();
+  subscribeToChanges(load);
 
   function filterRows() {
     const term = search.value.trim().toLowerCase();

--- a/docs/js/views/settings.js
+++ b/docs/js/views/settings.js
@@ -1,4 +1,4 @@
-import { getAll, ready } from '../dataService.js';
+import { getAll, ready, subscribeToChanges } from '../dataService.js';
 import { getUser } from '../session.js';
 import { activateDevMode, deactivateDevMode } from '../pageSettings.js';
 import { animateInsert } from '../ui/animations.js';
@@ -41,11 +41,17 @@ export async function render(container) {
 
   animateInsert(container);
 
-  await ready;
-  const data = await getAll('sinoptico');
   const p = document.createElement('p');
-  p.textContent = `Registros en sinóptico: ${data.length}`;
   container.appendChild(p);
+
+  async function load() {
+    await ready;
+    const data = await getAll('sinoptico');
+    p.textContent = `Registros en sinóptico: ${data.length}`;
+  }
+
+  await load();
+  subscribeToChanges(load);
 
   const range = container.querySelector('#brightnessRange');
   const valueLabel = container.querySelector('#brightnessValue');
@@ -143,7 +149,6 @@ export async function render(container) {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ name }),
       });
-      window.location.reload();
     });
   }
 

--- a/docs/js/views/sinoptico.js
+++ b/docs/js/views/sinoptico.js
@@ -1,4 +1,4 @@
-import { getAll } from '../dataService.js';
+import { getAll, subscribeToChanges } from '../dataService.js';
 import { createSinopticoEditor } from '../editors/sinopticoEditor.js';
 import { isAdmin, isGuest } from '../session.js';
 
@@ -30,10 +30,15 @@ export async function render(container) {
     </table>
   `;
 
-  const data = await getAll('sinoptico');
-  if (typeof window.renderSinoptico === 'function') {
-    window.renderSinoptico(data);
+  async function load() {
+    const data = await getAll('sinoptico');
+    if (typeof window.renderSinoptico === 'function') {
+      window.renderSinoptico(data);
+    }
   }
+
+  await load();
+  subscribeToChanges(load);
 
   const excelBtn = container.querySelector('#btnExcel');
   const pdfBtn = container.querySelector('#btnPdf');


### PR DESCRIPTION
## Summary
- refresh data tables when websocket updates arrive
- stop reloading the page after restoring backups

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859cdc88fb8832f9d19beffc36af74d