### PR TITLE
Fix socket.io path

### DIFF
--- a/docs/arbol.html
+++ b/docs/arbol.html
@@ -90,7 +90,7 @@
     </div>
   </div>
   <script src="lib/dexie.min.js" defer></script>
-  <script src="socket.io/socket.io.js" defer></script>
+  <script src="/socket.io/socket.io.js" defer></script>
   <script type="module" src="js/authGuard.js"></script>
   <script type="module" src="js/dataService.js" defer></script>
   <script type="module" src="js/patchConflict.js" defer></script>

--- a/docs/asistente.html
+++ b/docs/asistente.html
@@ -122,7 +122,7 @@
     </aside>
   </div> <!-- wizard-layout -->
   <script src="lib/dexie.min.js" defer></script>
-  <script src="socket.io/socket.io.js" defer></script>
+  <script src="/socket.io/socket.io.js" defer></script>
   <script type="module" src="js/authGuard.js"></script>
   <script type="module" src="js/dataService.js" defer></script>
   <script type="module" src="js/patchConflict.js" defer></script>

--- a/docs/index.html
+++ b/docs/index.html
@@ -29,7 +29,7 @@
   </dialog>
   <script src="lib/dexie.min.js" defer></script>
   <script src="lib/fuse.min.js" defer></script>
-  <script src="socket.io/socket.io.js" defer></script>
+  <script src="/socket.io/socket.io.js" defer></script>
   <script type="module" src="js/authGuard.js"></script>
   <script type="module" src="js/nav.js" defer></script>
   <script type="module" src="js/router.js" defer></script>

--- a/docs/maestro.html
+++ b/docs/maestro.html
@@ -93,7 +93,7 @@
     </p>
   </noscript>
   <script src="lib/dexie.min.js" defer></script>
-  <script src="socket.io/socket.io.js" defer></script>
+  <script src="/socket.io/socket.io.js" defer></script>
   <script type="module" src="js/authGuard.js"></script>
   <script type="module" src="js/nav.js" defer></script>
   <script type="module" src="js/dataService.js" defer></script>

--- a/docs/registros.html
+++ b/docs/registros.html
@@ -125,7 +125,7 @@
   </dialog>
   <script src="lib/dexie.min.js" defer></script>
   <script src="lib/tabulator/tabulator.min.js" defer></script>
-  <script src="socket.io/socket.io.js" defer></script>
+  <script src="/socket.io/socket.io.js" defer></script>
   <script type="module" src="js/authGuard.js"></script>
   <script type="module" src="js/nav.js" defer></script>
   <script type="module" src="js/dataService.js" defer></script>

--- a/docs/sinoptico.html
+++ b/docs/sinoptico.html
@@ -63,7 +63,7 @@
   </section>
   <script src="lib/dexie.min.js" defer></script>
   <script src="lib/fuse.min.js" defer></script>
-  <script src="socket.io/socket.io.js" defer></script>
+  <script src="/socket.io/socket.io.js" defer></script>
   <script type="module" src="js/authGuard.js"></script>
   <script type="module" src="js/nav.js" defer></script>
   <script src="lib/xlsx.full.noeval.js" defer></script>


### PR DESCRIPTION
## Summary
- use an absolute `/socket.io/socket.io.js` path in HTML pages

## Testing
- `./format_check.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ae9709884832f86813c912d56b12f