### PR TITLE
Track active backups

### DIFF
--- a/docs/assets/styles.css
+++ b/docs/assets/styles.css
@@ -231,6 +231,12 @@ h1 {
   background-color: var(--maestro-row-alt);
 }
 
+.active-label {
+  color: green;
+  font-weight: bold;
+  margin-left: 4px;
+}
+
 .card {
   background: var(--color-light);
   color: var(--color-text);

--- a/docs/js/views/backup.js
+++ b/docs/js/views/backup.js
@@ -59,7 +59,13 @@ export async function render(container) {
       const list = await resp.json();
       if (backupList) {
         backupList.innerHTML = list
-          .map(b => `<li data-name="${b.name}" data-desc="${b.description || ''}" data-stats='${JSON.stringify(b.stats || {})}'><strong>${b.name.replace('.zip','')}</strong> - ${b.description || ''}</li>`)
+          .map(b =>
+            `<li data-name="${b.name}" data-desc="${b.description || ''}" data-stats='${JSON.stringify(
+              b.stats || {}
+            )}'><strong>${b.name.replace('.zip', '')}</strong>${
+              b.active ? ' <span class="active-label">ACTUAL</span>' : ''
+            } - ${b.description || ''}</li>`
+          )
           .join('');
         const first = backupList.querySelector('li');
         if (first) {


### PR DESCRIPTION
## Summary
- track current active backup in `metadata.json`
- show which backup is active via `/api/backups`
- update active backup info on restore
- highlight active backup in the web UI
- test active flag behaviour

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`
- `sh format_check.sh`

------
https://chatgpt.com/codex/tasks/task_e_685c0ecc6e70832f8c59c682709dcf58