### PR TITLE
Remove redundant export link

### DIFF
--- a/docs/js/views/home.js
+++ b/docs/js/views/home.js
@@ -117,7 +117,6 @@ function loadModules(el) {
       text: 'Listado Maestro',
       actions: [
         { label: 'Ver maestro', href: 'maestro.html' },
-        { label: 'Exportar maestro', href: 'maestro.html#export' },
       ],
     },
     {

--- a/docs/nav.html
+++ b/docs/nav.html
@@ -17,7 +17,6 @@
     <a href="maestro.html">Listado Maestro</a>
     <div class="dropdown-menu">
       <a href="maestro.html">Ver maestro</a>
-      <a href="maestro.html#export">Exportar maestro</a>
     </div>
   </div>
   <div class="nav-item dropdown">


### PR DESCRIPTION
## Summary
- remove "Exportar maestro" from nav
- remove "Exportar maestro" from home modules

## Testing
- `npm test`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685e90900bbc832fa47c07e3040f5c3b