### PR TITLE
Ensure DB closes on server shutdown

### DIFF
--- a/main.js
+++ b/main.js
@@ -3,6 +3,7 @@ const path = require('path');
 const createServer = require('./backend');
 
 let server;
+let db;
 
 function createWindow(port) {
   const win = new BrowserWindow({
@@ -17,7 +18,8 @@ function createWindow(port) {
 }
 
 app.whenReady().then(async () => {
-  const { httpServer, dbReady } = createServer();
+  const { httpServer, dbReady, db: dbInstance } = createServer();
+  db = dbInstance;
   await dbReady;
   server = httpServer.listen(0, () => {
     const port = server.address().port;
@@ -27,5 +29,6 @@ app.whenReady().then(async () => {
 
 app.on('window-all-closed', () => {
   if (server) server.close();
+  if (db) db.close();
   if (process.platform !== 'darwin') app.quit();
 });

--- a/tests/shutdown.spec.js
+++ b/tests/shutdown.spec.js
@@ -1,0 +1,19 @@
+const assert = require('assert');
+const createServer = require('../backend');
+
+describe('server shutdown', function() {
+  it('closes database when http server is closed', function(done) {
+    const { httpServer, dbReady, db } = createServer();
+    dbReady.then(() => {
+      let closed = false;
+      const origClose = db.close;
+      db.close = function(...args) { closed = true; return origClose.apply(this,args); };
+      const srv = httpServer.listen(0, () => {
+        srv.close(() => {
+          assert.ok(closed);
+          done();
+        });
+      });
+    }).catch(done);
+  });
+});


### PR DESCRIPTION
## Summary
- expose SQLite db handle from `createServer`
- close db when Electron app windows close
- auto-close db when the HTTP server shuts down
- test database closure on server shutdown

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685dd7cfcd60832f8f0ad742d89c95bb