### PR TITLE
Add home link to AMFE page

### DIFF
--- a/docs/amef.html
+++ b/docs/amef.html
@@ -61,6 +61,7 @@
                 <div class="flex items-center mb-4">
                     <svg class="w-12 h-12 text-blue-600 mr-4 no-print" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"></path></svg>
                     <h1 class="text-3xl font-bold text-blue-800">Herramienta AMFE de Proceso</h1>
+                    <a href="#/home" class="ml-6 text-blue-600 underline no-print">Inicio</a>
                 </div>
                 <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4" id="main-header-fields">
                     <div><label class="block text-xs font-medium text-gray-600">Nombre de la Organización</label><input type="text" data-field="orgName" class="header-input" value="BARACK MERCOSUL"></div>


### PR DESCRIPTION
## Summary
- add a visible `Inicio` link in AMFE page header

## Testing
- `npm test`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e8b0c559c832faf28d63b72de1606