### PR TITLE
Document PyInstaller build steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,18 @@ Para actualizar la version de escritorio simplemente reemplaza los archivos de l
 Consulta [docs/electron.md](docs/electron.md) para detalles sobre la construcción
 del modo escritorio con Electron y las recomendaciones sobre CommonJS.
 
+## Compilar el backend con PyInstaller
+
+Si deseas un ejecutable nativo del servidor ejecuta:
+
+```bash
+pyinstaller --onefile backend/main.py --name server
+```
+
+El archivo resultante `server.exe` se ubicará dentro de `dist/`.
+Inicia `server.exe` antes de `app.exe` y coloca ambos junto a la
+carpeta `datos` (o un enlace simbólico) para que compartan la base de datos.
+
 ## Compartir la carpeta `datos` en red
 
 Si varias computadoras necesitan acceder a la misma base de datos, crea una


### PR DESCRIPTION
## Summary
- add instructions for packaging `backend/main.py` with PyInstaller
- note that `server.exe` must be launched before `app.exe`
- mention `datos` folder location for the executables

## Testing
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_685eaf91bf8c832fa4c2ffc673f6f5d8