### PR TITLE
Add electron builder config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ backups/
 .DS_Store
 Thumbs.db
 
+/dist/
+/out/

--- a/build.json
+++ b/build.json
@@ -1,0 +1,22 @@
+{
+  "appId": "com.proyecto.barack",
+  "productName": "Proyecto Barack",
+  "directories": {
+    "output": "dist"
+  },
+  "files": [
+    "**/*",
+    "!dist/**/*",
+    "!out/**/*"
+  ],
+  "extraResources": [
+    {
+      "from": "datos",
+      "to": "datos"
+    }
+  ],
+  "asar": true,
+  "win": {
+    "target": "nsis"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "license": "MIT",
   "type": "commonjs",
   "scripts": {
-    "test": "echo \"No tests available\" && exit 0"
+    "test": "echo \"No tests available\" && exit 0",
+    "make": "electron-builder --config build.json"
   }
 }


### PR DESCRIPTION
## Summary
- add basic `build.json` file for electron-builder
- ignore `dist/` and `out/` folders
- add `npm run make` script that builds using `electron-builder`

## Testing
- `./format_check.sh`
- `npm test`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_685e6f3b01dc832f97976c173d6ee1b0