### PR TITLE
Add error handling for backup list fetch

### DIFF
--- a/docs/js/views/backup.js
+++ b/docs/js/views/backup.js
@@ -43,7 +43,14 @@ export async function render(container) {
   async function loadBackups() {
     try {
       const resp = await fetch('/api/backups');
-      if (!resp.ok) return;
+      if (!resp.ok) {
+        if (backupMsg) {
+          backupMsg.textContent = 'Error al cargar la lista de backups';
+          backupMsg.classList.add('show', 'error');
+          setTimeout(() => backupMsg.classList.remove('show'), 5000);
+        }
+        return;
+      }
       const list = await resp.json();
       if (backupList) {
         backupList.innerHTML = list
@@ -68,6 +75,11 @@ export async function render(container) {
       }
     } catch (e) {
       console.error(e);
+      if (backupMsg) {
+        backupMsg.textContent = 'Error al cargar la lista de backups';
+        backupMsg.classList.add('show', 'error');
+        setTimeout(() => backupMsg.classList.remove('show'), 5000);
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- show a message when loading backups fails

## Testing
- `sh format_check.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c0554dcb0832f8ecf27f15aabe1dd