### PR TITLE
Implement row locks

### DIFF
--- a/tests/test_locks.py
+++ b/tests/test_locks.py
@@ -1,0 +1,26 @@
+from backend import main
+
+
+def test_row_locking_conflict_and_release():
+    client = main.app.test_client()
+    db = main.get_db()
+    db.execute(
+        "INSERT INTO Cliente(codigo,nombre,updated_at,version) VALUES('L1','A','2024-01-01',1)"
+    )
+    db.commit()
+
+    resp = client.post('/api/locks/clientes/1', json={'user': 'alice'})
+    assert resp.status_code == 200
+
+    resp = client.post('/api/locks/clientes/1', json={'user': 'bob'})
+    assert resp.status_code == 409
+
+    payload = {'updated_at': '2024-01-01', 'version': 1, 'nombre': 'B', 'user': 'bob'}
+    resp = client.patch('/api/clientes/1', json=payload)
+    assert resp.status_code == 409
+
+    resp = client.delete('/api/locks/clientes/1?user=alice')
+    assert resp.status_code == 200
+
+    resp = client.patch('/api/clientes/1', json=payload)
+    assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- add in-memory lock dictionary and CRUD endpoints
- enforce locks when updating rows
- expose lock helpers in frontend dataService and use them in renderer
- add regression test for locking behavior

## Testing
- `black server.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685adaeb1404832fbc0106905ce690cf