### PR TITLE
Fix default API URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ Cuando uses varias PC debes indicar la URL del servidor. Puedes hacerlo con:
 1. Guardar la dirección en `localStorage` usando `localStorage.setItem('apiUrl', 'http://<IP>:5000/api/data')` desde la consola del navegador.
 2. O bien establecer la variable de entorno `API_URL` antes de iniciar la aplicación.
 
-Si no se define ningún valor se usará `http://192.168.1.233:5000/api/data` por defecto.
+Si no se define ningún valor se usará `http://localhost:5000/api/data` por defecto.
 Para mas detalles consulta `docs/backend.md`.
 
 ## API


### PR DESCRIPTION
## Summary
- correct README to use http://localhost:5000/api/data as default API URL

## Testing
- `bash format_check.sh`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685b43abb7d8832fbd37d6e7af8a1ab1