### PR TITLE
Improve loading UX and cleanup exports

### DIFF
--- a/docs/arbol.html
+++ b/docs/arbol.html
@@ -90,7 +90,7 @@
     </div>
   </div>
   <script src="lib/dexie.min.js" defer></script>
-  <script src="/socket.io/socket.io.js" defer></script>
+  <script src="socket.io/socket.io.js" defer></script>
   <script type="module" src="js/authGuard.js"></script>
   <script type="module" src="js/dataService.js" defer></script>
   <script type="module" src="js/patchConflict.js" defer></script>

--- a/docs/asistente.html
+++ b/docs/asistente.html
@@ -122,7 +122,7 @@
     </aside>
   </div> <!-- wizard-layout -->
   <script src="lib/dexie.min.js" defer></script>
-  <script src="/socket.io/socket.io.js" defer></script>
+  <script src="socket.io/socket.io.js" defer></script>
   <script type="module" src="js/authGuard.js"></script>
   <script type="module" src="js/dataService.js" defer></script>
   <script type="module" src="js/patchConflict.js" defer></script>

--- a/docs/index.html
+++ b/docs/index.html
@@ -14,9 +14,9 @@
 </head>
 <body>
   <nav id="nav-placeholder"></nav>
-  <section id="loading"></section>
+  <section id="loading"><div class="spinner"></div></section>
   <section id="appMessage" role="alert" aria-live="polite"></section>
-  <main id="app">Cargando…</main>
+  <main id="app"></main>
   <dialog id="dlgNuevoCliente" class="modal">
     <form method="dialog">
       <label for="nuevoClienteNombre">Nombre del cliente:</label>
@@ -29,7 +29,7 @@
   </dialog>
   <script src="lib/dexie.min.js" defer></script>
   <script src="lib/fuse.min.js" defer></script>
-  <script src="/socket.io/socket.io.js" defer></script>
+  <script src="socket.io/socket.io.js" defer></script>
   <script type="module" src="js/authGuard.js"></script>
   <script type="module" src="js/nav.js" defer></script>
   <script type="module" src="js/router.js" defer></script>

--- a/docs/js/dataService.js
+++ b/docs/js/dataService.js
@@ -180,6 +180,16 @@ function markFetchSuccess() {
     }
   }
 }
+
+function handleApiError(resp, fallback = 'Error') {
+  if (typeof window === 'undefined' || !window.mostrarMensaje) return;
+  resp
+    .json()
+    .then((d) => {
+      window.mostrarMensaje(d.error || fallback);
+    })
+    .catch(() => window.mostrarMensaje(fallback));
+}
 // promise that resolves once IndexedDB is ready (or failed)
 let readyResolve;
 const ready = new Promise((res) => {
@@ -367,8 +377,12 @@ async function initFromServer(force = false) {
       markFetchSuccess();
       return true;
     }
+    handleApiError(resp, 'Error al cargar datos');
   } catch (e) {
     console.error('Failed to initialize data from server', e);
+    if (typeof window !== 'undefined' && window.mostrarMensaje) {
+      window.mostrarMensaje('Error de conexión');
+    }
   }
   return false;
 }
@@ -743,5 +757,4 @@ export {
   syncNow,
   lockRecord,
   unlockRecord,
-  subscribeBackupUpdates,
 };

--- a/docs/js/hideLoading.js
+++ b/docs/js/hideLoading.js
@@ -1,4 +1,9 @@
+import { initialized } from './dataService.js';
+
 document.addEventListener('DOMContentLoaded', () => {
   const loader = document.getElementById('loading');
-  if (loader) loader.style.display = 'none';
+  if (!loader) return;
+  initialized.finally(() => {
+    loader.style.display = 'none';
+  });
 });

--- a/docs/maestro.html
+++ b/docs/maestro.html
@@ -93,7 +93,7 @@
     </p>
   </noscript>
   <script src="lib/dexie.min.js" defer></script>
-  <script src="/socket.io/socket.io.js" defer></script>
+  <script src="socket.io/socket.io.js" defer></script>
   <script type="module" src="js/authGuard.js"></script>
   <script type="module" src="js/nav.js" defer></script>
   <script type="module" src="js/dataService.js" defer></script>

--- a/docs/registros.html
+++ b/docs/registros.html
@@ -125,7 +125,7 @@
   </dialog>
   <script src="lib/dexie.min.js" defer></script>
   <script src="lib/tabulator/tabulator.min.js" defer></script>
-  <script src="/socket.io/socket.io.js" defer></script>
+  <script src="socket.io/socket.io.js" defer></script>
   <script type="module" src="js/authGuard.js"></script>
   <script type="module" src="js/nav.js" defer></script>
   <script type="module" src="js/dataService.js" defer></script>

--- a/docs/sinoptico.html
+++ b/docs/sinoptico.html
@@ -63,7 +63,7 @@
   </section>
   <script src="lib/dexie.min.js" defer></script>
   <script src="lib/fuse.min.js" defer></script>
-  <script src="/socket.io/socket.io.js" defer></script>
+  <script src="socket.io/socket.io.js" defer></script>
   <script type="module" src="js/authGuard.js"></script>
   <script type="module" src="js/nav.js" defer></script>
   <script src="lib/xlsx.full.noeval.js" defer></script>


### PR DESCRIPTION
## Summary
- make Socket.IO client path relative
- remove redundant export for `subscribeBackupUpdates`
- keep loading spinner visible until data loads
- surface API errors through message banner

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ae3f1ac88832fa6377f3c83d2f47d