### PR TITLE
Make allowed origins configurable

### DIFF
--- a/docs/backend.md
+++ b/docs/backend.md
@@ -39,6 +39,8 @@ The frontend reads the server URL from `localStorage` (`apiUrl`) or from the `AP
   full application state.
 - `SSL_CERT` / `SSL_KEY` – optional certificate paths for HTTPS when running `server.py`.
 - `DB_PATH` – path to the SQLite file used by `backend/main.py` (`data/db.sqlite` by default).
+- `ALLOWED_ORIGINS` – comma-separated list of origins allowed for CORS and
+  WebSocket connections. Defaults to `http://192.168.1.233:8080,http://localhost:8080`.
 
 ## Offline fallback
 

--- a/server.py
+++ b/server.py
@@ -43,10 +43,16 @@ ASSET_DIRS = ["imagenes_sinoptico", "images"]
 from flask_socketio import SocketIO
 
 # Permit requests from the development front-end and the local API consumer
-allowed = ["http://192.168.1.233:8080", "http://localhost:8080"]
-socketio = SocketIO(app, async_mode="eventlet", cors_allowed_origins=allowed)
+default_origins = ["http://192.168.1.233:8080", "http://localhost:8080"]
+orig_env = os.getenv("ALLOWED_ORIGINS")
+origins = (
+    [o.strip() for o in orig_env.split(",") if o.strip()]
+    if orig_env
+    else default_origins
+)
+socketio = SocketIO(app, async_mode="eventlet", cors_allowed_origins=origins)
 clients = {}
-CORS(app, resources={r"/api/*": {"origins": allowed}})
+CORS(app, resources={r"/api/*": {"origins": origins}})
 
 
 @app.get("/health")


### PR DESCRIPTION
## Summary
- let server.py read `ALLOWED_ORIGINS` environment variable
- pass this origin list to Flask-CORS and SocketIO
- document the new variable in backend docs

## Testing
- `sh format_check.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b47c35790832f935017a7c8f5e689