### PR TITLE
Update client dialog to use API

### DIFF
--- a/docs/js/newClientDialog.js
+++ b/docs/js/newClientDialog.js
@@ -1,5 +1,4 @@
 'use strict';
-import { addNode, ready } from './dataService.js';
 
 export function initNewClientDialog() {
   const dialog = document.getElementById('dlgNuevoCliente');
@@ -9,36 +8,48 @@ export function initNewClientDialog() {
   openBtn.addEventListener('click', () => dialog.showModal());
 
   const form = dialog.querySelector('form');
+  const input = dialog.querySelector('#nuevoClienteNombre');
+  const submitBtn = form?.querySelector('button[type="submit"]');
+  if (input) input.disabled = true;
+  if (submitBtn) submitBtn.disabled = true;
+
+  fetch('/api/clients')
+    .then(resp => {
+      if (resp.ok) {
+        if (input) input.disabled = false;
+        if (submitBtn) submitBtn.disabled = false;
+      }
+    })
+    .catch(() => {});
+
   const cancelBtn = dialog.querySelector('button[type="button"]');
   cancelBtn?.addEventListener('click', () => dialog.close());
 
   form?.addEventListener('submit', async ev => {
     ev.preventDefault();
-    const input = dialog.querySelector('#nuevoClienteNombre');
+    if (!input) return;
     const nombre = input.value.trim();
-    if (!nombre) return;
-    await ready;
-    await addNode({
-      ID: Date.now().toString(),
-      ParentID: '',
-      Tipo: 'Cliente',
-      Descripción: nombre,
-      Cliente: nombre,
-      Vehículo: '',
-      RefInterno: '',
-      versión: '',
-      Imagen: '',
-      Consumo: '',
-      Unidad: '',
-      Sourcing: '',
-      Código: ''
-    });
-    if (typeof window.mostrarMensaje === 'function') {
-      window.mostrarMensaje('Cliente creado con éxito', 'success');
+    if (!nombre) {
+      alert('El nombre es obligatorio');
+      return;
     }
-    input.value = '';
-    dialog.close();
-    document.dispatchEvent(new Event('sinopticoUpdated'));
+    input.disabled = true;
+    submitBtn && (submitBtn.disabled = true);
+    let resp;
+    try {
+      resp = await fetch('/api/clients', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: nombre })
+      });
+      if (!resp.ok) throw new Error('bad status');
+      input.disabled = false;
+      submitBtn && (submitBtn.disabled = false);
+      input.value = '';
+      dialog.close();
+    } catch (e) {
+      alert('Error al crear cliente');
+    }
   });
 }
 


### PR DESCRIPTION
## Summary
- fetch `/api/clients` before enabling new-client form
- POST to `/api/clients` when adding clients
- alert on empty name or failed request

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685d834fdaac832fb2892d281034626f