### PR TITLE
Fix update conflict logic

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -389,9 +389,7 @@ def update_row(table, item_id, data):
     if not row:
         conn.close()
         return None, "not found", 404
-    if row["updated_at"] != data.get("updated_at") or row["version"] != data.get(
-        "version"
-    ):
+    if row["version"] != data.get("version"):
         conn.close()
         return None, "conflict", 409
     new_version = row["version"] + 1

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -59,3 +59,18 @@ def test_post_client_and_fetch_list():
     assert resp.status_code == 200
     items = resp.get_json()["data"]
     assert any(item["codigo"] == "CNEW" for item in items)
+
+
+def test_patch_conflict_on_version():
+    client = main.app.test_client()
+    db = main.get_db()
+    db.execute(
+        "INSERT INTO Cliente(codigo,nombre,updated_at) VALUES('C3','A','2024-01-01')"
+    )
+    db.execute(
+        "INSERT INTO Producto(codigo,descripcion,cliente_id,peso,updated_at,version) VALUES('P3','Prod',1,1,'2024-01-01',1)"
+    )
+    db.commit()
+    payload = {"updated_at": "wrong", "version": 2, "descripcion": "Cambio"}
+    resp = client.patch("/api/productos_db/1", json=payload)
+    assert resp.status_code == 409


### PR DESCRIPTION
## Summary
- only check the `version` field when detecting update conflicts
- test that mismatched versions return HTTP 409

## Testing
- `sh format_check.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c4c8bd984832fbc8de96797ab40e3