### PR TITLE
Update caching headers for HTML/JS

### DIFF
--- a/server.py
+++ b/server.py
@@ -180,7 +180,10 @@ def static_proxy(path):
         alt = file_path + ".html"
         if os.path.exists(alt):
             path += ".html"
-    return send_from_directory(app.static_folder, path)
+    resp = send_from_directory(app.static_folder, path)
+    if path.endswith((".html", ".js")):
+        resp.headers["Cache-Control"] = "no-store"
+    return resp
 
 
 @app.route("/api/data", methods=["GET", "POST"])


### PR DESCRIPTION
## Summary
- adjust `static_proxy` so HTML and JS files return `Cache-Control: no-store`

## Testing
- `bash format_check.sh`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685c4b8d400c832fa3f0fe48ab649caf