### PR TITLE
Make api base configurable in docs

### DIFF
--- a/docs/js/history.js
+++ b/docs/js/history.js
@@ -1,5 +1,10 @@
 'use strict';
 
+const BASE =
+  (localStorage.getItem('apiUrl') || '').replace(/\/api\/data$/, '') ||
+  window.API_BASE ||
+  '';
+
 document.addEventListener('DOMContentLoaded', () => {
   const tbody = document.querySelector('#historyTable tbody');
   const pageInput = document.getElementById('pageFilter');
@@ -50,7 +55,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   async function loadBackups() {
     try {
-      const resp = await fetch('/api/backups');
+      const resp = await fetch(`${BASE}/api/backups`);
       if (!resp.ok) return;
       const list = await resp.json();
       backupSel.innerHTML = list
@@ -65,7 +70,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   createBtn?.addEventListener('click', async () => {
     const description = descInput?.value || '';
-    const resp = await fetch('/api/backups', {
+    const resp = await fetch(`${BASE}/api/backups`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ description })
@@ -87,7 +92,7 @@ document.addEventListener('DOMContentLoaded', () => {
   restoreBtn?.addEventListener('click', async () => {
     const name = backupSel.value;
     if (!name) return;
-    await fetch('/api/restore', {
+    await fetch(`${BASE}/api/restore`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ name })
@@ -97,7 +102,7 @@ document.addEventListener('DOMContentLoaded', () => {
   deleteBtn?.addEventListener('click', async () => {
     const name = backupSel.value;
     if (!name) return;
-    await fetch(`/api/backups/${encodeURIComponent(name)}`, { method: 'DELETE' });
+    await fetch(`${BASE}/api/backups/${encodeURIComponent(name)}`, { method: 'DELETE' });
     loadBackups();
   });
 

--- a/docs/js/views/backup.js
+++ b/docs/js/views/backup.js
@@ -1,5 +1,10 @@
 import { animateInsert } from '../ui/animations.js';
 
+const BASE =
+  (localStorage.getItem('apiUrl') || '').replace(/\/api\/data$/, '') ||
+  window.API_BASE ||
+  '';
+
 export async function render(container) {
   container.innerHTML = `
     <h1>Backups</h1>
@@ -42,7 +47,7 @@ export async function render(container) {
 
   async function loadBackups() {
     try {
-      const resp = await fetch('/api/backups');
+      const resp = await fetch(`${BASE}/api/backups`);
       if (!resp.ok) {
         if (backupMsg) {
           backupMsg.textContent = 'Error al cargar la lista de backups';
@@ -86,7 +91,7 @@ export async function render(container) {
   async function loadStats() {
     if (!statsList) return;
     try {
-      const resp = await fetch('/api/db-stats');
+      const resp = await fetch(`${BASE}/api/db-stats`);
       if (!resp.ok) return;
       const data = await resp.json();
       statsList.innerHTML = Object.entries(data)
@@ -100,7 +105,7 @@ export async function render(container) {
   if (createBtn) {
     createBtn.addEventListener('click', async () => {
       const description = descInput?.value || '';
-      const resp = await fetch('/api/backups', {
+      const resp = await fetch(`${BASE}/api/backups`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ description })
@@ -135,7 +140,7 @@ export async function render(container) {
     restoreBtn.addEventListener('click', async () => {
       const name = selectedBackup;
       if (!name) return;
-      const resp = await fetch('/api/restore', {
+      const resp = await fetch(`${BASE}/api/restore`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ name }),
@@ -157,7 +162,7 @@ export async function render(container) {
     deleteBtn.addEventListener('click', async () => {
       const name = selectedBackup;
       if (!name) return;
-      const resp = await fetch(`/api/backups/${encodeURIComponent(name)}`, { method: 'DELETE' });
+      const resp = await fetch(`${BASE}/api/backups/${encodeURIComponent(name)}`, { method: 'DELETE' });
       if (!resp.ok) {
         let msg = '';
         try {


### PR DESCRIPTION
## Summary
- support optional `BASE` url for backups and restore endpoints
- reference `BASE` url in backup-related fetch calls

## Testing
- `sh format_check.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c077d9034832fa80e8fb1d158a295