### PR TITLE
Document ALLOWED_ORIGINS usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,16 @@ Cuando uses varias PC debes indicar la URL del servidor. Puedes hacerlo con:
 
 Si no se define ningún valor se usará `http://localhost:5000/api/data` por defecto.
 Para más información sobre variables como `API_URL`, `DATA_DIR` y `DB_PATH` revisa `docs/backend.md`.
-Si necesitas usar otra dirección u otro puerto, agrega esa URL a la variable `ALLOWED_ORIGINS` antes de iniciar el servidor.
+
+### Configurar `ALLOWED_ORIGINS`
+
+Si la interfaz se sirve desde un nombre de host o puerto distinto al del backend,
+debes añadir esa URL a la variable de entorno `ALLOWED_ORIGINS` para evitar
+errores de CORS. Por ejemplo:
+
+```bash
+ALLOWED_ORIGINS=http://desktop-14jg95b:8080 docker compose up
+```
 
 ## API
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@ services:
     image: barack-backend:latest
     environment:
       - DB_PATH=/data/db.sqlite
+      - ALLOWED_ORIGINS=http://desktop-14jg95b:8080
     volumes:
       - ./data/db.sqlite:/data/db.sqlite
       - ./backups:/app/backups

--- a/docs/backend.md
+++ b/docs/backend.md
@@ -42,6 +42,16 @@ The frontend reads the server URL from `localStorage` (`apiUrl`) or from the `AP
 - `ALLOWED_ORIGINS` – comma-separated list of origins allowed for CORS and
   WebSocket connections. Defaults to `http://192.168.1.233:8080,http://localhost:8080`.
 
+### Changing `ALLOWED_ORIGINS`
+
+If the web interface is hosted under a different hostname or port, add that
+origin to the `ALLOWED_ORIGINS` environment variable before starting the
+backend. For example:
+
+```bash
+ALLOWED_ORIGINS=http://desktop-14jg95b:8080 docker compose up
+```
+
 ## Offline fallback
 
 If the API server is unreachable, the frontend keeps working thanks to IndexedDB (via Dexie) and localStorage. Data modifications are saved locally and synchronized once the server becomes available again.


### PR DESCRIPTION
## Summary
- explain how to set `ALLOWED_ORIGINS` in README and backend docs
- include `ALLOWED_ORIGINS` example in docker-compose.yml

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b5875c6e0832f84416babde21e43b