### PR TITLE
Update SPA URL instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,11 +106,16 @@ docker compose up --build -d
 ```
 
 Tras iniciar los contenedores abre
-`http://desktop-14jg95b:8080/index.html#/home` (reemplaza el hostname
-según corresponda) para acceder a la aplicación. Desde la vista
-**Historial** podrás administrar respaldos. Todos los usuarios deben utilizar
-esta misma URL para que sus datos permanezcan sincronizados. Puedes verificar
-que el backend esté activo visitando `http://localhost:5000/health`.
+`http://<host>:5000/index.html#/home` (reemplaza `<host>` según
+corresponda) para acceder a la aplicación. Desde la vista **Historial**
+podrás administrar respaldos. Todos los usuarios deben utilizar esta misma
+URL para que sus datos permanezcan sincronizados. Puedes verificar que el
+backend esté activo visitando `http://localhost:5000/health`.
+
+Si prefieres servir los archivos estáticos con Nginx puedes iniciar el
+servicio `docs` ejecutando `docker compose --profile prod up -d`. En ese caso
+la SPA se encontrará disponible en
+`http://<host>:8080/index.html#/home`.
 
 > **Nota:** Asegúrate de que las carpetas `./data` y `./backups` existan y
 > cuenten con permisos de escritura antes de ejecutar `docker compose up`.
@@ -120,8 +125,10 @@ que el backend esté activo visitando `http://localhost:5000/health`.
 > “Bad Gateway”.
 
 Todas las computadoras de la red deben abrir la URL
-`http://desktop-14jg95b:8080/index.html#/home` o la equivalente con su
-hostname. El backend permite solicitudes desde esta URL de forma predeterminada.
+`http://<host>:5000/index.html#/home` o la equivalente con su hostname.
+El backend permite solicitudes desde esta URL de forma predeterminada. Si se
+inicia el servicio `docs` con Nginx, la ruta alterna será
+`http://<host>:8080/index.html#/home`.
 Si la interfaz se aloja en otro hostname, añade esa dirección en la variable de
 entorno `ALLOWED_ORIGINS` dentro de `docker-compose.yml` o al ejecutar
 `server.py` para evitar errores de CORS.


### PR DESCRIPTION
## Summary
- clarify that the SPA runs on `http://<host>:5000/index.html#/home`
- describe optional nginx service via `--profile prod`

## Testing
- `bash format_check.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c45b0a1dc832fb5541a91ed23a8d6