### PR TITLE
Add backup deletion feature

### DIFF
--- a/docs/history.html
+++ b/docs/history.html
@@ -21,6 +21,7 @@
     <button id="createBackup" type="button">Crear backup</button>
     <select id="backupList"></select>
     <button id="restoreBackup" type="button">Restaurar</button>
+    <button id="deleteBackup" type="button">Eliminar backup</button>
   </section>
 
   <div class="advanced-filters">

--- a/docs/js/history.js
+++ b/docs/js/history.js
@@ -10,6 +10,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const backupSel = document.getElementById('backupList');
   const createBtn = document.getElementById('createBackup');
   const restoreBtn = document.getElementById('restoreBackup');
+  const deleteBtn = document.getElementById('deleteBackup');
 
   async function loadHistory() {
     const params = new URLSearchParams();
@@ -70,6 +71,13 @@ document.addEventListener('DOMContentLoaded', () => {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ name })
     });
+  });
+
+  deleteBtn?.addEventListener('click', async () => {
+    const name = backupSel.value;
+    if (!name) return;
+    await fetch(`/api/backups/${encodeURIComponent(name)}`, { method: 'DELETE' });
+    loadBackups();
   });
 
   applyBtn?.addEventListener('click', loadHistory);

--- a/docs/js/views/settings.js
+++ b/docs/js/views/settings.js
@@ -37,6 +37,7 @@ export async function render(container) {
       <button id="createBackup" type="button">Crear backup</button>
       <select id="backupList"></select>
       <button id="restoreBackup" type="button">Restaurar</button>
+      <button id="deleteBackup" type="button">Eliminar backup</button>
     </section>`;
 
   animateInsert(container);
@@ -65,6 +66,7 @@ export async function render(container) {
   const backupSel = container.querySelector('#backupList');
   const createBtn = container.querySelector('#createBackup');
   const restoreBtn = container.querySelector('#restoreBackup');
+  const deleteBtn = container.querySelector('#deleteBackup');
 
   const storedBrightness = localStorage.getItem('pageBrightness') || '100';
   range.value = storedBrightness;
@@ -149,6 +151,15 @@ export async function render(container) {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ name }),
       });
+    });
+  }
+
+  if (deleteBtn) {
+    deleteBtn.addEventListener('click', async () => {
+      const name = backupSel.value;
+      if (!name) return;
+      await fetch(`/api/backups/${encodeURIComponent(name)}`, { method: 'DELETE' });
+      loadBackups();
     });
   }
 

--- a/server.py
+++ b/server.py
@@ -228,6 +228,15 @@ def create_backup_route():
     return jsonify({"path": f"backups/{name}"})
 
 
+@app.delete("/api/backups/<name>")
+def delete_backup(name):
+    path = os.path.join(BACKUP_DIR, name)
+    if not os.path.exists(path):
+        return jsonify({"error": "not found"}), 404
+    os.remove(path)
+    return jsonify({"status": "deleted"})
+
+
 @app.post("/api/restore")
 def restore_backup():
     global memory, history


### PR DESCRIPTION
## Summary
- add DELETE /api/backups/<filename> endpoint
- provide Eliminar backup button on settings and history pages
- refresh backup list after deleting

## Testing
- `./format_check.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859d0753a0c832fa340305e60bcb3e2