### PR TITLE
Fix Electron startup as root

### DIFF
--- a/docs/electron.md
+++ b/docs/electron.md
@@ -13,6 +13,17 @@ If you ever need to migrate to ESM modules:
 
 For now keep `"type": "commonjs"` and `.js` extensions to ensure the desktop app starts without module errors.
 
+If you need to run Electron as the `root` user (for example inside a container
+without a regular user account), pass the `--no-sandbox` flag when starting the
+application:
+
+```bash
+npm start -- --no-sandbox
+```
+
+The `package.json` in this repository already includes this argument so the
+development build works even when executed as root.
+
 ## Building the Windows executable
 
 1. Install dependencies if they are not already present:

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "main": "main.js",
   "scripts": {
     "test": "mocha \"tests/**/*.spec.js\"",
-    "start": "electron .",
+    "start": "electron --no-sandbox .",
     "make": "electron-builder"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- allow Electron to launch when running as the root user
- document how to start Electron with `--no-sandbox`

## Testing
- `npm test`
- `pytest -q`
- `npm start` *(fails: Missing X server)*

------
https://chatgpt.com/codex/tasks/task_e_685eabc27c40832fb5b6dda235902a13