### PR TITLE
Fix websocket support for socket.io

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -12,8 +12,11 @@ server {
         proxy_pass http://backend:5000/api/;
     }
 
-    # Proxy Socket.IO requests to the backend
+    # Proxy Socket.IO requests to the backend with WebSocket upgrade
     location /socket.io/ {
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
         proxy_pass http://backend:5000/socket.io/;
     }
 


### PR DESCRIPTION
## Summary
- update nginx to allow WebSocket upgrades on `/socket.io/`

## Testing
- `bash format_check.sh`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685ae972a3f4832fbeae679d3895dcb6