### PR TITLE
Implement shared save status helper

### DIFF
--- a/docs/amef.html
+++ b/docs/amef.html
@@ -94,13 +94,13 @@
     </div>
     <div id="modals-container"></div>
     <div id="save-status" class="fixed bottom-4 right-4 bg-gray-800 text-white text-sm py-2 px-4 rounded-lg shadow-lg opacity-0 transition-opacity duration-500 no-print"></div>
-    <script>
+    <script type="module">
+    import { showSaveStatus } from './js/utils/status.js';
     document.addEventListener('DOMContentLoaded', () => {
         let saveTimeout;
         const appContainer = document.getElementById('app-container');
         const processesContainer = document.getElementById('processes-container');
         const modalsContainer = document.getElementById('modals-container');
-        const saveStatusEl = document.getElementById('save-status');
         const socket = io();
         const API_URL = '/api/amfe';
         let hasData = false;
@@ -263,7 +263,7 @@
             confirmCallback = null;
         };
         const scheduleSave = () => {
-            saveStatusEl.textContent = 'Guardando...'; saveStatusEl.classList.remove('opacity-0');
+            showSaveStatus('Guardando...');
             clearTimeout(saveTimeout);
             saveTimeout = setTimeout(saveState, 1500);
         };
@@ -289,8 +289,7 @@
                 });
                 hasData = true;
             } catch (e) { console.error(e); }
