### PR TITLE
Update docs for optional docs service

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,13 @@ El flujo recomendado para poner en marcha la aplicación es ejecutar desde Power
 docker compose up -d
 ```
 
+Por defecto se inicia únicamente el contenedor `app`. Si también quieres
+servir la carpeta `docs` mediante Nginx ejecuta:
+
+```bash
+docker compose --profile prod up -d
+```
+
 
 ## Control de versiones
 

--- a/docs/backend.md
+++ b/docs/backend.md
@@ -80,8 +80,9 @@ If the API server is unreachable, the frontend keeps working thanks to IndexedDB
 ### Docker Compose
 
 1. Ensure Docker and Docker Compose are installed.
-2. Build the image the first time with `docker-compose build`.
-3. Run `docker-compose up` from the project root.
-4. Nginx will serve the `docs/` folder on port 8080 and the API from `backend/main.py` on port 5000.
+2. Build the image the first time with `docker compose build`.
+3. Run `docker compose up` from the project root to start only the API container.
+   Add `--profile prod` to also launch the optional `docs` service.
+4. With the profile enabled, Nginx serves the `docs/` folder on port 8080 while the API from `backend/main.py` remains on port 5000.
 5. Point the frontend to `http://<host>:5000/api` as needed.
 


### PR DESCRIPTION
## Summary
- clarify `docker compose` instructions in README
- document profile usage for the docs service in backend guide

## Testing
- `bash format_check.sh`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685c45b7c888832fb46608e945d303c8