### PR TITLE
Configure SPA fallback in nginx

### DIFF
--- a/docs/nginx_spa.md
+++ b/docs/nginx_spa.md
@@ -1,0 +1,41 @@
+# Nginx y SPA
+
+Este documento analiza el problema al acceder a la SPA desde `/` o `/index.html` y la forma correcta de configurarlo.
+
+## Diagnóstico
+
+- La configuración actual contiene `try_files $uri $uri/ =404;`.
+- Cuando se accede a `/` Nginx intenta servir primero el directorio `/` y luego `/index.html/` (que no existe) y termina devolviendo *404*.
+- Como la aplicación usa rutas con hash (`#/settings`), la parte después del `#` nunca se envía al servidor, por lo que Nginx no sabe que debe cargar `index.html`.
+
+## Causa raíz
+
+`try_files` con `=404` impide que Nginx busque `index.html` si el recurso solicitado no existe de forma literal. Por eso `/` y cualquier ruta interna de la SPA provocan un error.
+
+## Solución
+
+Hacer que todas las rutas caigan en `index.html` cuando no exista un archivo real. Opcionalmente se puede redirigir `/` a `#/settings` si se desea que la SPA abra esa vista por defecto.
+
+### Configuración propuesta (`nginx.conf`)
+
+```nginx
+server {
+    listen 80;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    location /api/ {
+        proxy_pass http://backend:5000/api/;
+    }
+
+    # Sirve index.html para cualquier ruta que no exista
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    # Descomenta lo siguiente si quieres ir directo a #/settings
+    #location = / {
+    #    return 302 /index.html#/settings;
+    #}
+}
+```

--- a/nginx.conf
+++ b/nginx.conf
@@ -5,12 +5,21 @@
 
 server {
     listen 80;
-    location / {
-        root /usr/share/nginx/html;
-        try_files $uri $uri/ =404;
-    }
+    root /usr/share/nginx/html;
+    index index.html;
+
     location /api/ {
         proxy_pass http://backend:5000/api/;
     }
+
+    # Serve index.html for all SPA routes
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    # Uncomment to redirect root to #/settings
+    #location = / {
+    #    return 302 /index.html#/settings;
+    #}
 }
 # End of file


### PR DESCRIPTION
## Summary
- document why `/` fails to load the SPA under nginx
- update nginx.conf to serve `index.html` for unknown routes and show optional redirect

## Testing
- `./format_check.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859db4048cc832fbe506cea5ccfae95