### PR TITLE
Fix API paths and Socket.IO proxy

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -12,6 +12,11 @@ server {
         proxy_pass http://backend:5000/api/;
     }
 
+    # Proxy Socket.IO requests to the backend
+    location /socket.io/ {
+        proxy_pass http://backend:5000/socket.io/;
+    }
+
     # Serve index.html for all SPA routes
     location / {
         try_files $uri $uri/ /index.html;

--- a/server.py
+++ b/server.py
@@ -199,6 +199,13 @@ def server_info():
     return jsonify(info)
 
 
+@app.get("/api/products")
+def get_products():
+    """Return the list of products stored in memory if present."""
+    products = memory.get("productos_db") or memory.get("products") or []
+    return jsonify(products)
+
+
 @app.get("/api/<module>/export")
 def export_module(module):
     fmt = request.args.get("format", "excel")


### PR DESCRIPTION
## Summary
- expose Socket.IO through nginx
- add `/api/products` route to Flask app for the SPA

## Testing
- `./format_check.sh`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_685ac0e03334832f9d6191b3be823fc6