### PR TITLE
Set API base via inline script

### DIFF
--- a/docs/arbol.html
+++ b/docs/arbol.html
@@ -92,7 +92,13 @@
   <script src="lib/dexie.min.js" defer></script>
   <script src="./socket.io/socket.io.js" defer></script>
   <script type="module" src="js/authGuard.js"></script>
-  <script type="module" src="js/dataService.js" defer></script>
+  <script>
+    window.API_BASE = 'http://desktop-14jg95b:5000';
+    if (!localStorage.getItem('apiUrl')) {
+      localStorage.setItem('apiUrl', window.API_BASE + '/api/data');
+    }
+  </script>
+<script type="module" src="js/dataService.js" defer></script>
   <script type="module" src="js/arbol.js" defer></script>
   <script type="module" src="js/ui/animations.js" defer></script>
   <script type="module" src="js/darkMode.js" defer></script>

--- a/docs/asistente.html
+++ b/docs/asistente.html
@@ -124,6 +124,12 @@
   <script src="lib/dexie.min.js" defer></script>
   <script src="./socket.io/socket.io.js" defer></script>
   <script type="module" src="js/authGuard.js"></script>
+  <script>
+    window.API_BASE = 'http://desktop-14jg95b:5000';
+    if (!localStorage.getItem('apiUrl')) {
+      localStorage.setItem('apiUrl', window.API_BASE + '/api/data');
+    }
+  </script>
   <script type="module" src="js/dataService.js" defer></script>
   <script type="module" src="js/asistente.js" defer></script>
   <script type="module" src="js/ui/animations.js" defer></script>

--- a/docs/index.html
+++ b/docs/index.html
@@ -33,6 +33,12 @@
   <script type="module" src="js/authGuard.js"></script>
   <script type="module" src="js/nav.js" defer></script>
   <script type="module" src="js/router.js" defer></script>
+  <script>
+    window.API_BASE = 'http://desktop-14jg95b:5000';
+    if (!localStorage.getItem('apiUrl')) {
+      localStorage.setItem('apiUrl', window.API_BASE + '/api/data');
+    }
+  </script>
   <script type="module" src="js/dataService.js" defer></script>
   <script src="lib/xlsx.full.noeval.js" defer></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js" defer></script>

--- a/docs/maestro.html
+++ b/docs/maestro.html
@@ -96,6 +96,12 @@
   <script src="./socket.io/socket.io.js" defer></script>
   <script type="module" src="js/authGuard.js"></script>
   <script type="module" src="js/nav.js" defer></script>
+  <script>
+    window.API_BASE = 'http://desktop-14jg95b:5000';
+    if (!localStorage.getItem('apiUrl')) {
+      localStorage.setItem('apiUrl', window.API_BASE + '/api/data');
+    }
+  </script>
   <script type="module" src="js/dataService.js" defer></script>
   <script src="lib/xlsx.full.noeval.js" defer></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js" defer></script>

--- a/docs/registros.html
+++ b/docs/registros.html
@@ -128,6 +128,12 @@
   <script src="./socket.io/socket.io.js" defer></script>
   <script type="module" src="js/authGuard.js"></script>
   <script type="module" src="js/nav.js" defer></script>
+  <script>
+    window.API_BASE = 'http://desktop-14jg95b:5000';
+    if (!localStorage.getItem('apiUrl')) {
+      localStorage.setItem('apiUrl', window.API_BASE + '/api/data');
+    }
+  </script>
   <script type="module" src="js/dataService.js" defer></script>
   <script type="module" src="js/interactiveTable.js" defer></script>
   <script type="module" src="js/ui/animations.js" defer></script>

--- a/docs/sinoptico.html
+++ b/docs/sinoptico.html
@@ -69,6 +69,12 @@
   <script src="lib/xlsx.full.noeval.js" defer></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js" defer></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf-autotable/3.5.28/jspdf.plugin.autotable.min.js" defer></script>
+  <script>
+    window.API_BASE = 'http://desktop-14jg95b:5000';
+    if (!localStorage.getItem('apiUrl')) {
+      localStorage.setItem('apiUrl', window.API_BASE + '/api/data');
+    }
+  </script>
   <script type="module" src="js/dataService.js" defer></script>
   <script type="module" src="js/views/sinoptico.js" defer></script>
   <script type="module" src="js/ui/renderer.js" defer></script>


### PR DESCRIPTION
## Summary
- define API_BASE inline for every HTML page
- persist apiUrl in `localStorage` when undefined

## Testing
- `sh format_check.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685bf8d59e74832f9a90ab3198ee610d