### PR TITLE
Fix loading overlay on registros page

### DIFF
--- a/docs/registros.html
+++ b/docs/registros.html
@@ -140,6 +140,7 @@
   <script type="module" src="js/newProductDialog.js" defer></script>
   <script type="module" src="js/newSubDialog.js" defer></script>
   <script type="module" src="js/newInsumoDialog.js" defer></script>
+  <script type="module" src="js/hideLoading.js" defer></script>
   <script type="module" src="js/version.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- hide the transparent overlay on `registros.html`

## Testing
- `npm test` *(fails: TypeError in tests)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*
- `sh format_check.sh`

------
https://chatgpt.com/codex/tasks/task_e_685e8fdf6f7c832fa7e0b2c1ebd6ddaa