### PR TITLE
Add backup metadata tests

### DIFF
--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -147,6 +147,7 @@ def test_active_flag_on_backup_and_restore(tmp_path, monkeypatch):
     resp = client.get("/api/backups")
     data = {item["name"]: item for item in resp.get_json()}
     assert data[b1]["active"] is True
+    assert sum(1 for item in data.values() if item["active"]) == 1
 
 
 def test_last_updated_updates_on_change(tmp_path, monkeypatch):
@@ -174,4 +175,42 @@ def test_last_updated_updates_on_change(tmp_path, monkeypatch):
 
     meta = json.load(meta_file.open())
     assert meta[name]["last_updated"] != initial
+
+
+def test_create_backup_route_without_description_fails(tmp_path, monkeypatch):
+    server = _load_server(monkeypatch, tmp_path)
+    Path(os.environ["DB_PATH"]).touch()
+    client = server.app.test_client()
+    for payload in [{}, {"description": ""}, {"description": "   "}]:
+        resp = client.post("/api/backups", json=payload)
+        assert resp.status_code == 400
+
+
+def test_restore_updates_last_updated(tmp_path, monkeypatch):
+    monkeypatch.setenv("BACKUP_DIR", str(tmp_path / "backups"))
+    monkeypatch.setenv("DATA_DIR", str(tmp_path / "data"))
+    monkeypatch.setenv("DB_PATH", str(tmp_path / "data/db.sqlite"))
+
+    data_dir = Path(os.environ["DATA_DIR"])
+    data_dir.mkdir(parents=True)
+    with open(data_dir / "latest.json", "w") as f:
+        json.dump({"a": 1}, f)
+    with open(Path(os.environ["DB_PATH"]), "w") as f:
+        f.write("db")
+
+    server = importlib.reload(importlib.import_module("server"))
+    name = os.path.basename(server.manual_backup("one"))
+    meta_file = Path(os.environ["BACKUP_DIR"]) / "metadata.json"
+    meta = json.load(meta_file.open())
+    before = meta[name]["last_updated"]
+
+    import time
+    time.sleep(1)
+
+    client = server.app.test_client()
+    resp = client.post("/api/restore", json={"name": name})
+    assert resp.status_code == 200
+
+    meta = json.load(meta_file.open())
+    assert meta[name]["last_updated"] != before
 


### PR DESCRIPTION
## Summary
- expand backup tests
- cover description check, active flag count, and timestamp update

## Testing
- `sh format_check.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c11b89c14832f8b76178f02254aac