### PR TITLE
Fix SocketIO server run

### DIFF
--- a/server.py
+++ b/server.py
@@ -357,4 +357,4 @@ if __name__ == "__main__":
         scheduler.add_job(backup_latest, "interval", days=1)
         scheduler.start()
 
-    app.run(host="0.0.0.0", port=5000)
+    socketio.run(app, host="0.0.0.0", port=5000)


### PR DESCRIPTION
## Summary
- use `socketio.run` when starting `server.py` so real-time updates work

## Testing
- `./format_check.sh`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6859f4123994832fa3114afbd8811ca0