### PR TITLE
Update client endpoints in viewer

### DIFF
--- a/docs/dbviewer.html
+++ b/docs/dbviewer.html
@@ -19,7 +19,7 @@
       const table = document.getElementById('dbTable');
       const err = document.getElementById('errorMsg');
       try {
-        const resp = await fetch('/api/clients');
+        const resp = await fetch('/api/clientes');
         if (!resp.ok) throw new Error('HTTP ' + resp.status);
         const result = await resp.json();
         const data = result.data || result;

--- a/docs/js/newClientDialog.js
+++ b/docs/js/newClientDialog.js
@@ -16,7 +16,7 @@ export function initNewClientDialog() {
     input?.focus();
   });
 
-  fetch('/api/clients').catch(() => {});
+  fetch('/api/clientes').catch(() => {});
 
   const cancelBtn = dialog.querySelector('button[type="button"]');
   cancelBtn?.addEventListener('click', () => dialog.close());
@@ -33,7 +33,7 @@ export function initNewClientDialog() {
     submitBtn && (submitBtn.disabled = true);
     let resp;
     try {
-      resp = await fetch('/api/clients', {
+      resp = await fetch('/api/clientes', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ name: nombre })


### PR DESCRIPTION
## Summary
- switch `/api/clients` to `/api/clientes` in newClientDialog
- update database viewer to use new route

## Testing
- `pytest -q`
- `npm test`
- `./format_check.sh`

------
https://chatgpt.com/codex/tasks/task_e_685e9b7bb894832f971d2555408f82e4