### PR TITLE
Refactor DB handling to keep a single connection

### DIFF
--- a/main.js
+++ b/main.js
@@ -29,6 +29,5 @@ app.whenReady().then(async () => {
 
 app.on('window-all-closed', () => {
   if (server) server.close();
-  if (db) db.close();
   if (process.platform !== 'darwin') app.quit();
 });

--- a/tests/api.spec.js
+++ b/tests/api.spec.js
@@ -11,19 +11,17 @@ describe('API', function() {
   let serverObj;
   let server;
   beforeEach(function(done) {
-    if (fs.existsSync(DB_FILE)) fs.unlinkSync(DB_FILE);
     serverObj = createServer();
     serverObj.dbReady
       .then(() => {
-        server = serverObj.httpServer.listen(0, done);
+        serverObj.db.exec('DELETE FROM items;DELETE FROM clients;DELETE FROM history;DELETE FROM amfe;', () => {
+          server = serverObj.httpServer.listen(0, done);
+        });
       })
       .catch(done);
   });
   afterEach(function(done) {
-    server.close(() => {
-      if (fs.existsSync(DB_FILE)) fs.unlinkSync(DB_FILE);
-      done();
-    });
+    server.close(done);
   });
 
   it('POST /api/clients increases the list', async function() {

--- a/tests/backend_clients.test.js
+++ b/tests/backend_clients.test.js
@@ -7,12 +7,14 @@ const DB_FILE = path.join(__dirname, '..', 'datos', 'base_de_datos.sqlite');
 
 describe('POST /api/clients with name only', () => {
   beforeEach(() => {
-    if (fs.existsSync(DB_FILE)) fs.unlinkSync(DB_FILE);
+    // clear existing data
+    if (fs.existsSync(DB_FILE)) {
+      const sqlite3 = require('sqlite3').verbose();
+      const db = new sqlite3.Database(DB_FILE);
+      db.exec('DELETE FROM items;DELETE FROM clients;DELETE FROM history;DELETE FROM amfe;', () => db.close());
+    }
   });
 
-  afterEach(() => {
-    if (fs.existsSync(DB_FILE)) fs.unlinkSync(DB_FILE);
-  });
 
     test('creates client', async () => {
       const { app, dbReady } = createServer();

--- a/tests/db.spec.js
+++ b/tests/db.spec.js
@@ -11,19 +11,17 @@ describe('API', function() {
   let serverObj;
   let server;
   beforeEach(function(done) {
-    if (fs.existsSync(DB_FILE)) fs.unlinkSync(DB_FILE);
     serverObj = createServer();
     serverObj.dbReady
       .then(() => {
-        server = serverObj.httpServer.listen(0, done);
+        serverObj.db.exec('DELETE FROM items;DELETE FROM clients;DELETE FROM history;DELETE FROM amfe;', () => {
+          server = serverObj.httpServer.listen(0, done);
+        });
       })
       .catch(done);
   });
   afterEach(function(done) {
-    server.close(() => {
-      if (fs.existsSync(DB_FILE)) fs.unlinkSync(DB_FILE);
-      done();
-    });
+    server.close(done);
   });
 
   it('POST /api/clients increases the list', async function() {

--- a/tests/shutdown.spec.js
+++ b/tests/shutdown.spec.js
@@ -2,16 +2,15 @@ const assert = require('assert');
 const createServer = require('../backend');
 
 describe('server shutdown', function() {
-  it('closes database when http server is closed', function(done) {
+  it('keeps database open when http server is closed', function(done) {
     const { httpServer, dbReady, db } = createServer();
     dbReady.then(() => {
-      let closed = false;
-      const origClose = db.close;
-      db.close = function(...args) { closed = true; return origClose.apply(this,args); };
       const srv = httpServer.listen(0, () => {
         srv.close(() => {
-          assert.ok(closed);
-          done();
+          db.all('SELECT 1', err => {
+            assert.ifError(err);
+            done();
+          });
         });
       });
     }).catch(done);


### PR DESCRIPTION
## Summary
- maintain one global SQLite connection in `backend.js`
- close DB on `beforeExit`/signals only
- return error if DB is closed during requests
- adjust Electron main process shutdown
- update tests for new lifetime of DB

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685e92336224832fa28717f9323eff35