### PR TITLE
Update dbviewer to use new endpoints

### DIFF
--- a/docs/dbviewer.html
+++ b/docs/dbviewer.html
@@ -9,17 +9,41 @@
   <nav id="nav-placeholder"></nav>
   <main class="container">
     <h1>Base de datos</h1>
-    <p>Vista de la base de datos actual en formato JSON.</p>
-    <pre id="dbDump">Cargando...</pre>
+    <p id="errorMsg" class="error"></p>
+    <table id="dbTable"></table>
     <p>Para conocer el esquema completo puedes consultar <a href="er.svg" target="_blank">er.svg</a>.</p>
   </main>
   <script src="js/nav.js"></script>
-  <script>
-    fetch('/api/data').then(r => r.json()).then(data => {
-      const pre = document.getElementById('dbDump');
-      pre.textContent = JSON.stringify(data, null, 2);
-    }).catch(() => {
-      document.getElementById('dbDump').textContent = 'No se pudo cargar la base de datos';
+  <script type="module">
+    async function load() {
+      const table = document.getElementById('dbTable');
+      const err = document.getElementById('errorMsg');
+      try {
+        const resp = await fetch('/api/clients');
+        if (!resp.ok) throw new Error('HTTP ' + resp.status);
+        const result = await resp.json();
+        const data = result.data || result;
+        if (!Array.isArray(data)) throw new Error('Formato incorrecto');
+        if (data.length === 0) {
+          table.innerHTML = '<tr><td>No hay datos</td></tr>';
+          return;
+        }
+        const cols = Object.keys(data[0]);
+        const head = '<thead><tr>' + cols.map(c => `<th>${c}</th>`).join('') + '</tr></thead>';
+        const rows = data
+          .map(r => '<tr>' + cols.map(c => `<td>${r[c] ?? ''}</td>`).join('') + '</tr>')
+          .join('');
+        table.innerHTML = head + '<tbody>' + rows + '</tbody>';
+      } catch (e) {
+        console.error(e);
+        err.textContent = 'No se pudo cargar la base de datos';
+      }
+    }
+
+    window.addEventListener('DOMContentLoaded', load);
+    window.addEventListener('error', ev => {
+      const msg = document.getElementById('errorMsg');
+      if (msg && !msg.textContent) msg.textContent = ev.message;
     });
   </script>
 </body>


### PR DESCRIPTION
## Summary
- adapt `docs/dbviewer.html` to fetch from `/api/clients`
- show an error message if the request fails
- display JavaScript errors to the user

## Testing
- `sh format_check.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d83513d58832f933c91cecd364c57