### PR TITLE
Handle real-time history updates

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -562,7 +562,9 @@ def _validate_simple_name(name: str) -> str | None:
     if base != name or not base.endswith(".db"):
         return None
     full = os.path.abspath(os.path.join(BACKUP_DIR, base))
-    if os.path.commonpath([full, os.path.abspath(BACKUP_DIR)]) != os.path.abspath(BACKUP_DIR):
+    if os.path.commonpath([full, os.path.abspath(BACKUP_DIR)]) != os.path.abspath(
+        BACKUP_DIR
+    ):
         return None
     return base
 
@@ -716,8 +718,7 @@ def create_simple_backup_route():
 @app.get("/api/simple-backups")
 def list_simple_backups_route():
     files = sorted(
-        os.path.basename(f)
-        for f in glob.glob(os.path.join(BACKUP_DIR, "backup_*.db"))
+        os.path.basename(f) for f in glob.glob(os.path.join(BACKUP_DIR, "backup_*.db"))
     )
     return jsonify(files)
 

--- a/docs/js/history.js
+++ b/docs/js/history.js
@@ -1,4 +1,7 @@
+
 'use strict';
+
+const socket = io();
 
 const BASE =
   (localStorage.getItem('apiUrl') || '').replace(/\/api\/data$/, '') ||
@@ -31,8 +34,9 @@ document.addEventListener('DOMContentLoaded', () => {
       tbody.innerHTML = '';
       data.slice().reverse().forEach(entry => {
         const tr = document.createElement('tr');
+        const ts = entry.ts ? new Date(entry.ts).toLocaleString() : '';
         tr.innerHTML =
-          `<td>${entry.ts || ''}</td>` +
+          `<td>${ts}</td>` +
           `<td>${entry.summary || ''}</td>`;
         tbody.appendChild(tr);
       });
@@ -150,4 +154,11 @@ document.addEventListener('DOMContentLoaded', () => {
   loadBackups();
   loadSimple();
   loadHistory();
+
+  socket.on('data_updated', () => {
+    loadHistory();
+    if (typeof loadClients === 'function') loadClients();
+  });
+
+  socket.on('connect_error', e => console.error('WS error', e));
 });

--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -245,6 +245,7 @@ def test_simple_backup_and_restore(tmp_path, monkeypatch):
     backend = importlib.reload(importlib.import_module("backend.main"))
     db = Path(os.environ["DB_PATH"])
     import sqlite3
+
     conn = sqlite3.connect(db)
     conn.execute("CREATE TABLE t(id INTEGER)")
     conn.commit()


### PR DESCRIPTION
## Summary
- create a Socket.IO client in `history.js`
- refresh history and client lists when `data_updated` fires
- log websocket connection errors
- format timestamps to locale strings
- apply Python formatting fixes for tests

## Testing
- `bash format_check.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c772d91ac832f960d598984b442a3