### PR TITLE
Rename quick backup button

### DIFF
--- a/docs/history.html
+++ b/docs/history.html
@@ -28,7 +28,7 @@
   </section>
 
   <section class="simple-backup">
-    <button id="simpleCreate" type="button">Crear backup rápido</button>
+    <button id="simpleCreate" type="button">Backup exprés</button>
     <select id="simpleList"></select>
     <button id="simpleRestore" type="button">Restaurar</button>
   </section>

--- a/docs/js/history.js
+++ b/docs/js/history.js
@@ -157,7 +157,7 @@ document.addEventListener('DOMContentLoaded', () => {
   simpleCreate?.addEventListener('click', async () => {
     const resp = await fetch('/api/simple-backup', { method: 'POST' });
     if (!resp.ok) {
-      showToast('Error al crear respaldo rápido');
+      showToast('Error al crear backup exprés');
       return;
     }
     loadSimple();


### PR DESCRIPTION
## Summary
- rename the quick backup button to **Backup exprés**
- update toast message to match new naming

## Testing
- `bash format_check.sh`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685d44230e40832fbcdb5e4bab000a74