### PR TITLE
Update nginx upstream

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -9,7 +9,7 @@ server {
     index index.html;
 
     location /api/ {
-        proxy_pass http://backend:5000/api/;
+        proxy_pass http://app:5000/api/;
         proxy_http_version 1.1;
         proxy_connect_timeout 5s;
         proxy_send_timeout 120s;
@@ -17,7 +17,7 @@ server {
     }
 
     location /socket.io/ {
-        proxy_pass http://backend:5000/socket.io/;
+        proxy_pass http://app:5000/socket.io/;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "Upgrade";


### PR DESCRIPTION
## Summary
- proxy to `app:5000` in `nginx.conf`

## Testing
- `sh format_check.sh`
- `pytest -q`
- `curl -f -I http://localhost:5000/health`
- `curl -v http://localhost/socket.io/socket.io.js` *(fails: 400 BAD REQUEST)*

------
https://chatgpt.com/codex/tasks/task_e_685c32c5f920832fae8e5b7e1fa9e2c9