### PR TITLE
Improve error handling

### DIFF
--- a/docs/js/history.js
+++ b/docs/js/history.js
@@ -64,11 +64,22 @@ document.addEventListener('DOMContentLoaded', () => {
 
   createBtn?.addEventListener('click', async () => {
     const description = descInput?.value || '';
-    await fetch('/api/backups', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ description })
-    });
+    try {
+      const resp = await fetch('/api/backups', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ description })
+      });
+      if (!resp.ok) {
+        const err = await resp.json().catch(() => ({}));
+        if (window.mostrarMensaje) window.mostrarMensaje(err.error || 'Error al crear backup');
+      } else {
+        if (window.mostrarMensaje) window.mostrarMensaje('Backup creado', 'success');
+      }
+    } catch (e) {
+      console.error(e);
+      if (window.mostrarMensaje) window.mostrarMensaje('Error al crear backup');
+    }
     if (descInput) descInput.value = '';
     loadBackups();
   });
@@ -81,18 +92,40 @@ document.addEventListener('DOMContentLoaded', () => {
   restoreBtn?.addEventListener('click', async () => {
     const name = backupSel.value;
     if (!name) return;
-    await fetch('/api/restore', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ name })
-    });
+    try {
+      const resp = await fetch('/api/restore', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name })
+      });
+      if (!resp.ok) {
+        const err = await resp.json().catch(() => ({}));
+        if (window.mostrarMensaje) window.mostrarMensaje(err.error || 'Error al restaurar');
+      } else {
+        if (window.mostrarMensaje) window.mostrarMensaje('Restaurado', 'success');
+      }
+    } catch (e) {
+      console.error(e);
+      if (window.mostrarMensaje) window.mostrarMensaje('Error al restaurar');
+    }
   });
 
   deleteBtn?.addEventListener('click', async () => {
     const name = backupSel.value;
     if (!name) return;
-    await fetch(`/api/backups/${encodeURIComponent(name)}`, { method: 'DELETE' });
-    loadBackups();
+    try {
+      const resp = await fetch(`/api/backups/${encodeURIComponent(name)}`, { method: 'DELETE' });
+      if (!resp.ok) {
+        const err = await resp.json().catch(() => ({}));
+        if (window.mostrarMensaje) window.mostrarMensaje(err.error || 'Error al eliminar');
+      } else {
+        if (window.mostrarMensaje) window.mostrarMensaje('Backup eliminado', 'success');
+        loadBackups();
+      }
+    } catch (e) {
+      console.error(e);
+      if (window.mostrarMensaje) window.mostrarMensaje('Error al eliminar');
+    }
   });
 
   applyBtn?.addEventListener('click', loadHistory);

