### PR TITLE
Add express/sqlite3 runtime deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,9 @@
       "version": "407",
       "license": "ISC",
       "dependencies": {
-        "jsdom": "^22.1.0"
+        "express": "5.1.0",
+        "jsdom": "^22.1.0",
+        "sqlite3": "5.1.7"
       },
       "devDependencies": {
         "@types/jest": "^29.5.2",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
   "license": "ISC",
   "type": "commonjs",
   "dependencies": {
-    "jsdom": "^22.1.0"
+    "jsdom": "^22.1.0",
+    "express": "5.1.0",
+    "sqlite3": "5.1.7"
   },
   "pkg": {
     "assets": [


### PR DESCRIPTION
## Summary
- add `express` and `sqlite3` entries under `dependencies`
- run npm install to update lockfile

## Testing
- `npm install`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d8a8fae94832fbc0795a6f0b11fba