### PR TITLE
Fix Socket.IO loading

### DIFF
--- a/docs/history.html
+++ b/docs/history.html
@@ -52,7 +52,7 @@
       <tbody></tbody>
     </table>
   </section>
-  <script src="https://cdn.socket.io/4.7.2/socket.io.min.js" defer></script>
+  <script src="/socket.io/socket.io.js"></script>
   <script type="module" src="js/authGuard.js"></script>
   <script type="module" src="js/nav.js" defer></script>
   <script type="module" src="js/history.js" defer></script>


### PR DESCRIPTION
## Summary
- load Socket.IO from the local server in `history.html`
- ensure the script appears before `history.js`

## Testing
- `pytest -q`
- `sh format_check.sh`


------
https://chatgpt.com/codex/tasks/task_e_685d834d075c832f9c73f449005134b8