### PR TITLE
Handle dataService load errors

### DIFF
--- a/docs/js/hideLoading.js
+++ b/docs/js/hideLoading.js
@@ -1,9 +1,16 @@
-import { initialized } from './dataService.js';
-
-document.addEventListener('DOMContentLoaded', () => {
+document.addEventListener('DOMContentLoaded', async () => {
   const loader = document.getElementById('loading');
   if (!loader) return;
-  initialized.finally(() => {
+
+  try {
+    const { initialized } = await import('./dataService.js');
+    await initialized;
+  } catch (e) {
+    console.error('Error loading dataService', e);
+    if (window.mostrarMensaje) {
+      window.mostrarMensaje('Error al inicializar la aplicación');
+    }
+  } finally {
     loader.style.display = 'none';
-  });
+  }
 });


### PR DESCRIPTION
## Summary
- handle initialization failures in `hideLoading.js`

## Testing
- `bash format_check.sh`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685ae972c700832fbdc63bcf45855474