### PR TITLE
Improve history view, cache headers and socket tests

### DIFF
--- a/docs/arbol.html
+++ b/docs/arbol.html
@@ -92,12 +92,6 @@
   <script src="lib/dexie.min.js" defer></script>
   <script src="https://cdn.socket.io/4.7.2/socket.io.min.js" defer></script>
   <script type="module" src="js/authGuard.js"></script>
-  <script>
-    window.API_BASE = 'http://desktop-14jg95b:5000';
-    if (!localStorage.getItem('apiUrl')) {
-      localStorage.setItem('apiUrl', window.API_BASE + '/api/data');
-    }
-  </script>
 <script type="module" src="js/dataService.js" defer></script>
   <script type="module" src="js/arbol.js" defer></script>
   <script type="module" src="js/ui/animations.js" defer></script>

--- a/docs/asistente.html
+++ b/docs/asistente.html
@@ -124,12 +124,6 @@
   <script src="lib/dexie.min.js" defer></script>
   <script src="https://cdn.socket.io/4.7.2/socket.io.min.js" defer></script>
   <script type="module" src="js/authGuard.js"></script>
-  <script>
-    window.API_BASE = 'http://desktop-14jg95b:5000';
-    if (!localStorage.getItem('apiUrl')) {
-      localStorage.setItem('apiUrl', window.API_BASE + '/api/data');
-    }
-  </script>
   <script type="module" src="js/dataService.js" defer></script>
   <script type="module" src="js/asistente.js" defer></script>
   <script type="module" src="js/ui/renderer.js" defer></script>

--- a/docs/assets/styles.css
+++ b/docs/assets/styles.css
@@ -1678,23 +1678,8 @@ body.sidebar-open .sidebar-toggle {
   background: rgba(255, 255, 255, 0.2);
 }
 
-.sidebar-overlay {
-  position: fixed;
-  inset: 0;
-  background: rgba(0, 0, 0, 0.4);
-  opacity: 0;
-  visibility: hidden;
-  transition: opacity var(--anim-duration) var(--anim-ease);
-  z-index: 1099;
-}
-
 body.sidebar-open .dataset-sidebar {
   left: 0;
-}
-
-body.sidebar-open .sidebar-overlay {
-  opacity: 1;
-  visibility: visible;
 }
 
 /* Admin menu buttons */

--- a/docs/history.html
+++ b/docs/history.html
@@ -55,7 +55,7 @@
   <script src="https://cdn.socket.io/4.7.2/socket.io.min.js" defer></script>
   <script type="module" src="js/authGuard.js"></script>
   <script type="module" src="js/nav.js" defer></script>
-  <script type="module" src="js/history.js"></script>
+  <script type="module" src="js/history.js" defer></script>
   <script type="module" src="js/ui/animations.js" defer></script>
   <script type="module" src="js/backButton.js" defer></script>
   <script type="module" src="js/app.js" defer></script>

--- a/docs/index.html
+++ b/docs/index.html
@@ -33,12 +33,6 @@
   <script type="module" src="js/authGuard.js"></script>
   <script type="module" src="js/nav.js" defer></script>
   <script type="module" src="js/router.js" defer></script>
-  <script>
-    window.API_BASE = 'http://desktop-14jg95b:5000';
-    if (!localStorage.getItem('apiUrl')) {
-      localStorage.setItem('apiUrl', window.API_BASE + '/api/data');
-    }
-  </script>
   <script type="module" src="js/dataService.js" defer></script>
   <script src="lib/xlsx.full.noeval.js" defer></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js" defer></script>

