### PR TITLE
Fix docs folder ignoring

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,7 +10,9 @@ __pycache__/
 
 # test and documentation directories
 tests/
-docs/
+docs/*
+!docs/imagenes_sinoptico/
+!docs/imagenes_sinoptico/**
 
 # Node modules and package lock (if any)
 node_modules/


### PR DESCRIPTION
## Summary
- include `docs/imagenes_sinoptico` in Docker build context

## Testing
- `sh format_check.sh`
- `pytest -q`
- `docker build` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685c3cb00ce8832fba82350ab9fae12b