### PR TITLE
Fix docs inclusion in Docker build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,9 +10,6 @@ __pycache__/
 
 # test and documentation directories
 tests/
-docs/*
-!docs/imagenes_sinoptico/
-!docs/imagenes_sinoptico/**
 
 # Node modules and package lock (if any)
 node_modules/


### PR DESCRIPTION
## Summary
- remove `docs` ignore rules from `.dockerignore`

## Testing
- `pytest -q`
- `curl -I http://localhost:5000/index.html` (after running `server.py` directly)
- `docker build -t barack .` *(fails: cannot connect to Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_685c45a7dd50832fb30702efdf7ef4b8