### PR TITLE
Add noscript warnings for CSP issue

### DIFF
--- a/docs/arbol.html
+++ b/docs/arbol.html
@@ -89,6 +89,12 @@
     </div>
     </div>
   </div>
+  <noscript>
+    <p class="noscript-warning">
+      Esta página necesita JavaScript para funcionar. Si la estás viendo desde
+      GitHub, descárgala y ábrela localmente con un navegador.
+    </p>
+  </noscript>
   <script src="lib/dexie.min.js" defer></script>
   <script src="/socket.io/socket.io.js" defer></script>
   <script type="module" src="js/authGuard.js"></script>

--- a/docs/asistente.html
+++ b/docs/asistente.html
@@ -121,6 +121,12 @@
       </div>
     </aside>
   </div> <!-- wizard-layout -->
+  <noscript>
+    <p class="noscript-warning">
+      Esta página necesita JavaScript para funcionar. Si la estás viendo desde
+      GitHub, descárgala y ábrela localmente con un navegador.
+    </p>
+  </noscript>
   <script src="lib/dexie.min.js" defer></script>
   <script src="/socket.io/socket.io.js" defer></script>
   <script type="module" src="js/authGuard.js"></script>

--- a/docs/assets/styles.css
+++ b/docs/assets/styles.css
@@ -83,6 +83,13 @@ body.fade-out {
   opacity: 0;
 }
 
+.noscript-warning {
+  color: #b00;
+  background: #fff4f4;
+  padding: 8px;
+  text-align: center;
+}
+
 body.home {
   padding-top: 0;
 }

--- a/docs/dbviewer.html
+++ b/docs/dbviewer.html
@@ -13,6 +13,12 @@
     <pre id="dbDump">Cargando...</pre>
     <p>Para conocer el esquema completo puedes consultar <a href="er.svg" target="_blank">er.svg</a>.</p>
   </main>
+  <noscript>
+    <p class="noscript-warning">
+      Esta página necesita JavaScript para funcionar. Si la estás viendo desde
+      GitHub, descárgala y ábrela localmente con un navegador.
+    </p>
+  </noscript>
   <script src="js/nav.js"></script>
   <script type="module" src="js/patchConflict.js" defer></script>
   <script>

--- a/docs/history.html
+++ b/docs/history.html
@@ -43,9 +43,15 @@
           <th>Resumen</th>
         </tr>
       </thead>
-      <tbody></tbody>
-    </table>
+    <tbody></tbody>
+  </table>
   </section>
+  <noscript>
+    <p class="noscript-warning">
+      Esta página necesita JavaScript para funcionar. Si la estás viendo desde
+      GitHub, descárgala y ábrela localmente con un navegador.
+    </p>
+  </noscript>
   <script type="module" src="js/authGuard.js"></script>
   <script type="module" src="js/nav.js" defer></script>
   <script type="module" src="js/history.js"></script>

--- a/docs/index.html
+++ b/docs/index.html
@@ -27,6 +27,12 @@
       </div>
     </form>
   </dialog>
+  <noscript>
+    <p class="noscript-warning">
+      Esta página necesita JavaScript para funcionar. Si la estás viendo desde
+      GitHub, descárgala y ábrela localmente con un navegador.
+    </p>
+  </noscript>
   <script src="lib/dexie.min.js" defer></script>
   <script src="lib/fuse.min.js" defer></script>
   <script src="/socket.io/socket.io.js" defer></script>

--- a/docs/registros.html
+++ b/docs/registros.html
@@ -123,6 +123,12 @@
       </div>
     </form>
   </dialog>
+  <noscript>
+    <p class="noscript-warning">
+      Esta página necesita JavaScript para funcionar. Si la estás viendo desde
+      GitHub, descárgala y ábrela localmente con un navegador.
+    </p>
+  </noscript>
   <script src="lib/dexie.min.js" defer></script>
   <script src="lib/tabulator/tabulator.min.js" defer></script>
   <script src="/socket.io/socket.io.js" defer></script>

--- a/docs/sinoptico.html
+++ b/docs/sinoptico.html
@@ -58,9 +58,15 @@
           <th>Imagen</th>
         </tr>
       </thead>
-      <tbody id="sinopticoBody"></tbody>
-    </table>
+  <tbody id="sinopticoBody"></tbody>
+  </table>
   </section>
+  <noscript>
+    <p class="noscript-warning">
+      Esta página necesita JavaScript para funcionar. Si la estás viendo desde
+      GitHub, descárgala y ábrela localmente con un navegador.
+    </p>
+  </noscript>
   <script src="lib/dexie.min.js" defer></script>
   <script src="lib/fuse.min.js" defer></script>
   <script src="/socket.io/socket.io.js" defer></script>


### PR DESCRIPTION
## Summary
- add `.noscript-warning` style
- show noscript warnings in HTML files to instruct local opening if scripts are blocked

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b2d2e8c04832fad95ea590f711c33