### PR TITLE
Improve CORS config and fix docs

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -15,8 +15,13 @@ DB_PATH = os.getenv("DB_PATH", os.path.join("data", "db.sqlite"))
 os.makedirs(os.path.dirname(DB_PATH), exist_ok=True)
 
 app = Flask(__name__)
-CORS(app)
-socketio = SocketIO(app, async_mode="eventlet", cors_allowed_origins="*")
+origins = os.getenv(
+    "ALLOWED_ORIGINS",
+    "http://192.168.1.233:8080,http://localhost:8080",
+)
+allowed = [o.strip() for o in origins.split(",") if o.strip()]
+CORS(app, resources={r"/api/*": {"origins": allowed}})
+socketio = SocketIO(app, async_mode="eventlet", cors_allowed_origins=allowed)
 sse_clients = []
 
 

--- a/docs/backend.md
+++ b/docs/backend.md
@@ -39,6 +39,8 @@ The frontend reads the server URL from `localStorage` (`apiUrl`) or from the `AP
   full application state.
 - `SSL_CERT` / `SSL_KEY` – optional certificate paths for HTTPS when running `server.py`.
 - `DB_PATH` – path to the SQLite file used by `backend/main.py` (`data/db.sqlite` by default).
+- `ALLOWED_ORIGINS` – comma-separated list of origins allowed for CORS when
+  running `server.py` or `backend/main.py`.
 
 ## Offline fallback
 
@@ -51,13 +53,13 @@ If the API server is unreachable, the frontend keeps working thanks to IndexedDB
 1. `pip install -r requirements.txt`
 2. Run `python server.py` to serve the frontend and JSON API on port 5000.
    Set `API_URL` in the browser (or as an environment variable) if the server is on another machine.
-3. Alternatively run `python backend/main.py` for the SQLite API on port 8000.
+3. Alternatively run `python backend/main.py` for the SQLite API on port 5000.
 
 ### Docker Compose
 
 1. Ensure Docker and Docker Compose are installed.
 2. Build the image the first time with `docker-compose build`.
 3. Run `docker-compose up` from the project root.
-4. Nginx will serve the `docs/` folder on port 8080 and the API from `backend/main.py` on port 8000.
-5. Point the frontend to `http://<host>:8000/api` as needed.
+4. Nginx will serve the `docs/` folder on port 8080 and the API from `backend/main.py` on port 5000.
+5. Point the frontend to `http://<host>:5000/api` as needed.
 

--- a/server.py
+++ b/server.py
@@ -42,8 +42,13 @@ IMAGES_DIR = os.path.join(app.static_folder, "imagenes_sinoptico")
 ASSET_DIRS = ["imagenes_sinoptico", "images"]
 from flask_socketio import SocketIO
 
-# Permit requests from the development front-end and the local API consumer
-allowed = ["http://192.168.1.233:8080", "http://localhost:8080"]
+# Allowed origins can be configured via ALLOWED_ORIGINS. Multiple values should
+# be comma-separated.
+origins = os.getenv(
+    "ALLOWED_ORIGINS",
+    "http://192.168.1.233:8080,http://localhost:8080",
+)
+allowed = [o.strip() for o in origins.split(",") if o.strip()]
 socketio = SocketIO(app, async_mode="eventlet", cors_allowed_origins=allowed)
 clients = {}
 CORS(app, resources={r"/api/*": {"origins": allowed}})


### PR DESCRIPTION
## Summary
- restrict Flask CORS in `server.py` and `backend/main.py` using new `ALLOWED_ORIGINS` env var
- document new variable and fix backend port in docs

## Testing
- `pip install -r requirements.txt`
- `pytest -q`
- `bash format_check.sh`

------
https://chatgpt.com/codex/tasks/task_e_685ac2a4ba24832fa297176ae5596ae7