### PR TITLE
Add project-wide .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,17 @@
+__pycache__/
+.pytest_cache/
+*.pyc
+
+node_modules/
+
+data/
+backups/
+
+# Editor directories and OS files
+.vscode/
+.idea/
+*.swp
+*.swo
+.DS_Store
+Thumbs.db
+


### PR DESCRIPTION
## Summary
- add `.gitignore` at repo root to ignore common Python artifacts, node modules, data, backups, and editor-specific files

## Testing
- `bash format_check.sh`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_685c3d636fa8832fa38ae997f3965fdd