### PR TITLE
Add test setup docs and script

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,3 +232,31 @@ Se abrirá la versión de escritorio basada en Electron y un servidor en
 `http://localhost:5000`. También puedes abrir `docs/index.html` manualmente y
 verificar que el CRUD y las actualizaciones por WebSocket funcionen correctamente.
 
+
+## Running Tests
+
+Antes de ejecutar la suite de pruebas instala las dependencias necesarias.
+
+Para las bibliotecas de Node.js ejecuta:
+
+```bash
+npm install
+```
+
+Para las dependencias de Python utiliza:
+
+```bash
+pip install flask flask-cors flask-socketio xlsxwriter reportlab eventlet pytest
+```
+
+Luego ejecuta los tests de JavaScript con:
+
+```bash
+npm test
+```
+
+Y las pruebas de Python con:
+
+```bash
+pytest
+```

--- a/tools/setup.sh
+++ b/tools/setup.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+# Install dependencies for Proyecto Barack tests
+
+npm install
+pip install flask flask-cors flask-socketio xlsxwriter reportlab eventlet pytest


### PR DESCRIPTION
## Summary
- document how to run tests in `README.md`
- add a `tools/setup.sh` helper to install dependencies

## Testing
- `./format_check.sh`
- `npm test`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685ea627af50832f81592d535f4398b2