### PR TITLE
Implement DB file watcher

### DIFF
--- a/backend.js
+++ b/backend.js
@@ -64,8 +64,22 @@ function createServer() {
 
   const db = new sqlite3.Database(DB_FILE);
   const dbReady = initDb(db);
+  let dbWatcher;
+
+  dbReady
+    .then(() => {
+      try {
+        dbWatcher = fs.watch(DB_FILE, () => {
+          io.emit('data_updated');
+        });
+      } catch (err) {
+        console.error('Failed to watch DB file', err);
+      }
+    })
+    .catch(() => {});
 
   httpServer.on('close', () => {
+    if (dbWatcher) dbWatcher.close();
     db.close();
   });
 


### PR DESCRIPTION
## Summary
- watch `datos/base_de_datos.sqlite` in the backend
- emit `data_updated` via socket when the DB file changes
- clean up the watcher when the HTTP server closes

## Testing
- `npm test`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685de213b080832fa29955582ce94422