### PR TITLE
Update README with Docker setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,14 +95,21 @@ python backend/main.py
 Para levantar el servidor que también hospeda la carpeta `docs` ejecuta:
 
 ```bash
+docker compose up -d
+```
+
+### Alternative setup
+
+Si prefieres iniciar el servidor con Python directamente:
+
+```bash
 pip install -r requirements.txt
 python server.py
 ```
 
-En Windows puedes ejecutar los siguientes comandos:
+En Windows puedes ejecutar:
 
 ```bash
-cd "C:\\Users\\FacundoS-PC\\Documents\\Proyecto-barack-main (11)\\Proyecto-barack-main"
 py -3 -m pip install -r requirements.txt
 py -3 server.py
 ```


### PR DESCRIPTION
## Summary
- document Docker Compose as the default way to start the project
- keep the legacy Python commands in a short *Alternative setup* section

## Testing
- `bash format_check.sh`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685b4296b1e0832f8df85c394388584b