--- a/docs/js/interactiveTable.js
+++ b/docs/js/interactiveTable.js
@@ -281,7 +281,10 @@ function setupExport() {
   const pdfBtn = document.getElementById('btnPdf');
   async function exportServer(fmt) {
     const resp = await fetch(`/api/sinoptico/export?format=${fmt}`);
-    if (!resp.ok) throw new Error('fail');
+    if (!resp.ok) {
+      const err = await resp.json().catch(() => ({}));
+      throw new Error(err.error || 'Error al exportar');
+    }
     const blob = await resp.blob();
     const url = URL.createObjectURL(blob);
     const ext = fmt === 'excel' ? 'xlsx' : 'pdf';
@@ -293,8 +296,8 @@ function setupExport() {
     a.remove();
     URL.revokeObjectURL(url);
   }
-  excelBtn?.addEventListener('click', () => exportServer('excel').catch(() => {}));
-  pdfBtn?.addEventListener('click', () => exportServer('pdf').catch(() => {}));
+  excelBtn?.addEventListener('click', () => exportServer('excel').catch(e => showToast(e.message)));
+  pdfBtn?.addEventListener('click', () => exportServer('pdf').catch(e => showToast(e.message)));
 }
 
 

--- a/docs/js/views/amfe.js
+++ b/docs/js/views/amfe.js
@@ -60,7 +60,10 @@ export async function render(container) {
       // bypass the network request and provide your own Blob when testing
       // offline or mocking the server.
       const resp = await fetch(`/api/amfe/export?format=${fmt}`);
-      if (!resp.ok) throw new Error('fail');
+      if (!resp.ok) {
+        const err = await resp.json().catch(() => ({}));
+        throw new Error(err.error || 'Error al exportar');
+      }
       const blob = await resp.blob();
       const url = URL.createObjectURL(blob);
       const ext = fmt === 'excel' ? 'xlsx' : 'pdf';
@@ -73,7 +76,8 @@ export async function render(container) {
       URL.revokeObjectURL(url);
       if (window.mostrarMensaje) window.mostrarMensaje('Exportación completa', 'success');
     } catch (e) {
-      if (window.mostrarMensaje) window.mostrarMensaje('Error al exportar');
+      const err = e && e.message ? e.message : 'Error al exportar';
+      if (window.mostrarMensaje) window.mostrarMensaje(err);
     } finally {
       hideSpinner();
     }

--- a/docs/js/views/maestro.js
+++ b/docs/js/views/maestro.js
@@ -161,7 +161,11 @@ export async function render(container) {
     showSpinner();
     try {
       const resp = await fetch(`/api/maestro/export?format=${fmt}`);
-      if (!resp.ok) throw new Error('fail');
+      if (!resp.ok) {
+        const err = await resp.json().catch(() => ({}));
+        if (window.mostrarMensaje) window.mostrarMensaje(err.error || 'Error al exportar');
+        return;
+      }
       const blob = await resp.blob();
       const url = URL.createObjectURL(blob);
       const ext = fmt === 'excel' ? 'xlsx' : 'pdf';
@@ -172,12 +176,13 @@ export async function render(container) {
       a.click();
       a.remove();
       URL.revokeObjectURL(url);
+      if (window.mostrarMensaje) window.mostrarMensaje('Exportación completa', 'success');
     } finally {
       hideSpinner();
     }
   }
 
-  excelBtn.addEventListener('click', () => exportServer('excel').catch(() => {}));
+  excelBtn.addEventListener('click', () => exportServer('excel'));
 
   pdfBtn.addEventListener('click', async () => {
     try {

--- a/docs/js/views/sinoptico.js
+++ b/docs/js/views/sinoptico.js
@@ -70,7 +70,10 @@ export async function render(container) {
       // Interception point: developers can set localStorage.setItem('useMock','true')
       // to skip the network call and provide local data when running offline.
       const resp = await fetch(`/api/sinoptico/export?format=${fmt}`);
-      if (!resp.ok) throw new Error('fail');
+      if (!resp.ok) {
+        const err = await resp.json().catch(() => ({}));
+        throw new Error(err.error || 'Error al exportar');
+      }
       const blob = await resp.blob();
       const url = URL.createObjectURL(blob);
       const ext = fmt === 'excel' ? 'xlsx' : 'pdf';
@@ -83,15 +86,15 @@ export async function render(container) {
       URL.revokeObjectURL(url);
       if (window.mostrarMensaje) window.mostrarMensaje('Exportación completa', 'success');
     } catch (e) {
+      const err = e && e.message ? e.message : 'Error al exportar';
+      if (window.mostrarMensaje) window.mostrarMensaje(err);
       throw e;
     } finally {
       hideSpinner();
     }
   }
 
-  excelBtn?.addEventListener('click', () => exportServer('excel').catch(() => {
-    if (window.mostrarMensaje) window.mostrarMensaje('Error al exportar');
-  }));
+  excelBtn?.addEventListener('click', () => exportServer('excel').catch(() => {}));
 
   pdfBtn?.addEventListener('click', async () => {
     try {

--- a/server.py
+++ b/server.py
@@ -216,7 +216,7 @@ def export_module(module):
     elif module == "sinoptico":
         rows = memory.get("sinoptico", [])
     else:
-        return jsonify({"error": "not found"}), 404
+        return jsonify({"error": "module not found", "module": module}), 404
 
     if fmt == "pdf":
         output = BytesIO()
@@ -287,7 +287,7 @@ def create_backup_route():
     desc = data.get("description")
     path = manual_backup(desc)
     if not path:
-        return jsonify({"error": "no data"}), 404
+        return jsonify({"error": "no data to backup"}), 400
     name = os.path.basename(path)
     return jsonify({"path": f"backups/{name}", "description": desc or ""})
 
@@ -299,7 +299,7 @@ def delete_backup(name):
         return jsonify({"error": "invalid name"}), 400
     path = os.path.join(BACKUP_DIR, safe)
     if not os.path.exists(path):
-        return jsonify({"error": "not found"}), 404
+        return jsonify({"error": "backup not found", "name": safe}), 404
     os.remove(path)
     if os.path.exists(METADATA_FILE):
         with open(METADATA_FILE, "r", encoding="utf-8") as f:
@@ -322,7 +322,7 @@ def restore_backup():
         return jsonify({"error": "invalid name"}), 400
     path = os.path.join(BACKUP_DIR, safe)
     if not os.path.exists(path):
-        return jsonify({"error": "not found"}), 404
+        return jsonify({"error": "backup not found", "name": safe}), 404
     with ZipFile(path) as zf:
         with zf.open("latest.json") as f:
             new_data = json.load(f)


### PR DESCRIPTION
## Summary
- refine HTTP codes and messages in API routes
- return detailed errors from the DB backend
- surface API errors in backup management UI
- show export failures in tables and views

## Testing
- `bash format_check.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ac2a7f48c832f89d161f866e43e2a