### PR TITLE
Add socket.io proxy and restart docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ siguientes comandos:
 docker compose down --volumes
 docker compose build
 docker compose up -d
+docker compose restart docs  # Recarga Nginx con la nueva configuración
 ```
 
 Tras iniciar los contenedores abre `http://<HOST>:8080/index.html#/backup`

--- a/nginx.conf
+++ b/nginx.conf
@@ -18,6 +18,13 @@ server {
         proxy_read_timeout 120s;
     }
 
+    location /socket.io/ {
+        proxy_pass http://backend:5000/socket.io/;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "Upgrade";
+    }
+
     # Serve index.html for all SPA routes
     location / {
         try_files $uri $uri/ /index.html;


### PR DESCRIPTION
## Summary
- proxy websocket connections with a new `/socket.io/` block
- document the need to restart nginx after `docker compose up`

## Testing
- `bash format_check.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c1bc0d7e0832f9e4b9cca931a9135