### PR TITLE
Fix README backend description

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Versión actual: **406**
 
 Esta es una pequeña SPA (Single Page Application) escrita en HTML, CSS y JavaScript.
 Incluye un módulo llamado *Sinóptico* para gestionar jerarquías de productos.
-Todo se ejecuta en el navegador y no requiere servidor.
+La SPA utiliza un backend Flask, expuesto mediante Docker Compose o ejecutándolo directamente con Python.
 
 ## Inicio
 


### PR DESCRIPTION
## Summary
- clarify that the SPA uses a Flask backend available via Docker Compose or Python

## Testing
- `sh format_check.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c0c3a2734832fb06a001066ca24cb