### PR TITLE
Fix infinite loading on GitHub Pages

### DIFF
--- a/docs/arbol.html
+++ b/docs/arbol.html
@@ -17,7 +17,7 @@
     <button id="toggleDarkMode" type="button">🌙</button>
     <button type="button" class="logout-link">Cerrar sesión</button>
   </nav>
-  <div id="loading"></div>
+  <div id="loading" style="display:none"></div>
   <div id="appMessage" role="alert" aria-live="polite"></div>
   <div class="wizard">
     <div class="progress"><div id="progressBar"></div></div>

--- a/docs/asistente.html
+++ b/docs/asistente.html
@@ -17,7 +17,7 @@
     <button id="toggleDarkMode" type="button">🌙</button>
     <button type="button" class="logout-link">Cerrar sesión</button>
   </nav>
-  <div id="loading"></div>
+  <div id="loading" style="display:none"></div>
   <div id="appMessage" role="alert" aria-live="polite"></div>
   <div class="wizard-layout">
     <div class="wizard-left">

--- a/docs/index.html
+++ b/docs/index.html
@@ -14,7 +14,7 @@
 </head>
 <body>
   <nav id="nav-placeholder"></nav>
-  <section id="loading"></section>
+  <section id="loading" style="display:none"></section>
   <section id="appMessage" role="alert" aria-live="polite"></section>
   <main id="app">Cargando…</main>
   <dialog id="dlgNuevoCliente" class="modal">

--- a/docs/js/views/maestro.js
+++ b/docs/js/views/maestro.js
@@ -27,7 +27,7 @@ export async function render(container) {
       <select id="savedFilters"><option value="">Saved filters</option></select>
       <button id="moreFilters">More filters</button>
     </div>
-    <div id="loading"><div class="spinner"></div></div>
+    <div id="loading" style="display:none"><div class="spinner"></div></div>
     <section class="tabla-contenedor">
       <table id="maestroTable" class="master-table">
         <thead>

--- a/docs/maestro.html
+++ b/docs/maestro.html
@@ -41,7 +41,7 @@
       <select id="savedFilters"><option value="">Saved filters</option></select>
       <button id="moreFilters">More filters</button>
     </div>
-    <div id="loading"><div class="spinner"></div></div>
+    <div id="loading" style="display:none"><div class="spinner"></div></div>
     <section class="tabla-contenedor">
       <table id="maestroTable" class="master-table">
         <thead>


### PR DESCRIPTION
## Summary
- hide the loading overlay by default using inline styles

## Testing
- `bash format_check.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b2a8d5c30832fb4de6d4c66e80fe9