### PR TITLE
Fix /api/history JSON format

### DIFF
--- a/backend.js
+++ b/backend.js
@@ -147,7 +147,7 @@ function createServer() {
   app.get('/api/history', (req, res) => {
     db.all('SELECT * FROM history ORDER BY ts DESC', (err, rows) => {
       if (err) return res.status(500).json({ success: false, error: err.message });
-      res.json({ success: true, data: rows });
+      res.json(rows);
     });
   });
 


### PR DESCRIPTION
## Summary
- return plain history rows from Node backend

## Testing
- `sh format_check.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d8a933664832f9bf0b482eec74068