### PR TITLE
Add backup descriptions and full state restore

### DIFF
--- a/docs/history.html
+++ b/docs/history.html
@@ -18,8 +18,10 @@
   <h1>Historial y Backups</h1>
 
   <section class="backup-tools">
+    <input id="backupDesc" type="text" placeholder="Descripción">
     <button id="createBackup" type="button">Crear backup</button>
     <select id="backupList"></select>
+    <span id="selectedDesc"></span>
     <button id="restoreBackup" type="button">Restaurar</button>
     <button id="deleteBackup" type="button">Eliminar backup</button>
   </section>

--- a/docs/js/history.js
+++ b/docs/js/history.js
@@ -9,6 +9,8 @@ document.addEventListener('DOMContentLoaded', () => {
   const applyBtn = document.getElementById('applyFilters');
   const backupSel = document.getElementById('backupList');
   const createBtn = document.getElementById('createBackup');
+  const descInput = document.getElementById('backupDesc');
+  const descLabel = document.getElementById('selectedDesc');
   const restoreBtn = document.getElementById('restoreBackup');
   const deleteBtn = document.getElementById('deleteBackup');
 
@@ -51,16 +53,29 @@ document.addEventListener('DOMContentLoaded', () => {
       if (!resp.ok) return;
       const list = await resp.json();
       backupSel.innerHTML = list
-        .map(name => `<option value="${name}">${name}</option>`) 
+        .map(b => `<option value="${b.name}" data-desc="${b.description || ''}">${b.name}</option>`)
         .join('');
+      const opt = backupSel.selectedOptions[0];
+      if (descLabel) descLabel.textContent = opt ? opt.dataset.desc : '';
     } catch (e) {
       console.error(e);
     }
   }
 
   createBtn?.addEventListener('click', async () => {
-    await fetch('/api/backups', { method: 'POST' });
+    const description = descInput?.value || '';
+    await fetch('/api/backups', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ description })
+    });
+    if (descInput) descInput.value = '';
     loadBackups();
+  });
+
+  backupSel?.addEventListener('change', () => {
+    const opt = backupSel.selectedOptions[0];
+    if (descLabel) descLabel.textContent = opt ? opt.dataset.desc : '';
   });
 
   restoreBtn?.addEventListener('click', async () => {

--- a/docs/js/views/settings.js
+++ b/docs/js/views/settings.js
@@ -34,8 +34,10 @@ export async function render(container) {
     </section>
     <section class="backup-tools">
       <h2>Copias de seguridad</h2>
+      <input id="backupDesc" type="text" placeholder="Descripción">
       <button id="createBackup" type="button">Crear backup</button>
       <select id="backupList"></select>
+      <span id="selectedDesc"></span>
       <button id="restoreBackup" type="button">Restaurar</button>
       <button id="deleteBackup" type="button">Eliminar backup</button>
     </section>`;
@@ -65,6 +67,8 @@ export async function render(container) {
   const histSpan = container.querySelector('#devHistory');
   const backupSel = container.querySelector('#backupList');
   const createBtn = container.querySelector('#createBackup');
+  const descInput = container.querySelector('#backupDesc');
+  const descLabel = container.querySelector('#selectedDesc');
   const restoreBtn = container.querySelector('#restoreBackup');
   const deleteBtn = container.querySelector('#deleteBackup');
 
@@ -127,8 +131,10 @@ export async function render(container) {
       const list = await resp.json();
       if (backupSel) {
         backupSel.innerHTML = list
-          .map((name) => `<option value="${name}">${name}</option>`) 
+          .map((b) => `<option value="${b.name}" data-desc="${b.description || ''}">${b.name}</option>`)
           .join('');
+        const opt = backupSel.selectedOptions[0];
+        if (descLabel) descLabel.textContent = opt ? opt.dataset.desc : '';
       }
     } catch (e) {
       console.error(e);
@@ -137,7 +143,13 @@ export async function render(container) {
 
   if (createBtn) {
     createBtn.addEventListener('click', async () => {
-      await fetch('/api/backups', { method: 'POST' });
+      const description = descInput?.value || '';
+      await fetch('/api/backups', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ description })
+      });
+      if (descInput) descInput.value = '';
       loadBackups();
     });
   }
@@ -162,6 +174,11 @@ export async function render(container) {
       loadBackups();
     });
   }
+
+  backupSel?.addEventListener('change', () => {
+    const opt = backupSel.selectedOptions[0];
+    if (descLabel) descLabel.textContent = opt ? opt.dataset.desc : '';
+  });
 
   loadBackups();
 

--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -1,0 +1,30 @@
+import os
+import json
+import importlib
+from pathlib import Path
+
+def test_manual_backup_metadata(tmp_path, monkeypatch):
+    monkeypatch.setenv('BACKUP_DIR', str(tmp_path/'backups'))
+    monkeypatch.setenv('DATA_DIR', str(tmp_path/'data'))
+    monkeypatch.setenv('DB_PATH', str(tmp_path/'data/db.sqlite'))
+
+    data_dir = Path(os.environ['DATA_DIR'])
+    data_dir.mkdir(parents=True)
+    with open(data_dir/'latest.json', 'w') as f:
+        json.dump({'a': 1}, f)
+    with open(Path(os.environ['DB_PATH']), 'w') as f:
+        f.write('db')
+
+    server = importlib.import_module('server')
+    importlib.reload(server)
+
+    path = server.manual_backup('desc')
+    assert path is not None
+    meta_file = Path(os.environ['BACKUP_DIR'])/'metadata.json'
+    assert meta_file.exists()
+    meta = json.load(meta_file.open())
+    assert os.path.basename(path) in meta
+    assert meta[os.path.basename(path)] == 'desc'
+    with server.ZipFile(path) as zf:
+        assert 'db.sqlite' in zf.namelist()
+        assert 'latest.json' in zf.namelist()


### PR DESCRIPTION
## Summary
- allow providing a description when creating a backup
- store descriptions in a metadata file
- include history, images and SQLite DB in backup zips
- restore extracts database, history and images when present
- expose description via the API and UI
- update settings/history pages to handle descriptions
- add regression test for backup metadata

## Testing
- `bash format_check.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859ebb97460832faa26611f162ba875