### PR TITLE
Add regression test for dataService export

### DIFF
--- a/tests/test_data_service.py
+++ b/tests/test_data_service.py
@@ -1,0 +1,18 @@
+import re
+from pathlib import Path
+
+
+def test_no_named_export_after_default():
+    js_file = Path(__file__).resolve().parent.parent / "docs/js/dataService.js"
+    text = js_file.read_text(encoding="utf-8")
+    lines = text.splitlines()
+    idx = None
+    for i, line in enumerate(lines):
+        if "export default api;" in line:
+            idx = i
+            break
+    assert idx is not None, "export default api not found"
+    remainder = "\n".join(lines[idx + 1 :])
+    assert not re.search(
+        r"^\s*export\s*\{", remainder, re.MULTILINE
+    ), "Unexpected named export after default export"


### PR DESCRIPTION
## Summary
- add `tests/test_data_service.py` to ensure there is only one export block in `docs/js/dataService.js`

## Testing
- `./format_check.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685aef5291b4832fb51d9011ab89b853