-            saveStatusEl.textContent = 'Guardado ✓';
-            setTimeout(() => saveStatusEl.classList.add('opacity-0'), 2000);
+            showSaveStatus('Guardado ✓');
         };
         const loadState = async () => {
             let state = null;

--- a/docs/index.html
+++ b/docs/index.html
@@ -17,6 +17,7 @@
   <section id="loading"><div class="spinner"></div></section>
   <section id="appMessage" role="alert" aria-live="polite"></section>
   <main id="app">Cargando…</main>
+  <div id="save-status" class="fixed bottom-4 right-4 bg-gray-800 text-white text-sm py-2 px-4 rounded-lg shadow-lg opacity-0 transition-opacity duration-500"></div>
   <dialog id="dlgNuevoCliente" class="modal">
     <form method="dialog">
       <label for="nuevoClienteNombre">Nombre del cliente:</label>

--- a/docs/js/arbol.js
+++ b/docs/js/arbol.js
@@ -1,5 +1,6 @@
 import { getAll, addNode, ready } from './dataService.js';
 import { animateInsert, animateRemove } from './ui/animations.js';
+import { showSaveStatus } from './utils/status.js';
 
 function getClienteNombre(clientes, id) {
   const c = clientes.find(x => String(x.ID) === String(id));
@@ -208,6 +209,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     const desc = descInput.value.trim();
     if (!cid || !desc) return;
     const code = codeInput.value.trim();
+    showSaveStatus('Guardando...');
     const product = buildProduct(
       desc,
       code,
@@ -220,6 +222,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     await persist(product, [], []);
     if (progressBar) progressBar.style.width = '100%';
     if (window.mostrarMensaje) window.mostrarMensaje('Producto creado con éxito', 'success');
+    showSaveStatus('Guardado ✓');
     window.location.href = 'sinoptico.html';
   });
 
@@ -354,6 +357,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   finishBtn?.addEventListener('click', async () => {
     if (!productData) return;
     showSpinner();
+    showSaveStatus('Guardando...');
     try {
       const product = buildProduct(
         productData.desc,
@@ -367,6 +371,7 @@ document.addEventListener('DOMContentLoaded', async () => {
       await persist(product, subcomponents, insumos);
       if (progressBar) progressBar.style.width = '100%';
       if (window.mostrarMensaje) window.mostrarMensaje('Guardado', 'success');
+      showSaveStatus('Guardado ✓');
       window.location.href = 'sinoptico.html';
     } catch {
       if (window.mostrarMensaje) window.mostrarMensaje('Error al guardar');

--- a/docs/js/maestro.js
+++ b/docs/js/maestro.js
@@ -1,3 +1,5 @@
+import { showSaveStatus } from './utils/status.js';
+
 document.addEventListener('DOMContentLoaded', () => {
     const App = {
         // --- ESTADO Y CONFIGURACIÓN ---
@@ -67,7 +69,7 @@ document.addEventListener('DOMContentLoaded', () => {
             },
 
             addNewProduct(name) {
-                App.ui.showSaveStatus('Guardando...');
+                showSaveStatus('Guardando...');
                 const newId = App.state.products.length > 0 ? Math.max(...App.state.products.map(p => p.id)) + 1 : 1;
                 const newProductData = {};
                 App.state.docKeys.forEach(key => { newProductData[key] = { rev: '', link: '' }; });
@@ -75,19 +77,19 @@ document.addEventListener('DOMContentLoaded', () => {
                 this.logHistory(newId, 'Producto', 'creado', '', name.trim());
                 App.storage.save();
                 App.init();
-                App.ui.showSaveStatus('Guardado \u2713');
+                showSaveStatus('Guardado \u2713');
                 App.ui.showToast('Producto añadido correctamente', 'success');
             },
 
             deleteProduct(productId) {
                 const product = App.state.products.find(p => p.id === productId);
                 if(product) {
-                    App.ui.showSaveStatus('Guardando...');
+                    showSaveStatus('Guardando...');
                     App.state.products = App.state.products.filter(p => p.id !== productId);
                     this.logHistory(productId, 'Producto', 'eliminado', product.name, 'N/A');
                     App.storage.save();
                     App.render.table();
-                    App.ui.showSaveStatus('Guardado \u2713');
+                    showSaveStatus('Guardado \u2713');
                     App.ui.showToast('Producto eliminado', 'error');
                 }
             },
@@ -98,7 +100,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 const oldValue = product.data[docKey][field];
                 const newValue = cell.innerText.trim();
                 if (oldValue !== newValue) {
-                    App.ui.showSaveStatus('Guardando...');
+                    showSaveStatus('Guardando...');
                     product.data[docKey][field] = newValue;
                     this.logHistory(productId, docKey, field, oldValue, newValue);
                     const dependents = App.state.dependencies[docKey];
@@ -117,7 +119,7 @@ document.addEventListener('DOMContentLoaded', () => {
                     this.checkAndResolveSemaphore(productId);
                     App.storage.save();
                     App.render.table(App.dom.searchInput.value);
-                    App.ui.showSaveStatus('Guardado \u2713');
+                    showSaveStatus('Guardado \u2713');
                 }
             }
         },
@@ -185,14 +187,6 @@ document.addEventListener('DOMContentLoaded', () => {
                 setTimeout(() => toast.remove(), 4000);
             },
 
-            showSaveStatus(text) {
-                const el = document.getElementById('save-status');
-                if (!el) return;
-                el.textContent = text;
-                el.classList.remove('opacity-0');
-                clearTimeout(el._hideTimeout);
-                el._hideTimeout = setTimeout(() => el.classList.add('opacity-0'), 2000);
-            },
 
             showModal(title, content, onConfirm, confirmText = 'Confirmar', maxWidth = 'max-w-md') {
                 const modalId = `modal-${Date.now()}`;

--- a/docs/js/utils/status.js
+++ b/docs/js/utils/status.js
@@ -1,0 +1,8 @@
+export function showSaveStatus(text) {
+  const el = document.getElementById('save-status');
+  if (!el) return;
+  el.textContent = text;
+  el.classList.remove('opacity-0');
+  clearTimeout(el._hideTimeout);
+  el._hideTimeout = setTimeout(() => el.classList.add('opacity-0'), 2000);
+}


### PR DESCRIPTION
## Summary
- add save-status indicator element to the main template
- extract save status logic into `utils/status.js`
- integrate helper in Maestro, AMFE and Árbol views
- run tests

## Testing
- `npm test`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ea29e6688832fa0929db5a813850e