### PR TITLE
Expose history loader and relax client dialog

### DIFF
--- a/docs/js/dataService.js
+++ b/docs/js/dataService.js
@@ -223,8 +223,8 @@ if (socket) {
 
   socket.on('reconnect', () => {
     clearConnToast();
-    if (typeof loadClients === 'function') loadClients();
-    if (typeof loadHistory === 'function') loadHistory();
+    if (typeof window.loadClients === 'function') window.loadClients();
+    if (typeof window.loadHistory === 'function') window.loadHistory();
   });
 }
 

--- a/docs/js/history.js
+++ b/docs/js/history.js
@@ -73,17 +73,21 @@ document.addEventListener('DOMContentLoaded', () => {
 
   applyBtn?.addEventListener('click', loadHistory);
 
+  if (typeof window !== 'undefined') {
+    window.loadHistory = loadHistory;
+  }
+
   loadHistory();
 
   if (socket) {
     socket.on('data_updated', () => {
       loadHistory();
-      if (typeof loadClients === 'function') loadClients();
+      if (typeof window.loadClients === 'function') window.loadClients();
     });
 
     socket.on('reconnect', () => {
       clearConnToast();
-      if (typeof loadClients === 'function') loadClients();
+      if (typeof window.loadClients === 'function') window.loadClients();
       loadHistory();
     });
 

--- a/docs/js/newClientDialog.js
+++ b/docs/js/newClientDialog.js
@@ -5,22 +5,18 @@ export function initNewClientDialog() {
   const openBtn = document.getElementById('btnNuevoCliente');
   if (!dialog || !openBtn) return;
 
-  openBtn.addEventListener('click', () => dialog.showModal());
-
   const form = dialog.querySelector('form');
   const input = dialog.querySelector('#nuevoClienteNombre');
   const submitBtn = form?.querySelector('button[type="submit"]');
-  if (input) input.disabled = true;
-  if (submitBtn) submitBtn.disabled = true;
 
-  fetch('/api/clients')
-    .then(resp => {
-      if (resp.ok) {
-        if (input) input.disabled = false;
-        if (submitBtn) submitBtn.disabled = false;
-      }
-    })
-    .catch(() => {});
+  openBtn.addEventListener('click', () => {
+    if (input) input.disabled = false;
+    if (submitBtn) submitBtn.disabled = false;
+    dialog.showModal();
+    input?.focus();
+  });
+
+  fetch('/api/clients').catch(() => {});
 
   const cancelBtn = dialog.querySelector('button[type="button"]');
   cancelBtn?.addEventListener('click', () => dialog.close());


### PR DESCRIPTION
## Summary
- export `loadHistory` to the global window object
- guard refresh callbacks with `window.loadClients` and `window.loadHistory`
- allow typing new clients immediately when opening the dialog

## Testing
- `./format_check.sh`
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_685de66b0b94832fae5c91d2a715ca00