### PR TITLE
Replace placeholder API base URL with dynamic origin

### DIFF
--- a/docs/js/app.js
+++ b/docs/js/app.js
@@ -1,9 +1,15 @@
 import { logout } from './session.js';
 window.logout = logout;
 
+// Derive API base automatically when running outside GitHub Pages
 const API_BASE = window.location.hostname.includes('github.io')
   ? null
-  : 'http://TU_IP:5000';
+  : window.location.origin;
+
+// Expose the value for other modules if not already defined
+if (!window.API_BASE) {
+  window.API_BASE = API_BASE;
+}
 
 // Toggle tema
 const btnTheme = document.querySelector('.theme-toggle');


### PR DESCRIPTION
## Summary
- derive the base API URL at runtime using `window.location.origin`
- expose `window.API_BASE` only when not already defined

## Testing
- `bash format_check.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d319f40d8832f92b3f6932704219e