### PR TITLE
Switch settings to admin page

### DIFF
--- a/docs/assets/styles.css
+++ b/docs/assets/styles.css
@@ -2648,6 +2648,6 @@ tr:not(.pending) td:first-child::before {
   display: none !important;
 }
 
-body.settings-page main {
+body.admin-page main {
   animation: fadeIn 0.3s ease-in-out;
 }

--- a/docs/js/pageSettings.js
+++ b/docs/js/pageSettings.js
@@ -37,7 +37,7 @@ export function deactivateDevMode() {
 }
 
 export function checkDevBanner() {
-  const inSettings = document.body.classList.contains('settings-page');
+  const inSettings = document.body.classList.contains('admin-page');
   if (inSettings && localStorage.getItem('devMode') === 'true') {
     showDevBanner();
   }

--- a/docs/js/router.js
+++ b/docs/js/router.js
@@ -9,7 +9,8 @@ const routes = {
   '#/sinoptico': renderSinoptico,
   '#/amfe': renderAmfe,
   '#/maestro': renderMaestro,
-  '#/settings': renderSettings,
+  '#/admin': renderSettings,
+  '#/settings': renderSettings, // legacy
 };
 
 const bodyClasses = {
@@ -17,7 +18,8 @@ const bodyClasses = {
   '#/sinoptico': 'sinoptico-page',
   '#/amfe': 'amfe-page',
   '#/maestro': 'maestro-page',
-  '#/settings': 'settings-page',
+  '#/admin': 'admin-page',
+  '#/settings': 'admin-page', // legacy
 };
 
 export function router() {
@@ -31,7 +33,7 @@ export function router() {
     'sinoptico-page',
     'amfe-page',
     'maestro-page',
-    'settings-page'
+    'admin-page'
   );
   const cls = bodyClasses[hash];
   if (cls) document.body.classList.add(cls);

--- a/docs/js/views/home.js
+++ b/docs/js/views/home.js
@@ -135,9 +135,9 @@ function loadModules(el) {
       class: 'admin-only',
     },
     {
-      main: '#/settings',
+      main: '#/admin',
       icon: '⚙️',
-      text: 'Modo Dev',
+      text: 'Admin',
       actions: [],
       class: 'no-guest',
     },

--- a/docs/js/views/settings.js
+++ b/docs/js/views/settings.js
@@ -6,8 +6,25 @@ import { animateInsert } from '../ui/animations.js';
 export async function render(container) {
   await syncNow();
   container.innerHTML = `
-    <h1>Modo Dev</h1>
-    <section class="dev-options">
+    <h1>Admin</h1>
+    <section class="backup-controls">
+      <h2>Backup controls</h2>
+      <input id="backupDesc" type="text" placeholder="Descripción">
+      <button id="createBackup" type="button">Crear backup</button>
+      <select id="backupList"></select>
+      <span id="selectedDesc"></span>
+      <button id="restoreBackup" type="button">Restaurar</button>
+      <button id="deleteBackup" type="button">Eliminar backup</button>
+    </section>
+    <section class="live-data">
+      <h2>Datos en vivo (clientes, insumos, productos, sinóptico)</h2>
+      <p>Usuario actual: <span id="devUser"></span></p>
+      <p>Hora del servidor: <span id="devTime">-</span></p>
+      <p>Usuarios conectados: <span id="devClients">-</span></p>
+      <p>Registros en sinóptico: <span id="sinoCount">-</span></p>
+    </section>
+    <section class="history-section">
+      <h2>Historial de cambios y backups</h2>
       <label>
         <input type="checkbox" id="toggleDevMode">
         Activar Modo Dev
@@ -25,33 +42,17 @@ export async function render(container) {
         <input type="checkbox" id="toggleGridOverlay">
         Mostrar cuadrícula
       </label>
-    </section>
-    <section class="dev-info">
-      <h2>Información del servidor</h2>
-      <p>Usuario actual: <span id="devUser"></span></p>
-      <p>Hora del servidor: <span id="devTime">-</span></p>
-      <p>Usuarios conectados: <span id="devClients">-</span></p>
       <p>Entradas historial: <span id="devHistory">-</span></p>
-    </section>
-    <section class="backup-tools">
-      <h2>Copias de seguridad</h2>
-      <input id="backupDesc" type="text" placeholder="Descripción">
-      <button id="createBackup" type="button">Crear backup</button>
-      <select id="backupList"></select>
-      <span id="selectedDesc"></span>
-      <button id="restoreBackup" type="button">Restaurar</button>
-      <button id="deleteBackup" type="button">Eliminar backup</button>
     </section>`;
 
   animateInsert(container);
 
-  const p = document.createElement('p');
-  container.appendChild(p);
+  const sinCount = container.querySelector('#sinoCount');
 
   async function load() {
     await ready;
     const data = await getAll('sinoptico');
-    p.textContent = `Registros en sinóptico: ${data.length}`;
+    if (sinCount) sinCount.textContent = data.length;
   }
 
   await load();

--- a/docs/nav.html
+++ b/docs/nav.html
@@ -24,7 +24,7 @@
   <div class="nav-item dropdown">
     <a href="#">Ver más</a>
     <div class="dropdown-menu">
-      <a href="index.html#/settings" class="no-guest">Modo Dev</a>
+      <a href="index.html#/admin" class="no-guest">Admin</a>
       <a href="history.html" class="admin-only">Historial</a>
       <a href="dbviewer.html" class="no-guest">Ver base de datos</a>
     </div>

--- a/docs/nginx_spa.md
+++ b/docs/nginx_spa.md
@@ -6,7 +6,7 @@ Este documento analiza el problema al acceder a la SPA desde `/` o `/index.html`
 
 - La configuración actual contiene `try_files $uri $uri/ =404;`.
 - Cuando se accede a `/` Nginx intenta servir primero el directorio `/` y luego `/index.html/` (que no existe) y termina devolviendo *404*.
-- Como la aplicación usa rutas con hash (`#/settings`), la parte después del `#` nunca se envía al servidor, por lo que Nginx no sabe que debe cargar `index.html`.
+- Como la aplicación usa rutas con hash (`#/admin`), la parte después del `#` nunca se envía al servidor, por lo que Nginx no sabe que debe cargar `index.html`.
 
 ## Causa raíz
 
@@ -14,7 +14,7 @@ Este documento analiza el problema al acceder a la SPA desde `/` o `/index.html`
 
 ## Solución
 
-Hacer que todas las rutas caigan en `index.html` cuando no exista un archivo real. Opcionalmente se puede redirigir `/` a `#/settings` si se desea que la SPA abra esa vista por defecto.
+Hacer que todas las rutas caigan en `index.html` cuando no exista un archivo real. Opcionalmente se puede redirigir `/` a `#/admin` si se desea que la SPA abra esa vista por defecto.
 
 ### Configuración propuesta (`nginx.conf`)
 
@@ -33,9 +33,9 @@ server {
         try_files $uri $uri/ /index.html;
     }
 
-    # Descomenta lo siguiente si quieres ir directo a #/settings
+    # Descomenta lo siguiente si quieres ir directo a #/admin
     #location = / {
-    #    return 302 /index.html#/settings;
+    #    return 302 /index.html#/admin;
     #}
 }
 ```

--- a/nginx.conf
+++ b/nginx.conf
@@ -22,9 +22,9 @@ server {
         try_files $uri $uri/ /index.html;
     }
 
-    # Uncomment to redirect root to #/settings
+    # Uncomment to redirect root to #/admin
     #location = / {
-    #    return 302 /index.html#/settings;
+    #    return 302 /index.html#/admin;
     #}
 }
 # End of file


### PR DESCRIPTION
## Summary
- rename dev page to Admin and restructure sections
- use `#/admin` route and legacy `#/settings` alias
- update nav and home links
- change body class to `admin-page`
- adjust docs and nginx config

## Testing
- `./format_check.sh`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_685adaeac8d8832f94f719a4e27cfe4d