### PR TITLE
Simplify SocketIO initialization

### DIFF
--- a/server.py
+++ b/server.py
@@ -43,22 +43,9 @@ IMAGES_DIR = os.path.join(app.static_folder, "imagenes_sinoptico")
 ASSET_DIRS = ["imagenes_sinoptico", "images"]
 from flask_socketio import SocketIO
 
-# Permit requests from the development front-end and the local API consumer
-# Added desktop hostname so the SPA works out of the box when served there
-default_origins = [
-    "http://192.168.1.233:8080",
-    "http://localhost:8080",
-    "http://desktop-14jg95b:8080",
-]
-orig_env = os.getenv("ALLOWED_ORIGINS")
-origins = (
-    [o.strip() for o in orig_env.split(",") if o.strip()]
-    if orig_env
-    else default_origins
-)
-socketio = SocketIO(app, async_mode="eventlet", cors_allowed_origins=origins)
+socketio = SocketIO(app, cors_allowed_origins="*")
 clients = {}
-CORS(app, resources={r"/api/*": {"origins": origins}})
+CORS(app)
 
 
 @app.get("/health")


### PR DESCRIPTION
## Summary
- use `SocketIO(app, cors_allowed_origins="*")`
- drop complex CORS origin handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c755aa7a4832fba425ca95657d05f