### PR TITLE
Restore named exports and bump version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Proyecto Barack
 
-Versión actual: **405**
+Versión actual: **406**
 
 Esta es una pequeña SPA (Single Page Application) escrita en HTML, CSS y JavaScript.
 Incluye un módulo llamado *Sinóptico* para gestionar jerarquías de productos.

--- a/docs/js/dataService.js
+++ b/docs/js/dataService.js
@@ -745,3 +745,25 @@ if (hasWindow) {
 
 export default api;
 
+export {
+  getAll,
+  getAllSinoptico,
+  addNode,
+  updateNode,
+  deleteNode,
+  replaceAll,
+  add,
+  update,
+  remove,
+  exportJSON,
+  importJSON,
+  ready,
+  initialized,
+  subscribeToChanges,
+  subscribeSinopticoChanges,
+  subscribeBackupUpdates,
+  syncNow,
+  lockRecord,
+  unlockRecord,
+};
+

--- a/docs/js/version.js
+++ b/docs/js/version.js
@@ -1,4 +1,4 @@
-export const version = '405';
+export const version = '406';
 export function displayVersion() {
   const div = document.createElement('div');
   div.className = 'version-info';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "proyecto-barack",
-  "version": "405",
+  "version": "406",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "proyecto-barack",
-      "version": "405",
+      "version": "406",
       "license": "ISC",
       "dependencies": {
         "jsdom": "^22.1.0"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "proyecto-barack",
-  "version": "405",
-  "description": "Versión actual: **405**",
+  "version": "406",
+  "description": "Versión actual: **406**",
   "main": "index.js",
   "directories": {
     "lib": "lib"

--- a/tests/test_data_service.py
+++ b/tests/test_data_service.py
@@ -2,17 +2,15 @@ import re
 from pathlib import Path
 
 
-def test_no_named_export_after_default():
+def test_named_export_after_default():
     js_file = Path(__file__).resolve().parent.parent / "docs/js/dataService.js"
     text = js_file.read_text(encoding="utf-8")
     lines = text.splitlines()
-    idx = None
-    for i, line in enumerate(lines):
-        if "export default api;" in line:
-            idx = i
-            break
+    idx = next((i for i, line in enumerate(lines) if "export default api;" in line), None)
     assert idx is not None, "export default api not found"
     remainder = "\n".join(lines[idx + 1 :])
-    assert not re.search(
-        r"^\s*export\s*\{", remainder, re.MULTILINE
-    ), "Unexpected named export after default export"
+    m = re.search(r"export\s*\{([^}]*)\}", remainder)
+    assert m, "named export block not found"
+    exported = {name.strip() for name in m.group(1).split(",") if name.strip()}
+    assert {"getAll", "ready", "initialized"} <= exported
+


### PR DESCRIPTION
## Summary
- restore named export block in `docs/js/dataService.js`
- update regression test to ensure named exports exist
- bump version to 406

## Testing
- `bash format_check.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685af1e7c990832fb158257808185878