### PR TITLE
Persist latest JSON with compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ módulo `js/dataService.js`. A partir de la versión 358 puedes exportar e
 importar la información desde la página de inicio mediante dos botones. El
 archivo descargado se guarda como `data/latest.json`. El registro de cambios se
 almacena en `data/history.json` y las copias de seguridad se guardan en
-`data/backups/`.
+`backups/`.
 
 Para realizar copias de seguridad manuales desde la consola del navegador sigue
 si lo prefieres este procedimiento:
@@ -73,8 +73,8 @@ El servidor debe ejecutarse en un único equipo o servidor accesible por la red 
 
 El archivo activo se guarda en `data/latest.json`.
 Puedes generar copias manualmente con `POST /api/backups` o desde la página **Modo Dev**.
-Por defecto se programa una copia diaria en `data/backups/AAAA-MM-DD.json`. Si prefieres desactivar esta tarea define `DISABLE_AUTOBACKUP=1` antes de iniciar el servidor.
-Los respaldos se encuentran en la carpeta `data/backups/`. Cada archivo incluye la base de datos, el historial, la base SQLite y las carpetas de imágenes para que puedas restaurar el estado completo de la aplicación. Si eliminas el repositorio también se borrará esta carpeta a menos que la conserves aparte.
+Por defecto se programa una copia diaria en `backups/AAAA-MM-DD.json`. Si prefieres desactivar esta tarea define `DISABLE_AUTOBACKUP=1` antes de iniciar el servidor.
+Los respaldos se encuentran en la carpeta `backups/`. Cada archivo incluye la base de datos, el historial, la base SQLite y las carpetas de imágenes para que puedas restaurar el estado completo de la aplicación. Si eliminas el repositorio también se borrará esta carpeta a menos que la conserves aparte.
 
 Para revisar visualmente el contenido actual de la base de datos se incluye la página `docs/dbviewer.html`. Ábrela con el servidor en marcha para ver los datos en formato JSON.
 
@@ -128,7 +128,7 @@ docker compose up -d
 ```
 
 Al finalizar la SPA quedará disponible en `http://192.168.1.233:8080` y la API en `http://192.168.1.233:5000/api/...`.
-Los datos se guardan en `./data/db.sqlite` y los respaldos en `./backups`.
+Los archivos `latest.json`, `history.json` y `db.sqlite` se almacenan en `./data` y los respaldos en `./backups`.
 
 Si usas Windows y no puedes acceder desde otras máquinas, abre los puertos 5000 y 8080 en el firewall:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,8 +6,9 @@ services:
     image: barack-backend:latest
     environment:
       - DB_PATH=/data/db.sqlite
+      - DATA_DIR=/data
     volumes:
-      - ./data/db.sqlite:/data/db.sqlite
+      - ./data:/data
       - ./backups:/app/backups
     ports: ["5000:5000"]
   docs:

--- a/docs/backend.md
+++ b/docs/backend.md
@@ -60,4 +60,5 @@ If the API server is unreachable, the frontend keeps working thanks to IndexedDB
 3. Run `docker-compose up` from the project root.
 4. Nginx will serve the `docs/` folder on port 8080 and the API from `backend/main.py` on port 8000.
 5. Point the frontend to `http://<host>:8000/api` as needed.
+6. The Compose file mounts `./data` and `./backups` so database files and backups persist across container restarts.
 


### PR DESCRIPTION
## Summary
- mount `./data` to persist DATA_DIR
- update README paths for backups and volumes
- mention persistent volumes in backend docs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ac2a58ec0832fa7ad9930c8d09f1c