### PR TITLE
Update ALLOWED_ORIGINS docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,12 +105,10 @@ docker compose up -d
 
 Todas las computadoras de la red deben abrir la URL `http://<HOST>:8080/`,
 donde `<HOST>` es el nombre o la IP del equipo que ejecutó `docker compose up`.
-Si utilizas un hostname distinto a `localhost`, añádelo en la variable
-`ALLOWED_ORIGINS` del servicio `backend` para evitar errores de CORS:
-
-```bash
-ALLOWED_ORIGINS=http://desktop-14jg95b:8080 docker compose up -d
-```
+El archivo `docker-compose.yml` ya establece
+`ALLOWED_ORIGINS=http://desktop-14jg95b:8080`, por lo que dicha URL se acepta
+de forma predeterminada. Si utilizas otro hostname, añádelo en la variable
+`ALLOWED_ORIGINS` del servicio `backend` para evitar errores de CORS.
 
 ### Configurar `ALLOWED_ORIGINS`
 
@@ -119,7 +117,10 @@ debes añadir esa URL a la variable de entorno `ALLOWED_ORIGINS` para evitar
 errores de CORS. Por ejemplo:
 
 ```bash
-ALLOWED_ORIGINS=http://desktop-14jg95b:8080 docker compose up -d
+ALLOWED_ORIGINS=http://mi-host:8080 docker compose up -d
+
+# O con el servidor en Python
+ALLOWED_ORIGINS=http://mi-host:8080 python server.py
 ```
 
 ## API

--- a/docs/backend.md
+++ b/docs/backend.md
@@ -40,7 +40,9 @@ The frontend reads the server URL from `localStorage` (`apiUrl`) or from the `AP
 - `SSL_CERT` / `SSL_KEY` – optional certificate paths for HTTPS when running `server.py`.
 - `DB_PATH` – path to the SQLite file used by `backend/main.py` (`data/db.sqlite` by default).
 - `ALLOWED_ORIGINS` – comma-separated list of origins allowed for CORS and
-  WebSocket connections. Defaults to `http://192.168.1.233:8080,http://localhost:8080`.
+  WebSocket connections. Defaults to
+  `http://desktop-14jg95b:8080,http://192.168.1.233:8080,http://localhost:8080`.
+  This includes the desktop hostname specified in `docker-compose.yml`.
 
 ### Changing `ALLOWED_ORIGINS`
 
@@ -48,8 +50,18 @@ If the web interface is hosted under a different hostname or port, add that
 origin to the `ALLOWED_ORIGINS` environment variable before starting the
 backend. For example:
 
+The provided `docker-compose.yml` sets this variable to
+`http://desktop-14jg95b:8080`, so the SPA works out of the box. To use another
+origin run:
+
 ```bash
-ALLOWED_ORIGINS=http://desktop-14jg95b:8080 docker compose up
+ALLOWED_ORIGINS=http://mi-host:8080 docker compose up
+```
+
+Or when using the plain Python server:
+
+```bash
+ALLOWED_ORIGINS=http://mi-host:8080 python server.py
 ```
 
 ## Offline fallback


### PR DESCRIPTION
## Summary
- document default `ALLOWED_ORIGINS` value including desktop host
- show how to override `ALLOWED_ORIGINS` for Python or Docker

## Testing
- `bash format_check.sh`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_685be3965844832fad4ead878827d1e9