### PR TITLE
Fix nginx upgrade headers

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -11,8 +11,6 @@ server {
     location /api/ {
         proxy_pass http://backend:5000/api/;
         proxy_http_version 1.1;
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection "Upgrade";
         proxy_connect_timeout 5s;
         proxy_send_timeout 120s;
         proxy_read_timeout 120s;


### PR DESCRIPTION
## Summary
- remove websocket headers from `/api/` block in `nginx.conf`
- keep these headers under `/socket.io/`

## Testing
- `sh format_check.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c1ca41d80832fbb33563cbfd96516