### PR TITLE
Add spinners and messages for data actions

### DIFF
--- a/docs/history.html
+++ b/docs/history.html
@@ -14,6 +14,7 @@
 </head>
 <body>
   <nav id="nav-placeholder"></nav>
+  <div id="loading"><div class="spinner"></div></div>
   <button class="back-btn" onclick="goBack()">← Volver</button>
   <h1>Historial</h1>
 

--- a/docs/js/arbol.js
+++ b/docs/js/arbol.js
@@ -38,8 +38,27 @@ document.addEventListener('DOMContentLoaded', async () => {
   const productAlto = document.getElementById('productAlto');
   const productPeso = document.getElementById('productPeso');
 
+  function showSpinner() {
+    const el = document.getElementById('loading');
+    if (el) el.style.display = 'flex';
+  }
+
+  function hideSpinner() {
+    const el = document.getElementById('loading');
+    if (el) el.style.display = 'none';
+  }
+
+  showSpinner();
   await ready;
-  const all = await getAll('sinoptico');
+  let all = [];
+  try {
+    all = await getAll('sinoptico');
+    if (window.mostrarMensaje) window.mostrarMensaje('Guardado', 'success');
+  } catch {
+    if (window.mostrarMensaje) window.mostrarMensaje('Error al cargar');
+  } finally {
+    hideSpinner();
+  }
   const clientes = all.filter(n => n.Tipo === 'Cliente');
   if (clienteSel) {
     clienteSel.innerHTML = clientes
@@ -334,18 +353,25 @@ document.addEventListener('DOMContentLoaded', async () => {
 
   finishBtn?.addEventListener('click', async () => {
     if (!productData) return;
-    const product = buildProduct(
-      productData.desc,
-      productData.code,
-      productData.cid,
-      productData.largo,
-      productData.ancho,
-      productData.alto,
-      productData.peso
-    );
-    await persist(product, subcomponents, insumos);
-    if (progressBar) progressBar.style.width = '100%';
-    if (window.mostrarMensaje) window.mostrarMensaje('Árbol creado con éxito', 'success');
-    window.location.href = 'sinoptico.html';
+    showSpinner();
+    try {
+      const product = buildProduct(
+        productData.desc,
+        productData.code,
+        productData.cid,
+        productData.largo,
+        productData.ancho,
+        productData.alto,
+        productData.peso
+      );
+      await persist(product, subcomponents, insumos);
+      if (progressBar) progressBar.style.width = '100%';
+      if (window.mostrarMensaje) window.mostrarMensaje('Guardado', 'success');
+      window.location.href = 'sinoptico.html';
+    } catch {
+      if (window.mostrarMensaje) window.mostrarMensaje('Error al guardar');
+    } finally {
+      hideSpinner();
+    }
   });
 });

--- a/docs/js/asistente.js
+++ b/docs/js/asistente.js
@@ -46,8 +46,27 @@ document.addEventListener('DOMContentLoaded', async () => {
   const productAlto = document.getElementById('productAlto');
   const productPeso = document.getElementById('productPeso');
 
+  function showSpinner() {
+    const el = document.getElementById('loading');
+    if (el) el.style.display = 'flex';
+  }
+
+  function hideSpinner() {
+    const el = document.getElementById('loading');
+    if (el) el.style.display = 'none';
+  }
+
+  showSpinner();
   await ready;
-  const all = await getAll('sinoptico');
+  let all = [];
+  try {
+    all = await getAll('sinoptico');
+    if (window.mostrarMensaje) window.mostrarMensaje('Guardado', 'success');
+  } catch {
+    if (window.mostrarMensaje) window.mostrarMensaje('Error al cargar');
+  } finally {
+    hideSpinner();
+  }
   const clientes = all.filter(n => n.Tipo === 'Cliente');
   if (clienteSel) {
     clienteSel.innerHTML = clientes
@@ -423,18 +442,25 @@ document.addEventListener('DOMContentLoaded', async () => {
 
   finishBtn?.addEventListener('click', async () => {
     if (!productData) return;
-    const product = buildProduct(
-      productData.desc,
-      productData.code,
-      productData.cid,
-      productData.largo,
-      productData.ancho,
-      productData.alto,
-      productData.peso
-    );
-    await persist(product, subcomponents, insumos);
-    activateStep(4);
-    if (window.mostrarMensaje) window.mostrarMensaje('Árbol creado con éxito', 'success');
-    window.location.href = 'sinoptico.html';
+    showSpinner();
+    try {
+      const product = buildProduct(
+        productData.desc,
+        productData.code,
+        productData.cid,
+        productData.largo,
+        productData.ancho,
+        productData.alto,
+        productData.peso
+      );
+      await persist(product, subcomponents, insumos);
+      activateStep(4);
+      if (window.mostrarMensaje) window.mostrarMensaje('Guardado', 'success');
+      window.location.href = 'sinoptico.html';
+    } catch {
+      if (window.mostrarMensaje) window.mostrarMensaje('Error al guardar');
+    } finally {
+      hideSpinner();
+    }
   });
 });

--- a/docs/js/dbManager.js
+++ b/docs/js/dbManager.js
@@ -14,9 +14,28 @@ export function initDBManager() {
   const tipoFilter = form.querySelector('#dbTipoFilter');
   const tableBody = dlg.querySelector('tbody');
 
+  function showSpinner() {
+    const el = document.getElementById('loading');
+    if (el) el.style.display = 'flex';
+  }
+
+  function hideSpinner() {
+    const el = document.getElementById('loading');
+    if (el) el.style.display = 'none';
+  }
+
   async function load() {
+    showSpinner();
     await ready;
-    const data = await getAll('sinoptico');
+    let data = [];
+    try {
+      data = await getAll('sinoptico');
+      if (window.mostrarMensaje) window.mostrarMensaje('Guardado', 'success');
+    } catch {
+      if (window.mostrarMensaje) window.mostrarMensaje('Error al cargar');
+    } finally {
+      hideSpinner();
+    }
     const clientes = data.filter(d => d.Tipo === 'Cliente');
     if (clientFilter) {
       const sel = clientFilter.value || '';
@@ -66,13 +85,19 @@ export function initDBManager() {
     if (btn.classList.contains('db-edit')) {
       const desc = prompt('Nueva descripción');
       if (desc != null) {
+        showSpinner();
         await updateNode(id, { Descripción: desc });
         await load();
+        hideSpinner();
+        if (window.mostrarMensaje) window.mostrarMensaje('Guardado', 'success');
       }
     } else if (btn.classList.contains('db-del')) {
       if (confirm('¿Eliminar elemento?')) {
+        showSpinner();
         await deleteNode(id);
         await load();
+        hideSpinner();
+        if (window.mostrarMensaje) window.mostrarMensaje('Guardado', 'success');
       }
     }
   });
@@ -94,9 +119,12 @@ export function initDBManager() {
       Sourcing: '',
       Código: codeInput.value.trim()
     };
+    showSpinner();
     await addNode(newItem);
     form.reset();
     await load();
+    hideSpinner();
+    if (window.mostrarMensaje) window.mostrarMensaje('Guardado', 'success');
   });
 }
 

--- a/docs/js/history.js
+++ b/docs/js/history.js
@@ -20,7 +20,18 @@ document.addEventListener('DOMContentLoaded', () => {
   const endInput = document.getElementById('endDate');
   const applyBtn = document.getElementById('applyFilters');
 
+  function showSpinner() {
+    const el = document.getElementById('loading');
+    if (el) el.style.display = 'flex';
+  }
+
+  function hideSpinner() {
+    const el = document.getElementById('loading');
+    if (el) el.style.display = 'none';
+  }
+
   async function loadHistory() {
+    showSpinner();
     try {
       const resp = await fetch('/api/history');
       if (!resp.ok) {
@@ -44,6 +55,10 @@ document.addEventListener('DOMContentLoaded', () => {
     } catch (e) {
       console.error(e);
       tbody.innerHTML = '<tr><td colspan="2">Error al cargar historial</td></tr>';
+      if (window.mostrarMensaje) window.mostrarMensaje('Error al cargar');
+    } finally {
+      hideSpinner();
+      if (window.mostrarMensaje) window.mostrarMensaje('Guardado', 'success');
     }
   }
 

--- a/docs/js/views/home.js
+++ b/docs/js/views/home.js
@@ -34,7 +34,18 @@ export function render(container) {
   if (moduleGrid) loadModules(moduleGrid);
 }
 
+function showSpinner() {
+  const el = document.getElementById('loading');
+  if (el) el.style.display = 'flex';
+}
+
+function hideSpinner() {
+  const el = document.getElementById('loading');
+  if (el) el.style.display = 'none';
+}
+
 async function loadKpis(el) {
+  showSpinner();
   try {
     let products = [];
     let history = [];
@@ -75,7 +86,10 @@ async function loadKpis(el) {
     });
   } catch (err) {
     console.error('KPI fetch failed', err);
+    if (window.mostrarMensaje) window.mostrarMensaje('Error al cargar');
   }
+  hideSpinner();
+  if (window.mostrarMensaje) window.mostrarMensaje('Guardado', 'success');
 }
 
 function loadModules(el) {

--- a/docs/registros.html
+++ b/docs/registros.html
@@ -15,6 +15,7 @@
 </head>
 <body>
   <nav id="nav-placeholder"></nav>
+  <div id="loading"><div class="spinner"></div></div>
   <button id="sidebarToggle" class="sidebar-toggle" type="button" aria-label="Abrir filtros">▶</button>
   <aside id="datasetSidebar" class="dataset-sidebar">
     <button data-filter="" class="active">Todos</button>

--- a/docs/sinoptico.html
+++ b/docs/sinoptico.html
@@ -14,6 +14,7 @@
 </head>
 <body class="sinoptico-page">
   <nav id="nav-placeholder"></nav>
+  <div id="loading"><div class="spinner"></div></div>
   <button class="back-btn" onclick="goBack()">← Volver</button>
   <section class="filtro-contenedor">
     <section class="filtros-texto">

--- a/server.py
+++ b/server.py
@@ -1,4 +1,4 @@
 from backend.main import app, socketio
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     socketio.run(app)


### PR DESCRIPTION
## Summary
- show loading indicator for data operations in multiple pages
- handle success and error messaging after loads and saves
- insert a spinner container in history, sinoptico and registros pages
- format server.py with black

## Testing
- `npm test` *(fails: mocha not found)*
- `./format_check.sh`

------
https://chatgpt.com/codex/tasks/task_e_685e88207494832fbefacf2091c1235f