### PR TITLE
Fix maestro UI colors and save status

### DIFF
--- a/docs/assets/styles.css
+++ b/docs/assets/styles.css
@@ -26,6 +26,13 @@
   --anim-ease: cubic-bezier(0.4, 0, 0.2, 1);
 }
 
+/* colores utilitarios para la vista Maestro (Tailwind fallback) */
+.bg-corporate { background-color: var(--color-primary); }
+.hover\:bg-corporate-dark:hover { background-color: var(--color-primary-hover); }
+.text-corporate { color: var(--color-primary); }
+.border-corporate { border-color: var(--color-primary); }
+.focus\:ring-corporate:focus { box-shadow: 0 0 0 2px var(--color-primary); }
+
 .dark {
   --color-bg: #000;
   --color-text: #e0e0e0;

--- a/docs/js/maestro.js
+++ b/docs/js/maestro.js
@@ -67,6 +67,7 @@ document.addEventListener('DOMContentLoaded', () => {
             },
 
             addNewProduct(name) {
+                App.ui.showSaveStatus('Guardando...');
                 const newId = App.state.products.length > 0 ? Math.max(...App.state.products.map(p => p.id)) + 1 : 1;
                 const newProductData = {};
                 App.state.docKeys.forEach(key => { newProductData[key] = { rev: '', link: '' }; });
@@ -74,16 +75,19 @@ document.addEventListener('DOMContentLoaded', () => {
                 this.logHistory(newId, 'Producto', 'creado', '', name.trim());
                 App.storage.save();
                 App.init();
+                App.ui.showSaveStatus('Guardado \u2713');
                 App.ui.showToast('Producto añadido correctamente', 'success');
             },
 
             deleteProduct(productId) {
                 const product = App.state.products.find(p => p.id === productId);
                 if(product) {
+                    App.ui.showSaveStatus('Guardando...');
                     App.state.products = App.state.products.filter(p => p.id !== productId);
                     this.logHistory(productId, 'Producto', 'eliminado', product.name, 'N/A');
                     App.storage.save();
                     App.render.table();
+                    App.ui.showSaveStatus('Guardado \u2713');
                     App.ui.showToast('Producto eliminado', 'error');
                 }
             },
@@ -94,6 +98,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 const oldValue = product.data[docKey][field];
                 const newValue = cell.innerText.trim();
                 if (oldValue !== newValue) {
+                    App.ui.showSaveStatus('Guardando...');
                     product.data[docKey][field] = newValue;
                     this.logHistory(productId, docKey, field, oldValue, newValue);
                     const dependents = App.state.dependencies[docKey];
@@ -112,6 +117,7 @@ document.addEventListener('DOMContentLoaded', () => {
                     this.checkAndResolveSemaphore(productId);
                     App.storage.save();
                     App.render.table(App.dom.searchInput.value);
+                    App.ui.showSaveStatus('Guardado \u2713');
                 }
             }
         },
@@ -177,6 +183,15 @@ document.addEventListener('DOMContentLoaded', () => {
                 toast.textContent = message;
                 App.dom.toastContainer.appendChild(toast);
                 setTimeout(() => toast.remove(), 4000);
+            },
+
+            showSaveStatus(text) {
+                const el = document.getElementById('save-status');
+                if (!el) return;
+                el.textContent = text;
+                el.classList.remove('opacity-0');
+                clearTimeout(el._hideTimeout);
+                el._hideTimeout = setTimeout(() => el.classList.add('opacity-0'), 2000);
             },
 
             showModal(title, content, onConfirm, confirmText = 'Confirmar', maxWidth = 'max-w-md') {

--- a/docs/maestro.html
+++ b/docs/maestro.html
@@ -71,6 +71,7 @@
 
     <div id="modal-container"></div>
     <div id="toast-container" class="fixed bottom-5 right-5 z-50"></div>
+    <div id="save-status" class="fixed bottom-4 right-4 bg-gray-800 text-white text-sm py-2 px-4 rounded-lg shadow-lg opacity-0 transition-opacity duration-500"></div>
   </main>
   <section id="fileWarning" class="file-warning" style="display:none">
     Para utilizar la aplicación abre el archivo en un navegador moderno.


### PR DESCRIPTION
## Summary
- add corporate color fallback styles
- add save status UI element and logic for maestro view

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e8fa6724c832f8270a849b706b46c