### PR TITLE
Fix page loading overlay

### DIFF
--- a/docs/assets/styles.css
+++ b/docs/assets/styles.css
@@ -117,7 +117,7 @@ h1 {
 #loading {
   position: fixed;
   inset: 0;
-  display: flex;
+  display: none;
   align-items: center;
   justify-content: center;
   background: rgba(255, 255, 255, 0.8);


### PR DESCRIPTION
## Summary
- hide loading overlay by default so pages remain visible without JS

## Testing
- `./format_check.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b28b8854c832fa3e7c5cb0174dd3d