--- a/docs/js/history.js
+++ b/docs/js/history.js
@@ -42,9 +42,13 @@ document.addEventListener('DOMContentLoaded', () => {
       }
       const data = await resp.json();
       tbody.innerHTML = '';
+      const fmt = new Intl.DateTimeFormat('es-AR', {
+        dateStyle: 'short',
+        timeStyle: 'short'
+      });
       data.slice().reverse().forEach(entry => {
         const tr = document.createElement('tr');
-        const ts = entry.ts ? dayjs(entry.ts).format('DD/MM/YYYY HH:mm') : '';
+        const ts = entry.ts ? fmt.format(new Date(entry.ts)) : '';
         tr.innerHTML =
           `<td>${ts}</td>` +
           `<td>${entry.summary || ''}</td>`;
@@ -108,12 +112,11 @@ document.addEventListener('DOMContentLoaded', () => {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ description })
     });
-    if (resp.ok && statusSpan) {
-      statusSpan.textContent = 'Backup creado';
-      statusSpan.classList.remove('error');
-      statusSpan.classList.add('show');
-      setTimeout(() => statusSpan.classList.remove('show'), 3000);
-    } else if (!resp.ok && statusSpan) {
+    if (resp.ok) {
+      showToast('Backup creado');
+      loadHistory();
+      if (typeof loadClients === 'function') loadClients();
+    } else if (statusSpan) {
       if (resp.status === 409) {
         alert('Conflicto al crear backup. Recargá la página.');
       }
@@ -150,7 +153,7 @@ document.addEventListener('DOMContentLoaded', () => {
       return;
     }
     if (resp.ok) {
-      alert('Backup restaurado con éxito');
+      showToast('Backup restaurado');
       if (typeof loadClients === 'function') loadClients();
       loadHistory();
     } else {
@@ -164,7 +167,10 @@ document.addEventListener('DOMContentLoaded', () => {
       showToast('Error al crear backup exprés');
       return;
     }
+    showToast('Backup exprés creado');
     loadSimple();
+    loadHistory();
+    if (typeof loadClients === 'function') loadClients();
   });
 
   simpleRestore?.addEventListener('click', async () => {
@@ -179,8 +185,13 @@ document.addEventListener('DOMContentLoaded', () => {
       alert('Conflicto al restaurar. Recargá la página.');
       return;
     }
-    if (resp.ok) location.reload();
-    else showToast('Error al restaurar respaldo');
+    if (resp.ok) {
+      showToast('Backup exprés restaurado');
+      loadHistory();
+      if (typeof loadClients === 'function') loadClients();
+    } else {
+      showToast('Error al restaurar respaldo');
+    }
   });
 
   deleteBtn?.addEventListener('click', async () => {
@@ -191,7 +202,10 @@ document.addEventListener('DOMContentLoaded', () => {
       showToast('Error al eliminar backup');
       return;
     }
+    showToast('Backup eliminado');
     loadBackups();
+    loadHistory();
+    if (typeof loadClients === 'function') loadClients();
   });
 
   applyBtn?.addEventListener('click', loadHistory);

--- a/docs/js/interactiveTable.js
+++ b/docs/js/interactiveTable.js
@@ -173,7 +173,6 @@ function setupFilterButtons() {
 function setupSidebar() {
   const toggle = document.getElementById('sidebarToggle');
   const sidebar = document.getElementById('datasetSidebar');
-  const overlay = document.getElementById('sidebarOverlay');
   if (!sidebar || !toggle) return;
   const close = () => {
     document.body.classList.remove('sidebar-open');
@@ -190,7 +189,6 @@ function setupSidebar() {
       open();
     }
   });
-  overlay && overlay.addEventListener('click', close);
   document.addEventListener('keydown', ev => {
     if (ev.key === 'Escape') close();
   });

--- a/docs/maestro.html
+++ b/docs/maestro.html
@@ -96,12 +96,6 @@
   <script src="https://cdn.socket.io/4.7.2/socket.io.min.js" defer></script>
   <script type="module" src="js/authGuard.js"></script>
   <script type="module" src="js/nav.js" defer></script>
-  <script>
-    window.API_BASE = 'http://desktop-14jg95b:5000';
-    if (!localStorage.getItem('apiUrl')) {
-      localStorage.setItem('apiUrl', window.API_BASE + '/api/data');
-    }
-  </script>
   <script type="module" src="js/dataService.js" defer></script>
   <script src="lib/xlsx.full.noeval.js" defer></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js" defer></script>

--- a/docs/registros.html
+++ b/docs/registros.html
@@ -16,7 +16,6 @@
 <body>
   <nav id="nav-placeholder"></nav>
   <button id="sidebarToggle" class="sidebar-toggle" type="button" aria-label="Abrir filtros">▶</button>
-  <div id="sidebarOverlay" class="sidebar-overlay"></div>
   <aside id="datasetSidebar" class="dataset-sidebar">
     <button data-filter="" class="active">Todos</button>
     <button data-filter="Cliente">Clientes</button>
@@ -128,12 +127,6 @@
   <script src="https://cdn.socket.io/4.7.2/socket.io.min.js" defer></script>
   <script type="module" src="js/authGuard.js"></script>
   <script type="module" src="js/nav.js" defer></script>
-  <script>
-    window.API_BASE = 'http://desktop-14jg95b:5000';
-    if (!localStorage.getItem('apiUrl')) {
-      localStorage.setItem('apiUrl', window.API_BASE + '/api/data');
-    }
-  </script>
   <script type="module" src="js/dataService.js" defer></script>
   <script type="module" src="js/interactiveTable.js" defer></script>
   <script type="module" src="js/ui/animations.js" defer></script>

--- a/docs/sinoptico.html
+++ b/docs/sinoptico.html
@@ -69,12 +69,6 @@
   <script src="lib/xlsx.full.noeval.js" defer></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js" defer></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf-autotable/3.5.28/jspdf.plugin.autotable.min.js" defer></script>
-  <script>
-    window.API_BASE = 'http://desktop-14jg95b:5000';
-    if (!localStorage.getItem('apiUrl')) {
-      localStorage.setItem('apiUrl', window.API_BASE + '/api/data');
-    }
-  </script>
   <script type="module" src="js/dataService.js" defer></script>
   <script type="module" src="js/views/sinoptico.js" defer></script>
   <script type="module" src="js/ui/renderer.js" defer></script>

--- a/nginx.conf
+++ b/nginx.conf
@@ -23,6 +23,10 @@ server {
         proxy_set_header Connection "Upgrade";
     }
 
+    location ~* \.(?:js|css|html)$ {
+        add_header Cache-Control "no-store";
+    }
+
     # Serve index.html for all SPA routes
     location / {
         try_files $uri $uri/ /index.html;

--- a/tests/test_socketio_crud.py
+++ b/tests/test_socketio_crud.py
@@ -1,0 +1,32 @@
+import importlib
+import os
+from pathlib import Path
+
+
+def test_socketio_events_on_crud(tmp_path, monkeypatch):
+    monkeypatch.setenv("DATA_DIR", str(tmp_path / "data"))
+    monkeypatch.setenv("BACKUP_DIR", str(tmp_path / "backups"))
+    monkeypatch.setenv("DB_PATH", str(tmp_path / "data/db.sqlite"))
+    server = importlib.reload(importlib.import_module("server"))
+
+    client = server.app.test_client()
+    sio = server.socketio.test_client(server.app)
+
+    resp = client.post("/api/clientes", json={"codigo": "C", "nombre": "N"})
+    assert resp.status_code == 200
+    assert any(e["name"] == "data_updated" for e in sio.get_received())
+    data = resp.get_json()["data"]
+
+    payload = {
+        "nombre": "N2",
+        "updated_at": data["updated_at"],
+        "version": data["version"],
+    }
+    resp = client.patch(f"/api/clientes/{data['id']}", json=payload)
+    assert resp.status_code == 200
+    assert any(e["name"] == "data_updated" for e in sio.get_received())
+
+    resp = client.delete(f"/api/clientes/{data['id']}")
+    assert resp.status_code == 200
+    assert any(e["name"] == "data_updated" for e in sio.get_received())
+    sio.disconnect()

--- a/tools/verify_headless.py
+++ b/tools/verify_headless.py
@@ -17,7 +17,10 @@ else:
 
 # prepare data and backup
 requests.post("http://localhost:5000/api/data", json={})
-requests.post("http://localhost:5000/api/clientes", json={"codigo": "C1", "nombre": "Test", "user": "admin"})
+requests.post(
+    "http://localhost:5000/api/clientes",
+    json={"codigo": "C1", "nombre": "Test", "user": "admin"},
+)
 resp = requests.post("http://localhost:5000/api/backups", json={"description": "auto"})
 resp.raise_for_status()
 backup_name = resp.json()["path"].split("/")[-1]
@@ -35,14 +38,16 @@ with sync_playwright() as p:
     assert page.inner_text("#createBackup").strip() == "Crear backup"
     assert page.locator("#createBackup").count() == 1
 
-    bg = page.evaluate("getComputedStyle(document.querySelector('.tabla-contenedor')).backgroundColor")
-    assert '255, 255, 255' in bg
+    bg = page.evaluate(
+        "getComputedStyle(document.querySelector('.tabla-contenedor')).backgroundColor"
+    )
+    assert "255, 255, 255" in bg
 
     rows = page.locator("#historyTable tbody tr")
     assert rows.count() >= 1
 
     page.select_option("#backupList", backup_name)
-    with page.expect_event('dialog') as d:
+    with page.expect_event("dialog") as d:
         page.click("#restoreBackup")
     assert d.value.message == "Backup restaurado con éxito"
 
@@ -50,7 +55,7 @@ with sync_playwright() as p:
     assert cache.headers.get("Cache-Control") == "no-store"
 
     # verify reconnect handler defined in history.js
-    with open('docs/js/history.js', 'r', encoding='utf-8') as f:
+    with open("docs/js/history.js", "r", encoding="utf-8") as f:
         js_content = f.read()
     assert "socket.on('reconnect'" in js_content
 


### PR DESCRIPTION
## Summary
- show readable dates without dayjs
- notify and refresh UI after backup actions
- remove outdated API_BASE snippets
- remove unused sidebar overlay
- disable caching for static files in nginx
- add socket.io event tests for CRUD

## Testing
- `sh format_check.sh`
- `pytest -q`
- `curl -s http://127.0.0.1:5000/health`

------
https://chatgpt.com/codex/tasks/task_e_685d59e19770832fba05c4f46b2c2b79