### PR TITLE
Update README URL note

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,8 @@ Si la interfaz se aloja en otro hostname, añade esa dirección en la variable d
 entorno `ALLOWED_ORIGINS` dentro de `docker-compose.yml` o al ejecutar
 `server.py` para evitar errores de CORS.
 
+> **Nota:** Si tu dispositivo no resuelve el hostname, abrí la SPA con la IP local del servidor, por ejemplo `http://192.168.x.y:8080/index.html#/home`.
+
 ### Configurar `ALLOWED_ORIGINS`
 
 Si no defines esta variable, `server.py` utilizará una lista de orígenes


### PR DESCRIPTION
## Summary
- clarify troubleshooting when hostname resolution fails

## Testing
- `pytest -q`
- `sh format_check.sh` *(fails: would reformat tests/test_server_db.py)*

------
https://chatgpt.com/codex/tasks/task_e_685d3ca91ce0832f987978fe63c665cc