### PR TITLE
Unify runtime data folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,8 @@ __pycache__/
 
 node_modules/
 
-data/
+datos/*
+!datos/.gitkeep
 backups/
 
 # Editor directories and OS files

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Por defecto se usa **Dexie/IndexedDB** para el almacenamiento local, pero `js/da
 Todas las vistas utilizan la misma base de datos `ProyectoBarackDB` a través del
 módulo `js/dataService.js`. Desde la página de inicio puedes exportar e importar
 la información mediante dos botones. El registro de cambios se almacena en
-`data/history.json`.
+`datos/history.json`.
 
 Para realizar copias de seguridad manuales desde la consola del navegador sigue
 si lo prefieres este procedimiento:
@@ -81,9 +81,9 @@ Todos los usuarios deben apuntar al mismo servidor para compartir la informació
 
 Para revisar visualmente el contenido actual de la base de datos se incluye la página `docs/dbviewer.html`. Ábrela con el servidor en marcha para ver los datos en formato JSON.
 
-Si quieres guardar la base de datos en otra ubicación puedes definir la variable de entorno `DATA_DIR` antes de iniciar el servidor y apuntar a la carpeta deseada.
+Si quieres guardar la base de datos en otra ubicación puedes definir la variable de entorno `DATA_DIR` antes de iniciar el servidor y apuntar a la carpeta deseada. Por defecto se usa la carpeta `datos`.
 
-El backend basado en SQLite (`backend/main.py`) lee la ruta del archivo desde `DB_PATH`. Si no se define, usará `data/db.sqlite`.
+El backend basado en SQLite (`backend/main.py`) lee la ruta del archivo desde `DB_PATH`. Si no se define, usará `datos/base_de_datos.sqlite`.
 
 El backend permite solicitudes desde la misma URL donde se abrió la interfaz. Si
 la interfaz se aloja en otra dirección puedes establecer la variable de entorno
@@ -197,8 +197,11 @@ Una vez habilitado podrás acceder a `https://<usuario>.github.io/<repositorio>/
 
 El proyecto utiliza SQLite a través del módulo `sqlite3` en `backend/main.py`.
 La ruta del archivo se define con la variable de entorno `DB_PATH` (por defecto
-`data/db.sqlite`). Actualmente no se emplea un ORM ni un sistema de migraciones,
+`datos/base_de_datos.sqlite`). Actualmente no se emplea un ORM ni un sistema de migraciones,
 por lo que cualquier cambio en el esquema debe aplicarse manualmente.
+
+Todos los archivos generados en tiempo de ejecución se guardan dentro de la carpeta
+`datos`. La antigua carpeta `data` ya no se utiliza y se eliminó del repositorio.
 
 La base funciona en modo *WAL*, por lo que la primera conexión ejecuta
 `PRAGMA journal_mode=WAL` al crear el esquema. Asegúrate de que el archivo

--- a/data/README.md
+++ b/data/README.md
@@ -1,1 +1,0 @@
-This directory stores the SQLite database and other runtime files.

--- a/docs/backend.md
+++ b/docs/backend.md
@@ -21,8 +21,8 @@ This project serves the frontend from GitHub Pages or any static server while st
 
 ## Environment variables
 
-- `DATA_DIR` – directory where the server stores its data (`data` by default).
-- `DB_PATH` – path to the SQLite file used by `backend/main.py` (`data/db.sqlite` by default).
+- `DATA_DIR` – directory where the server stores its data (`datos` by default).
+- `DB_PATH` – path to the SQLite file used by `backend/main.py` (`datos/base_de_datos.sqlite` by default).
 - `ALLOWED_ORIGINS` – comma-separated list of origins allowed for CORS and
   WebSocket connections. Defaults to
   `http://desktop-14jg95b:8080,http://192.168.1.233:8080,http://localhost:8080`.

--- a/tests/test_socketio_crud.py
+++ b/tests/test_socketio_crud.py
@@ -4,9 +4,9 @@ from pathlib import Path
 
 
 def test_socketio_events_on_crud(tmp_path, monkeypatch):
-    monkeypatch.setenv("DATA_DIR", str(tmp_path / "data"))
+    monkeypatch.setenv("DATA_DIR", str(tmp_path / "datos"))
     monkeypatch.setenv("BACKUP_DIR", str(tmp_path / "backups"))
-    monkeypatch.setenv("DB_PATH", str(tmp_path / "data/db.sqlite"))
+    monkeypatch.setenv("DB_PATH", str(tmp_path / "datos/base_de_datos.sqlite"))
     server = importlib.reload(importlib.import_module("server"))
 
     client = server.app.test_client()

--- a/tools/seed_demo.js
+++ b/tools/seed_demo.js
@@ -1,5 +1,5 @@
 const sqlite3 = require('sqlite3').verbose();
-const path = process.env.DB_PATH || 'data/db.sqlite';
+const path = process.env.DB_PATH || 'datos/base_de_datos.sqlite';
 const db = new sqlite3.Database(path);
 
 db.serialize(() => {


### PR DESCRIPTION
## Summary
- use `datos/` consistently across docs and code
- remove legacy `data/` directory
- note default folder in README and docs
- update ignore rules and tests

## Testing
- `npm test` *(fails: mocha not found)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'flask')*
- `./format_check.sh`

------
https://chatgpt.com/codex/tasks/task_e_685ebafe29c4832f8260e234888c6be7