### PR TITLE
Ensure DB setup completes before server start

### DIFF
--- a/main.js
+++ b/main.js
@@ -16,8 +16,9 @@ function createWindow(port) {
   win.loadURL(`http://localhost:${port}/docs/login.html`);
 }
 
-app.whenReady().then(() => {
-  const { httpServer } = createServer();
+app.whenReady().then(async () => {
+  const { httpServer, dbReady } = createServer();
+  await dbReady;
   server = httpServer.listen(0, () => {
     const port = server.address().port;
     createWindow(port);

--- a/tests/api.spec.js
+++ b/tests/api.spec.js
@@ -13,7 +13,11 @@ describe('API', function() {
   beforeEach(function(done) {
     if (fs.existsSync(DB_FILE)) fs.unlinkSync(DB_FILE);
     serverObj = createServer();
-    server = serverObj.httpServer.listen(0, done);
+    serverObj.dbReady
+      .then(() => {
+        server = serverObj.httpServer.listen(0, done);
+      })
+      .catch(done);
   });
   afterEach(function(done) {
     server.close(() => {
@@ -49,5 +53,11 @@ describe('API', function() {
     assert.ok(Array.isArray(resp.body));
     assert.ok(resp.body.length > 0);
     assert.ok(resp.body[0].summary);
+  });
+
+  it('handles request immediately after startup', function(done) {
+    request(serverObj.app)
+      .get('/api/clients')
+      .expect(200, done);
   });
 });

--- a/tests/backend_clients.test.js
+++ b/tests/backend_clients.test.js
@@ -14,13 +14,14 @@ describe('POST /api/clients with name only', () => {
     if (fs.existsSync(DB_FILE)) fs.unlinkSync(DB_FILE);
   });
 
-  test('creates client', async () => {
-    const { app } = createServer();
-    const resp = await request(app)
-      .post('/api/clients')
-      .send({ name: 'Test Client' });
-    expect(resp.status).toBe(200);
-    expect(resp.body.nombre).toBe('Test Client');
-    expect(resp.body.codigo).toBeDefined();
+    test('creates client', async () => {
+      const { app, dbReady } = createServer();
+      await dbReady;
+      const resp = await request(app)
+        .post('/api/clients')
+        .send({ name: 'Test Client' });
+      expect(resp.status).toBe(200);
+      expect(resp.body.nombre).toBe('Test Client');
+      expect(resp.body.codigo).toBeDefined();
   });
 });


### PR DESCRIPTION
## Summary
- make `initDb` return a Promise resolved after table creation
- expose `dbReady` from `createServer` and await it in `main.js`
- adjust tests to await database initialization
- add test checking immediate requests succeed

## Testing
- `sh format_check.sh`
- `npm test`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685dcd3c2ca8832faefe3fca0358f092