### PR TITLE
Implement syncNow helper for data refresh

### DIFF
--- a/docs/js/dataService.js
+++ b/docs/js/dataService.js
@@ -178,6 +178,11 @@ const ready = new Promise((res) => {
 
 const initialized = ready.then(() => initFromServer());
 
+async function syncNow() {
+  await ready;
+  return initFromServer(true);
+}
+
 let socket;
 let sse;
 if (hasWindow && SOCKET_URL && typeof io !== 'undefined') {
@@ -336,11 +341,11 @@ function notifyChange() {
   }
 }
 
-async function initFromServer() {
+async function initFromServer(force = false) {
   if (!API_URL) return false;
   const freshness = Date.now() - lastFetch;
   // avoid redundant requests shortly after a previous fetch
-  if (freshness < 5 * 60 * 1000) return false;
+  if (!force && freshness < 5 * 60 * 1000) return false;
   try {
     const resp = await fetch(API_URL);
     if (resp.ok) {
@@ -669,6 +674,7 @@ const api = {
   },
   subscribeToChanges,
   subscribeSinopticoChanges,
+  syncNow,
 };
 
 if (hasWindow) {
@@ -677,4 +683,4 @@ if (hasWindow) {
 
 export default api;
 
-export { getAll, add, update, remove, exportJSON, importJSON, ready, initialized };
+export { getAll, add, update, remove, exportJSON, importJSON, ready, initialized, syncNow };

--- a/docs/js/views/amfe.js
+++ b/docs/js/views/amfe.js
@@ -1,6 +1,7 @@
-import { getAll, ready, subscribeToChanges } from '../dataService.js';
+import { getAll, ready, subscribeToChanges, syncNow } from '../dataService.js';
 
 export async function render(container) {
+  await syncNow();
   container.innerHTML = `
     <h1>AMFE</h1>
     <button id="amfe-export" aria-label="Opciones de exportación" title="Opciones de exportación">Exportar...</button>

--- a/docs/js/views/maestro.js
+++ b/docs/js/views/maestro.js
@@ -1,6 +1,7 @@
-import { getAll, ready, subscribeToChanges } from '../dataService.js';
+import { getAll, ready, subscribeToChanges, syncNow } from '../dataService.js';
 
 export async function render(container) {
+  await syncNow();
   container.innerHTML = `
     <div class="top-actions">
       <button id="printBtn">🖨 Print</button>

--- a/docs/js/views/settings.js
+++ b/docs/js/views/settings.js
@@ -1,9 +1,10 @@
-import { getAll, ready, subscribeToChanges } from '../dataService.js';
+import { getAll, ready, subscribeToChanges, syncNow } from '../dataService.js';
 import { getUser } from '../session.js';
 import { activateDevMode, deactivateDevMode } from '../pageSettings.js';
 import { animateInsert } from '../ui/animations.js';
 
 export async function render(container) {
+  await syncNow();
   container.innerHTML = `
     <h1>Modo Dev</h1>
     <section class="dev-options">

--- a/docs/js/views/sinoptico.js
+++ b/docs/js/views/sinoptico.js
@@ -1,8 +1,9 @@
-import { getAll, subscribeToChanges } from '../dataService.js';
+import { getAll, subscribeToChanges, syncNow } from '../dataService.js';
 import { createSinopticoEditor } from '../editors/sinopticoEditor.js';
 import { isAdmin, isGuest } from '../session.js';
 
 export async function render(container) {
+  await syncNow();
   const editBtnHtml = isAdmin() ? '<button id="sin-edit">Editar</button>' : '';
   container.innerHTML = `
     <div class="toolbar">


### PR DESCRIPTION
## Summary
- allow `initFromServer` to skip the freshness check
- expose new `syncNow` API for immediate synchronization
- refresh data during page load in AMFE, Maestro, Settings and Sinóptico views

## Testing
- `./format_check.sh`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_685a00d0a7b8832fa246396224bb8a39