### PR TITLE
Improve Socket.IO fallbacks

### DIFF
--- a/docs/js/dataService.js
+++ b/docs/js/dataService.js
@@ -172,7 +172,13 @@ async function syncNow() {
 let socket;
 let sse;
 if (hasWindow && SOCKET_URL && typeof io !== 'undefined') {
-  socket = io(SOCKET_URL);
+  socket = io(SOCKET_URL, { transports: ['websocket'] });
+  socket.on('connect_error', err => alert('WS error: ' + err.message));
+} else if (hasWindow) {
+  alert('Socket.IO no disponible');
+}
+
+if (socket) {
   socket.on('data_updated', async () => {
     if (!API_URL) return;
     try {

--- a/docs/js/history.js
+++ b/docs/js/history.js
@@ -1,7 +1,9 @@
 
 'use strict';
 
-const socket = io();
+const socket = (typeof io !== 'undefined')
+  ? io({ transports: ['websocket'] })
+  : (alert('Socket.IO no disponible'), null);
 
 
 function showToast(msg) {
@@ -194,10 +196,12 @@ document.addEventListener('DOMContentLoaded', () => {
   loadSimple();
   loadHistory();
 
-  socket.on('data_updated', () => {
-    loadHistory();
-    if (typeof loadClients === 'function') loadClients();
-  });
+  if (socket) {
+    socket.on('data_updated', () => {
+      loadHistory();
+      if (typeof loadClients === 'function') loadClients();
+    });
 
-  socket.on('connect_error', e => console.error('WS error', e));
+    socket.on('connect_error', e => console.error('WS error', e));
+  }
 });

--- a/tests/test_server_db.py
+++ b/tests/test_server_db.py
@@ -18,8 +18,12 @@ def test_server_post_client_and_fetch_list():
 
 def test_server_patch_conflict_on_version():
     db = main.get_db()
-    db.execute("INSERT INTO Cliente(codigo,nombre,updated_at) VALUES('SC2','A','2024-01-01')")
-    db.execute("INSERT INTO Producto(codigo,descripcion,cliente_id,peso,updated_at,version) VALUES('SP2','Prod',1,1,'2024-01-01',1)")
+    db.execute(
+        "INSERT INTO Cliente(codigo,nombre,updated_at) VALUES('SC2','A','2024-01-01')"
+    )
+    db.execute(
+        "INSERT INTO Producto(codigo,descripcion,cliente_id,peso,updated_at,version) VALUES('SP2','Prod',1,1,'2024-01-01',1)"
+    )
     db.commit()
     server = importlib.reload(importlib.import_module("server"))
     client = server.app.test_client()


### PR DESCRIPTION
## Summary
- adjust websocket initialization in `dataService.js`
- adjust websocket initialization in `history.js`
- conditionally attach websocket handlers
- format `tests/test_server_db.py` to satisfy linting

## Testing
- `sh format_check.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d3c97a7d8832fa4f17b921ddebedb