### PR TITLE
Add named backup modal

### DIFF
--- a/docs/js/ui/backupNameModal.js
+++ b/docs/js/ui/backupNameModal.js
@@ -1,0 +1,47 @@
+'use strict';
+
+export function askBackupName() {
+  return new Promise(resolve => {
+    let dialog = document.getElementById('dlgBackupName');
+    if (!dialog) {
+      dialog = document.createElement('dialog');
+      dialog.id = 'dlgBackupName';
+      dialog.className = 'modal';
+      dialog.innerHTML = `
+        <form method="dialog">
+          <label for="backupNameInput">Nombre del backup:</label>
+          <input id="backupNameInput" type="text" required>
+          <div class="form-actions">
+            <button type="submit">Aceptar</button>
+            <button type="button">Cancelar</button>
+          </div>
+        </form>
+      `;
+      document.body.appendChild(dialog);
+      dialog.querySelector('button[type="button"]').addEventListener('click', () => {
+        dialog.close();
+        resolve(null);
+      });
+    }
+    const form = dialog.querySelector('form');
+    const input = dialog.querySelector('#backupNameInput');
+    input.value = '';
+    function submit(ev) {
+      ev.preventDefault();
+      const name = input.value.trim();
+      if (!name) return;
+      dialog.close();
+      resolve(name);
+    }
+    form.addEventListener('submit', submit, { once: true });
+    dialog.addEventListener('close', () => {
+      form.removeEventListener('submit', submit);
+    }, { once: true });
+    dialog.showModal();
+    input.focus();
+  });
+}
+
+if (typeof window !== 'undefined') {
+  window.askBackupName = askBackupName;
+}

--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -20,8 +20,10 @@ def test_manual_backup_metadata(tmp_path, monkeypatch):
     server = importlib.import_module("server")
     importlib.reload(server)
 
-    path = server.manual_backup("desc")
+    path = server.manual_backup(name="Mi Backup", description="desc")
     assert path is not None
+    fname = os.path.basename(path)
+    assert fname.startswith("MiBackup_") and fname.endswith(".zip")
     meta_file = Path(os.environ["BACKUP_DIR"]) / "metadata.json"
     assert meta_file.exists()
     meta = json.load(meta_file.open())


### PR DESCRIPTION
## Summary
- prompt for backup name with new reusable modal
- create backups using custom names in settings view
- support `name` parameter in server manual_backup and API
- verify custom name backups in tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ada2cd470832fa657de4f9ed3d36c