### PR TITLE
Insert socket.io loader for history page

### DIFF
--- a/docs/history.html
+++ b/docs/history.html
@@ -52,6 +52,7 @@
       <tbody></tbody>
     </table>
   </section>
+  <script src="https://cdn.socket.io/4.7.2/socket.io.min.js" defer></script>
   <script type="module" src="js/authGuard.js"></script>
   <script type="module" src="js/nav.js" defer></script>
   <script type="module" src="js/history.js"></script>


### PR DESCRIPTION
## Summary
- load Socket.IO client on `history.html` before all module scripts

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d3c962b54832fa9fa762318514608