### PR TITLE
Add spinner to homepage loading screen

### DIFF
--- a/docs/assets/styles.css
+++ b/docs/assets/styles.css
@@ -137,6 +137,7 @@ h1 {
   border-top-color: var(--color-accent);
   border-radius: 50%;
   animation: spin 1s linear infinite;
+  display: block;
 }
 
 @keyframes spin {

--- a/docs/index.html
+++ b/docs/index.html
@@ -14,7 +14,7 @@
 </head>
 <body>
   <nav id="nav-placeholder"></nav>
-  <section id="loading"></section>
+  <section id="loading"><div class="spinner"></div></section>
   <section id="appMessage" role="alert" aria-live="polite"></section>
   <main id="app">Cargando…</main>
   <dialog id="dlgNuevoCliente" class="modal">


### PR DESCRIPTION
## Summary
- show loading spinner on index page
- ensure spinner CSS is visible while loading

## Testing
- `./format_check.sh`
- `npm test`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ea121fae4832f9903e2101e855a17