### PR TITLE
Fix backend Dockerfile paths

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.11-slim
 WORKDIR /app
-COPY ../requirements.txt .
+COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
-COPY . .
+COPY backend/ .
 EXPOSE 5000
-CMD ["python", "server.py"]
+CMD ["python", "main.py"]


### PR DESCRIPTION
## Summary
- correct COPY paths in backend Dockerfile
- set backend container entrypoint to use `main.py`

## Testing
- `sh format_check.sh`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*
- `docker-compose build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b4894afac832f92d60e2941113a99