### PR TITLE
Switch DB watcher to fs.watchFile

### DIFF
--- a/backend.js
+++ b/backend.js
@@ -69,9 +69,10 @@ function createServer() {
   dbReady
     .then(() => {
       try {
-        dbWatcher = fs.watch(DB_FILE, () => {
+        dbWatcher = () => {
           io.emit('data_updated');
-        });
+        };
+        fs.watchFile(DB_FILE, dbWatcher);
       } catch (err) {
         console.error('Failed to watch DB file', err);
       }
@@ -79,7 +80,7 @@ function createServer() {
     .catch(() => {});
 
   httpServer.on('close', () => {
-    if (dbWatcher) dbWatcher.close();
+    if (dbWatcher) fs.unwatchFile(DB_FILE, dbWatcher);
     db.close();
   });
 


### PR DESCRIPTION
## Summary
- use `fs.watchFile` instead of `fs.watch`
- unwatch the DB file on server shutdown

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'server')*
- `./format_check.sh`


------
https://chatgpt.com/codex/tasks/task_e_685e70354ae0832f937a26858e48774f