### PR TITLE
Remove outdated API URL docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,10 +83,7 @@ Para revisar visualmente el contenido actual de la base de datos se incluye la p
 
 Si quieres guardar la base de datos en otra ubicación puedes definir la variable de entorno `DATA_DIR` antes de iniciar el servidor y apuntar a la carpeta deseada.
 
-Si quieres guardar la base de datos en otra ubicación puedes definir la variable de entorno `DATA_DIR` antes de iniciar el servidor y apuntar a la carpeta deseada.
-
 El backend basado en SQLite (`backend/main.py`) lee la ruta del archivo desde `DB_PATH`. Si no se define, usará `data/db.sqlite`.
-
 
 El backend permite solicitudes desde la misma URL donde se abrió la interfaz. Si
 la interfaz se aloja en otra dirección puedes establecer la variable de entorno
@@ -180,22 +177,7 @@ python -m http.server
 
 Luego abre `http://localhost:8000/` y navega normalmente.
 
-### Definir `API_URL` en `localStorage`
-
-Por defecto la interfaz calcula la ruta de la API con
-`location.origin + '/api/data'` y comprueba que esté disponible mediante
-`/health`. Sólo es necesario establecer `apiUrl` cuando el servidor se
-encuentra en otro host:
-
-```js
-localStorage.setItem('apiUrl', 'http://localhost:5000/api/data');
-```
-
-Si la URL almacenada no responde se descarta y se vuelve a usar la ruta
-automática.
-
 ### Publicar en GitHub Pages
-
 En la configuración del repositorio activa **GitHub Pages**. Puedes publicar desde la rama `gh-pages` o desde la carpeta `/docs` de `main`.
 Una vez habilitado podrás acceder a `https://<usuario>.github.io/<repositorio>/` para ver el sitio desplegado.
 

--- a/docs/backend.md
+++ b/docs/backend.md
@@ -7,8 +7,6 @@ This project serves the frontend from GitHub Pages or any static server while st
 - **GitHub Pages / `docs/`**: contains only static HTML, CSS and JavaScript. No server-side code runs here.
 - **API server**: runs separately, stores data and broadcasts changes. It can be started with plain Python.
 
-The frontend reads the server URL from `localStorage` (`apiUrl`) or from the `API_URL` environment variable at build time. If none is provided it defaults to `http://localhost:5000/api/data`.
-
 ## API endpoints
 
 
@@ -23,9 +21,7 @@ The frontend reads the server URL from `localStorage` (`apiUrl`) or from the `AP
 
 ## Environment variables
 
-- `API_URL` – URL used by the frontend to access `/api/data`.
 - `DATA_DIR` – directory where the server stores its data (`data` by default).
-- `SSL_CERT` / `SSL_KEY` – optional certificate paths for HTTPS.
 - `DB_PATH` – path to the SQLite file used by `backend/main.py` (`data/db.sqlite` by default).
 - `ALLOWED_ORIGINS` – comma-separated list of origins allowed for CORS and
   WebSocket connections. Defaults to

--- a/docs/js/pageSettings.js
+++ b/docs/js/pageSettings.js
@@ -1,7 +1,5 @@
 import { isGuest } from './session.js';
 // Apply saved UI preferences like brightness and version overlay
-// The API URL field in settings stores its value in localStorage ('apiUrl').
-// dataService reads it on page load after a reload.
 export function applyUserSettings() {
   const brightness = localStorage.getItem('pageBrightness') || '100';
   document.documentElement.style.setProperty('--page-brightness', brightness + '%');


### PR DESCRIPTION
## Summary
- clean up README duplicates and remove `API_URL` section
- drop outdated `apiUrl` references
- remove `API_URL` mentions from backend docs

## Testing
- `npm test` *(fails: Timeout of 2000ms exceeded)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_685e9e76f294832f9f58f73adadccb8a