### PR TITLE
Update backend docs to mention port 5000

### DIFF
--- a/docs/backend.md
+++ b/docs/backend.md
@@ -75,13 +75,13 @@ If the API server is unreachable, the frontend keeps working thanks to IndexedDB
 1. `pip install -r requirements.txt`
 2. Run `python server.py` to serve the frontend and JSON API on port 5000.
    Set `API_URL` in the browser (or as an environment variable) if the server is on another machine.
-3. Alternatively run `python backend/main.py` for the SQLite API on port 8000.
+3. Alternatively run `python backend/main.py` for the SQLite API on port 5000.
 
 ### Docker Compose
 
 1. Ensure Docker and Docker Compose are installed.
 2. Build the image the first time with `docker-compose build`.
 3. Run `docker-compose up` from the project root.
-4. Nginx will serve the `docs/` folder on port 8080 and the API from `backend/main.py` on port 8000.
-5. Point the frontend to `http://<host>:8000/api` as needed.
+4. Nginx will serve the `docs/` folder on port 8080 and the API from `backend/main.py` on port 5000.
+5. Point the frontend to `http://<host>:5000/api` as needed.
 


### PR DESCRIPTION
## Summary
- update backend docs so the SQLite API references port 5000
- remove outdated deployment instructions using port 8000

## Testing
- `sh format_check.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685bfcdc45ac832f8ade21271f920f2a