### PR TITLE
Improve UI refresh on data changes

### DIFF
--- a/docs/js/history.js
+++ b/docs/js/history.js
@@ -1,4 +1,5 @@
 'use strict';
+import { subscribeToChanges } from './dataService.js';
 
 document.addEventListener('DOMContentLoaded', () => {
   const tbody = document.querySelector('#historyTable tbody');
@@ -99,4 +100,5 @@ document.addEventListener('DOMContentLoaded', () => {
 
   loadBackups();
   loadHistory();
+  subscribeToChanges(loadHistory);
 });

--- a/docs/js/newClientDialog.js
+++ b/docs/js/newClientDialog.js
@@ -38,7 +38,6 @@ export function initNewClientDialog() {
     }
     input.value = '';
     dialog.close();
-    document.dispatchEvent(new Event('sinopticoUpdated'));
   });
 }
 

--- a/docs/js/newInsumoDialog.js
+++ b/docs/js/newInsumoDialog.js
@@ -60,7 +60,6 @@ export function initNewInsumoDialog() {
     }
     if (form) form.reset();
     dialog.close();
-    document.dispatchEvent(new Event('sinopticoUpdated'));
   });
 }
 

--- a/docs/js/newProductDialog.js
+++ b/docs/js/newProductDialog.js
@@ -63,7 +63,6 @@ export function initNewProductDialog() {
     }
     if (form) form.reset();
     dialog.close();
-    document.dispatchEvent(new Event('sinopticoUpdated'));
   });
 }
 

--- a/docs/js/newSubDialog.js
+++ b/docs/js/newSubDialog.js
@@ -52,7 +52,6 @@ export function initNewSubDialog() {
     }
     if (form) form.reset();
     dialog.close();
-    document.dispatchEvent(new Event('sinopticoUpdated'));
   });
 }
 

--- a/docs/js/views/home.js
+++ b/docs/js/views/home.js
@@ -1,4 +1,5 @@
 // Página de inicio con enlaces directos a las herramientas
+import { subscribeToChanges } from '../dataService.js';
 
 export function render(container) {
   container.innerHTML = `
@@ -29,7 +30,10 @@ export function render(container) {
 
 
   const kpiGrid = container.querySelector('#kpiGrid');
-  if (kpiGrid) loadKpis(kpiGrid);
+  if (kpiGrid) {
+    loadKpis(kpiGrid);
+    subscribeToChanges(() => loadKpis(kpiGrid));
+  }
   const moduleGrid = container.querySelector('#moduleGrid');
   if (moduleGrid) loadModules(moduleGrid);
 }


### PR DESCRIPTION
## Summary
- refresh KPIs when data changes in `home.js`
- auto-reload history page on updates
- remove redundant `sinopticoUpdated` dispatches from dialogs

## Testing
- `./format_check.sh`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_685ac2a6d1a4832f902d6e7096a5a159