### PR TITLE
fix: cache-control y reconexión websocket

### DIFF
--- a/docs/js/dataService.js
+++ b/docs/js/dataService.js
@@ -172,7 +172,7 @@ async function syncNow() {
 let socket;
 let sse;
 if (hasWindow && SOCKET_URL && typeof io !== 'undefined') {
-  socket = io(SOCKET_URL, { transports: ['websocket'] });
+  socket = io(SOCKET_URL, { transports: ['websocket'], reconnection: true });
   socket.on('connect_error', err => alert('WS error: ' + err.message));
 } else if (hasWindow) {
   alert('Socket.IO no disponible');
@@ -199,6 +199,11 @@ if (socket) {
   });
   socket.on('product_updated', row => {
     applyProductUpdate(row);
+  });
+
+  socket.on('reconnect', () => {
+    if (typeof loadClients === 'function') loadClients();
+    if (typeof loadHistory === 'function') loadHistory();
   });
 }
 

--- a/docs/js/history.js
+++ b/docs/js/history.js
@@ -2,7 +2,7 @@
 'use strict';
 
 const socket = (typeof io !== 'undefined')
-  ? io({ transports: ['websocket'] })
+  ? io({ transports: ['websocket'], reconnection: true })
   : (alert('Socket.IO no disponible'), null);
 
 
@@ -200,6 +200,11 @@ document.addEventListener('DOMContentLoaded', () => {
     socket.on('data_updated', () => {
       loadHistory();
       if (typeof loadClients === 'function') loadClients();
+    });
+
+    socket.on('reconnect', () => {
+      if (typeof loadClients === 'function') loadClients();
+      loadHistory();
     });
 
     socket.on('connect_error', e => console.error('WS error', e));

--- a/server.py
+++ b/server.py
@@ -66,6 +66,12 @@ def add_security_headers(resp):
     return resp
 
 
+@app.after_request
+def no_cache(resp):
+    resp.headers["Cache-Control"] = "no-store"
+    return resp
+
+
 @app.get("/health")
 def health():
     return jsonify({"status": "ok"})


### PR DESCRIPTION
## Summary
- add no_cache hook to always return `Cache-Control: no-store`
- connect Socket.IO with reconnection support
- refresh clients and history on reconnect events

## Testing
- `sh format_check.sh`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685d44274d10832fb82ad4e1959c0f05