### PR TITLE
Switch docs to socket.io CDN

### DIFF
--- a/docs/arbol.html
+++ b/docs/arbol.html
@@ -90,7 +90,7 @@
     </div>
   </div>
   <script src="lib/dexie.min.js" defer></script>
-  <script src="./socket.io/socket.io.js" defer></script>
+  <script src="https://cdn.socket.io/4.7.2/socket.io.min.js" defer></script>
   <script type="module" src="js/authGuard.js"></script>
   <script>
     window.API_BASE = 'http://desktop-14jg95b:5000';

--- a/docs/asistente.html
+++ b/docs/asistente.html
@@ -122,7 +122,7 @@
     </aside>
   </div> <!-- wizard-layout -->
   <script src="lib/dexie.min.js" defer></script>
-  <script src="./socket.io/socket.io.js" defer></script>
+  <script src="https://cdn.socket.io/4.7.2/socket.io.min.js" defer></script>
   <script type="module" src="js/authGuard.js"></script>
   <script>
     window.API_BASE = 'http://desktop-14jg95b:5000';

--- a/docs/index.html
+++ b/docs/index.html
@@ -29,7 +29,7 @@
   </dialog>
   <script src="lib/dexie.min.js" defer></script>
   <script src="lib/fuse.min.js" defer></script>
-  <script src="./socket.io/socket.io.js" defer></script>
+  <script src="https://cdn.socket.io/4.7.2/socket.io.min.js" defer></script>
   <script type="module" src="js/authGuard.js"></script>
   <script type="module" src="js/nav.js" defer></script>
   <script type="module" src="js/router.js" defer></script>

--- a/docs/maestro.html
+++ b/docs/maestro.html
@@ -93,7 +93,7 @@
     </p>
   </noscript>
   <script src="lib/dexie.min.js" defer></script>
-  <script src="./socket.io/socket.io.js" defer></script>
+  <script src="https://cdn.socket.io/4.7.2/socket.io.min.js" defer></script>
   <script type="module" src="js/authGuard.js"></script>
   <script type="module" src="js/nav.js" defer></script>
   <script>

--- a/docs/registros.html
+++ b/docs/registros.html
@@ -125,7 +125,7 @@
   </dialog>
   <script src="lib/dexie.min.js" defer></script>
   <script src="lib/tabulator/tabulator.min.js" defer></script>
-  <script src="./socket.io/socket.io.js" defer></script>
+  <script src="https://cdn.socket.io/4.7.2/socket.io.min.js" defer></script>
   <script type="module" src="js/authGuard.js"></script>
   <script type="module" src="js/nav.js" defer></script>
   <script>

--- a/docs/sinoptico.html
+++ b/docs/sinoptico.html
@@ -63,7 +63,7 @@
   </section>
   <script src="lib/dexie.min.js" defer></script>
   <script src="lib/fuse.min.js" defer></script>
-  <script src="./socket.io/socket.io.js" defer></script>
+  <script src="https://cdn.socket.io/4.7.2/socket.io.min.js" defer></script>
   <script type="module" src="js/authGuard.js"></script>
   <script type="module" src="js/nav.js" defer></script>
   <script src="lib/xlsx.full.noeval.js" defer></script>

--- a/tests/test_server_db.py
+++ b/tests/test_server_db.py
@@ -18,8 +18,12 @@ def test_server_post_client_and_fetch_list():
 
 def test_server_patch_conflict_on_version():
     db = main.get_db()
-    db.execute("INSERT INTO Cliente(codigo,nombre,updated_at) VALUES('SC2','A','2024-01-01')")
-    db.execute("INSERT INTO Producto(codigo,descripcion,cliente_id,peso,updated_at,version) VALUES('SP2','Prod',1,1,'2024-01-01',1)")
+    db.execute(
+        "INSERT INTO Cliente(codigo,nombre,updated_at) VALUES('SC2','A','2024-01-01')"
+    )
+    db.execute(
+        "INSERT INTO Producto(codigo,descripcion,cliente_id,peso,updated_at,version) VALUES('SP2','Prod',1,1,'2024-01-01',1)"
+    )
     db.commit()
     server = importlib.reload(importlib.import_module("server"))
     client = server.app.test_client()


### PR DESCRIPTION
## Summary
- use CDN for Socket.IO across user-facing docs
- run formatter on tests to pass checks

## Testing
- `./format_check.sh`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_685d3c9c96d0832f939707a512540917