### PR TITLE
Update docker documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,13 @@ Para levantar el servidor que también hospeda la carpeta `docs` ejecuta:
 docker compose up -d
 ```
 
+> **Nota:** Asegúrate de que las carpetas `./data` y `./backups` existan y
+> cuenten con permisos de escritura antes de ejecutar `docker compose up`.
+> Docker creará automáticamente `db.sqlite` dentro de `./data` la primera vez
+> que se inicie el backend. Si cualquiera de estas rutas falta o es de solo
+> lectura se producirá un `sqlite3.OperationalError` y Nginx mostrará
+> “Bad Gateway”.
+
 Todas las computadoras de la red deben abrir la URL `http://<HOST>:8080/`,
 donde `<HOST>` es el nombre o la IP del equipo que ejecutó `docker compose up`.
 El archivo `docker-compose.yml` ya establece


### PR DESCRIPTION
## Summary
- document that `./data` and `./backups` must exist before running Docker
- clarify automatic creation of `db.sqlite` and failure symptoms

## Testing
- `bash format_check.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685be4effdf8832fbb62844f3eebf5f5