### PR TITLE
Add confirmation and error handling for backups

### DIFF
--- a/docs/js/views/settings.js
+++ b/docs/js/views/settings.js
@@ -171,8 +171,23 @@ export async function render(container) {
     deleteBtn.addEventListener('click', async () => {
       const name = backupSel.value;
       if (!name) return;
-      await fetch(`/api/backups/${encodeURIComponent(name)}`, { method: 'DELETE' });
-      loadBackups();
+      if (!window.confirm('¿Eliminar backup?')) {
+        if (window.mostrarMensaje) window.mostrarMensaje('Cancelado', 'info');
+        return;
+      }
+      try {
+        const resp = await fetch(`/api/backups/${encodeURIComponent(name)}`, { method: 'DELETE' });
+        if (!resp.ok) {
+          const err = await resp.json().catch(() => ({}));
+          if (window.mostrarMensaje) window.mostrarMensaje(err.error || 'Error al eliminar');
+        } else {
+          if (window.mostrarMensaje) window.mostrarMensaje('Backup eliminado', 'success');
+          loadBackups();
+        }
+      } catch (e) {
+        console.error(e);
+        if (window.mostrarMensaje) window.mostrarMensaje('Error al eliminar');
+      }
     });
   }
 

--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -53,6 +53,14 @@ def test_restore_and_delete_invalid_names(tmp_path, monkeypatch):
     assert resp.status_code == 400
 
 
+def test_delete_unknown_backup(tmp_path, monkeypatch):
+    server = _load_server(monkeypatch, tmp_path)
+    client = server.app.test_client()
+
+    resp = client.delete("/api/backups/missing.zip")
+    assert resp.status_code == 404
+
+
 def test_backup_and_restore_assets(tmp_path, monkeypatch):
     monkeypatch.setenv("BACKUP_DIR", str(tmp_path / "backups"))
     monkeypatch.setenv("DATA_DIR", str(tmp_path / "data"))


### PR DESCRIPTION
## Summary
- ask for confirmation before deleting backups in Settings page
- show success or cancel messages when deleting backups
- test deleting an unknown backup returns `404`

## Testing
- `pytest -q`
- `sh format_check.sh`

------
https://chatgpt.com/codex/tasks/task_e_685adae98d78832f8b8fcb0abb4ee14a