### PR TITLE
Add .dockerignore to reduce build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,33 @@
+# Exclude git history and metadata
+.git
+
+# Python cache and virtual envs
+__pycache__/
+*.py[cod]
+
+# pytest cache
+.pytest_cache/
+
+# test and documentation directories
+tests/
+docs/
+
+# Node modules and package lock (if any)
+node_modules/
+
+# Temporary or development files
+*.log
+*.tmp
+*.swp
+
+# Build artifacts
+*.egg-info/
+
+# Other development directories
+.vscode/
+.idea/
+.env
+.venv
+
+# Database dumps or large assets not needed
+BASE DE DATOS/


### PR DESCRIPTION
## Summary
- create `.dockerignore` to strip development files from Docker build

## Testing
- `python` check of archive sizes to mimic Docker context reduction
- `docker --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c31ff590c832fa93bc49fd159f0ba